### PR TITLE
Add option to skip identity verification result checks

### DIFF
--- a/powerauth-backend-tests/src/main/java/com/wultra/security/powerauth/configuration/PowerAuthTestConfiguration.java
+++ b/powerauth-backend-tests/src/main/java/com/wultra/security/powerauth/configuration/PowerAuthTestConfiguration.java
@@ -96,6 +96,9 @@ public class PowerAuthTestConfiguration {
     @Value("${powerauth.test.assertRetryWaitPeriod:PT1S}")
     private Duration assertRetryWaitPeriod;
 
+    @Value("${powerauth.test.identity.result-verification.skip:false}")
+    private boolean skipResultVerification;
+
     @Value("${powerauth.test.db.concurrency.skip:true}")
     private boolean skipDbConcurrencyTests;
 
@@ -371,6 +374,10 @@ public class PowerAuthTestConfiguration {
 
     public boolean isVerificationOnSubmitEnabled() {
         return verificationOnSubmitEnabled;
+    }
+
+    public boolean isSkipResultVerification() {
+        return skipResultVerification;
     }
 
     public boolean isSkipDbConcurrencyTests() {

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthIdentityVerificationTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthIdentityVerificationTest.java
@@ -179,9 +179,11 @@ public class PowerAuthIdentityVerificationTest {
         }
 
         initPresenceCheck(processId);
-        verifyStatusBeforeOtp();
-        verifyOtpCheck(processId);
-        verifyProcessFinished(processId, activationId);
+        if (!config.isSkipResultVerification()) {
+            verifyStatusBeforeOtp();
+            verifyOtpCheck(processId);
+            verifyProcessFinished(processId, activationId);
+        }
 
         // Remove activation
         powerAuthClient.removeActivation(activationId, "test");
@@ -215,9 +217,11 @@ public class PowerAuthIdentityVerificationTest {
         }
 
         initPresenceCheck(processId);
-        verifyStatusBeforeOtp();
-        verifyOtpCheck(processId);
-        verifyProcessFinished(processId, activationId);;
+        if (!config.isSkipResultVerification()) {
+            verifyStatusBeforeOtp();
+            verifyOtpCheck(processId);
+            verifyProcessFinished(processId, activationId);
+        }
 
         // Remove activation
         powerAuthClient.removeActivation(activationId, "test");

--- a/powerauth-backend-tests/src/test/resources/application.properties
+++ b/powerauth-backend-tests/src/test/resources/application.properties
@@ -19,7 +19,7 @@ powerauth.service.security.clientSecret=
 powerauth.test.application.name=PA_Tests
 powerauth.test.application.version=default
 
-# Skip presence check in tests, used when provider is set to iproov instead of mock provider
+# Skip presence check in tests, used when presence check is disabled during identity verification
 powerauth.test.identity.presence-check.skip=false
 # Enable/disable state assertion approach for document submits with verification
 powerauth.test.identity.verificationOnSubmitEnabled=true
@@ -30,6 +30,10 @@ powerauth.test.assertRetryWaitPeriod=PT1S
 
 # Skip OTP verification in tests, used when OTP code delivery is disabled during identity verification
 powerauth.test.identity.otp-verification.skip=false
+
+# Skip checking of results of identity verification, used when real providers are enabled until we obtain documents
+# which pass all checks, and there exists a workaround for the iProov verification process in tests.
+powerauth.test.identity.result-verification.skip=false
 
 # Skip database concurrency test
 powerauth.test.db.concurrency.skip=true


### PR DESCRIPTION
Let's allow to skip the result verification until we can pass all document checks and workaround iProov check. This change is for the CI to avoid failing tests.