### PR TITLE
Fix #12: Test for Lookup for activations

### DIFF
--- a/powerauth-backend-tests/src/main/java/com/wultra/security/powerauth/configuration/PowerAuthTestConfiguration.java
+++ b/powerauth-backend-tests/src/main/java/com/wultra/security/powerauth/configuration/PowerAuthTestConfiguration.java
@@ -186,17 +186,20 @@ public class PowerAuthTestConfiguration {
         // Configure REST client
         RestClientConfiguration.configure();
 
+        // Prepare common userId
+        final String userId = UUID.randomUUID().toString();
+
         // Create status file and user for version 3.1
         statusFileV31 = File.createTempFile("pa_status_v31", ".json");
-        userV31 = "TestUser_" + UUID.randomUUID().toString();
+        userV31 = "TestUserV31_" + userId;
 
         // Create status file and user for version 3.0
         statusFileV3 = File.createTempFile("pa_status_v3", ".json");
-        userV3 = "TestUser_" + UUID.randomUUID().toString();
+        userV3 = "TestUserV3_" + userId;
 
         // Create status file and user for version 2.1
         statusFileV2 = File.createTempFile("pa_status_v2", ".json");
-        userV2 = "TestUser_" + UUID.randomUUID().toString();
+        userV2 = "TestUserV2_" + userId;
 
         // Random application name
         applicationVersionForTests = applicationVersion + "_" + System.currentTimeMillis();

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v3/PowerAuthActivationTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v3/PowerAuthActivationTest.java
@@ -537,9 +537,13 @@ public class PowerAuthActivationTest {
 
     @Test
     public void lookupActivationsInvalidStatusTest() throws Exception {
+        //
+        // This test may fail in case that our battery of tests leaves some activation in the blocked state.
+        // Try to re-run the test alone, or fix the new test case that collides with this one.
+        //
         LookupActivationsRequest lookupActivationsRequest = new LookupActivationsRequest();
         lookupActivationsRequest.getUserIds().add(config.getUserV3());
-        lookupActivationsRequest.setActivationStatus(ActivationStatus.REMOVED);
+        lookupActivationsRequest.setActivationStatus(ActivationStatus.BLOCKED);
         LookupActivationsResponse response = powerAuthClient.lookupActivations(lookupActivationsRequest);
         assertEquals(0, response.getActivations().size());
     }

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthActivationTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthActivationTest.java
@@ -552,9 +552,13 @@ public class PowerAuthActivationTest {
 
     @Test
     public void lookupActivationsInvalidStatusTest() throws Exception {
+        //
+        // This test may fail in case that our battery of tests leaves some activation in the blocked state.
+        // Try to re-run the test alone, or fix the new test case that collides with this one.
+        //
         LookupActivationsRequest lookupActivationsRequest = new LookupActivationsRequest();
         lookupActivationsRequest.getUserIds().add(config.getUserV31());
-        lookupActivationsRequest.setActivationStatus(ActivationStatus.REMOVED);
+        lookupActivationsRequest.setActivationStatus(ActivationStatus.BLOCKED);
         LookupActivationsResponse response = powerAuthClient.lookupActivations(lookupActivationsRequest);
         assertEquals(0, response.getActivations().size());
     }


### PR DESCRIPTION
This change fixes collision between recovery and activation tests. I'm not 100% sure that I understand the purpose of `lookupActivationsInvalidStatusTest()`. In this fix, I expect that we're looking for activations at the particular state, but there's no such one.