### PR TITLE
Remove obsolete parameter verifyOnSubmit

### DIFF
--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthIdentityVerificationTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthIdentityVerificationTest.java
@@ -198,11 +198,7 @@ class PowerAuthIdentityVerificationTest {
 
         submitDocuments(idCardSubmitRequest, idCardSubmits);
 
-        if (config.isVerificationOnSubmitEnabled()) {
-            assertStatusOfSubmittedDocsWithRetries(processId, idCardSubmits.size(), DocumentStatus.ACCEPTED);
-        } else {
-            assertStatusOfSubmittedDocs(processId, idCardSubmits.size(), DocumentStatus.ACCEPTED);
-        }
+        assertStatusOfSubmittedDocsWithRetries(processId, idCardSubmits.size(), DocumentStatus.ACCEPTED);
 
         assertIdentityVerificationStateWithRetries(
                 new IdentityVerificationState(IdentityVerificationPhase.DOCUMENT_UPLOAD, IdentityVerificationStatus.IN_PROGRESS));
@@ -213,11 +209,7 @@ class PowerAuthIdentityVerificationTest {
         final DocumentSubmitRequest driveLicenseSubmitRequest = createDocumentSubmitRequest(processId, drivingLicenseSubmits);
         submitDocuments(driveLicenseSubmitRequest, drivingLicenseSubmits);
 
-        if (config.isVerificationOnSubmitEnabled()) {
-            assertStatusOfSubmittedDocsWithRetries(processId, idCardSubmits.size() + drivingLicenseSubmits.size(), DocumentStatus.ACCEPTED);
-        } else {
-            assertStatusOfSubmittedDocs(processId, idCardSubmits.size() + drivingLicenseSubmits.size(), DocumentStatus.ACCEPTED);
-        }
+        assertStatusOfSubmittedDocsWithRetries(processId, idCardSubmits.size() + drivingLicenseSubmits.size(), DocumentStatus.ACCEPTED);
 
         assertIdentityVerificationStateWithRetries(
                 new IdentityVerificationState(IdentityVerificationPhase.PRESENCE_CHECK, IdentityVerificationStatus.NOT_INITIALIZED));
@@ -286,11 +278,7 @@ class PowerAuthIdentityVerificationTest {
 
             submitDocuments(idCardSubmitRequest, idCardSubmits);
 
-            if (config.isVerificationOnSubmitEnabled()) {
-                assertStatusOfSubmittedDocsWithRetries(processId, idCardSubmits.size(), DocumentStatus.ACCEPTED);
-            } else {
-                assertStatusOfSubmittedDocs(processId, idCardSubmits.size(), DocumentStatus.ACCEPTED);
-            }
+            assertStatusOfSubmittedDocsWithRetries(processId, idCardSubmits.size(), DocumentStatus.ACCEPTED);
 
             assertIdentityVerificationStateWithRetries(
                     new IdentityVerificationState(IdentityVerificationPhase.DOCUMENT_UPLOAD, IdentityVerificationStatus.IN_PROGRESS));
@@ -301,11 +289,7 @@ class PowerAuthIdentityVerificationTest {
             final DocumentSubmitRequest driveLicenseSubmitRequest = createDocumentSubmitRequest(processId, drivingLicenseSubmits);
             submitDocuments(driveLicenseSubmitRequest, drivingLicenseSubmits);
 
-            if (config.isVerificationOnSubmitEnabled()) {
-                assertStatusOfSubmittedDocsWithRetries(processId, idCardSubmits.size() + drivingLicenseSubmits.size(), DocumentStatus.ACCEPTED);
-            } else {
-                assertStatusOfSubmittedDocs(processId, idCardSubmits.size() + drivingLicenseSubmits.size(), DocumentStatus.ACCEPTED);
-            }
+            assertStatusOfSubmittedDocsWithRetries(processId, idCardSubmits.size() + drivingLicenseSubmits.size(), DocumentStatus.ACCEPTED);
 
             IdentityVerificationState idState =
                     new IdentityVerificationState(IdentityVerificationPhase.PRESENCE_CHECK, IdentityVerificationStatus.NOT_INITIALIZED);
@@ -350,11 +334,7 @@ class PowerAuthIdentityVerificationTest {
         DocumentSubmitRequest driveLicenseSubmitRequest = createDocumentSubmitRequest(processId, drivingLicenseSubmits);
         submitDocuments(driveLicenseSubmitRequest, drivingLicenseSubmits);
 
-        if (config.isVerificationOnSubmitEnabled()) {
-            assertStatusOfSubmittedDocsWithRetries(processId, idCardSubmits.size() + drivingLicenseSubmits.size(), DocumentStatus.ACCEPTED);
-        } else {
-            assertStatusOfSubmittedDocs(processId, idCardSubmits.size() + drivingLicenseSubmits.size(), DocumentStatus.ACCEPTED);
-        }
+        assertStatusOfSubmittedDocsWithRetries(processId, idCardSubmits.size() + drivingLicenseSubmits.size(), DocumentStatus.ACCEPTED);
 
         IdentityVerificationState idState =
                 new IdentityVerificationState(IdentityVerificationPhase.PRESENCE_CHECK, IdentityVerificationStatus.NOT_INITIALIZED);
@@ -389,11 +369,7 @@ class PowerAuthIdentityVerificationTest {
         DocumentSubmitRequest idCardSubmitRequest = createDocumentSubmitRequest(processId, docSubmits);
         submitDocuments(idCardSubmitRequest, docSubmits);
 
-        if (config.isVerificationOnSubmitEnabled()) {
-            assertStatusOfSubmittedDocsWithRetries(processId, docSubmits.size(), DocumentStatus.REJECTED);
-        } else {
-            assertStatusOfSubmittedDocs(processId, docSubmits.size(), DocumentStatus.REJECTED);
-        }
+        assertStatusOfSubmittedDocsWithRetries(processId, docSubmits.size(), DocumentStatus.REJECTED);
 
         powerAuthClient.removeActivation(activationId, "test");
     }
@@ -416,11 +392,7 @@ class PowerAuthIdentityVerificationTest {
         DocumentSubmitRequest idCardSubmitRequest = createDocumentSubmitRequest(processId, docSubmits);
         submitDocuments(idCardSubmitRequest, docSubmits);
 
-        if (config.isVerificationOnSubmitEnabled()) {
-            assertStatusOfSubmittedDocsWithRetries(processId, docSubmits.size(), DocumentStatus.REJECTED);
-        } else {
-            assertStatusOfSubmittedDocs(processId, docSubmits.size(), DocumentStatus.REJECTED);
-        }
+        assertStatusOfSubmittedDocsWithRetries(processId, docSubmits.size(), DocumentStatus.REJECTED);
 
         powerAuthClient.removeActivation(activationId, "test");
     }
@@ -445,11 +417,7 @@ class PowerAuthIdentityVerificationTest {
 
         for (int i = 0; i < 6; i++) {
             submitDocuments(idCardSubmitRequest, docSubmits);
-            if (config.isVerificationOnSubmitEnabled()) {
-                assertStatusOfSubmittedDocsWithRetries(processId, i + 1, DocumentStatus.REJECTED);
-            } else {
-                assertStatusOfSubmittedDocs(processId, i + 1, DocumentStatus.REJECTED);
-            }
+            assertStatusOfSubmittedDocsWithRetries(processId, i + 1, DocumentStatus.REJECTED);
             assertIdentityVerificationStateWithRetries(
                     new IdentityVerificationState(IdentityVerificationPhase.DOCUMENT_UPLOAD, IdentityVerificationStatus.IN_PROGRESS));
         }
@@ -477,11 +445,7 @@ class PowerAuthIdentityVerificationTest {
         DocumentSubmitRequest idCardSubmitRequest = createDocumentSubmitRequest(processId, invalidDocSubmits);
         submitDocuments(idCardSubmitRequest, invalidDocSubmits);
 
-        if (config.isVerificationOnSubmitEnabled()) {
-            assertStatusOfSubmittedDocsWithRetries(processId, invalidDocSubmits.size(), DocumentStatus.ACCEPTED);
-        } else {
-            assertStatusOfSubmittedDocs(processId, invalidDocSubmits.size(), DocumentStatus.ACCEPTED);
-        }
+        assertStatusOfSubmittedDocsWithRetries(processId, invalidDocSubmits.size(), DocumentStatus.ACCEPTED);
 
         powerAuthClient.removeActivation(activationId, "test");
     }
@@ -652,7 +616,6 @@ class PowerAuthIdentityVerificationTest {
         assertTrue(stepLogger.getResult().isSuccess());
         assertEquals(200, stepLogger.getResponse().getStatusCode());
 
-        boolean documentVerificationPending = false;
         String documentId = null;
         for (StepItem item: stepLogger.getItems()) {
             if (item.getName().equals("Decrypted Response")) {
@@ -663,17 +626,11 @@ class PowerAuthIdentityVerificationTest {
                 DocumentMetadataResponseDto doc1 = response.getDocuments().get(0);
                 documentId = doc1.getId();
                 assertNotNull(documentId);
-                if (config.isVerificationOnSubmitEnabled()) {
-                    assertEquals(DocumentStatus.UPLOAD_IN_PROGRESS, doc1.getStatus());
-                } else {
-                    assertEquals(DocumentStatus.VERIFICATION_PENDING, doc1.getStatus());
-                    documentVerificationPending = true;
-                }
+                // TODO - check that this state is correct, I would expect that submitted document is in VERIFICATION_PENDING
+                // state for synchronous processing, which is not sent at the moment
+                assertEquals(DocumentStatus.UPLOAD_IN_PROGRESS, doc1.getStatus());
                 break;
             }
-        }
-        if (!config.isVerificationOnSubmitEnabled()) {
-            assertTrue(documentVerificationPending);
         }
         assertNotNull(documentId);
 
@@ -1042,9 +999,9 @@ class PowerAuthIdentityVerificationTest {
         assertNotNull(responseOtpOK.getEncryptedData());
         assertNotNull(responseOtpOK.getMac());
 
-        List<DocumentStatus> expectedStatuses = config.isVerificationOnSubmitEnabled() ?
-                ImmutableList.of(DocumentStatus.REJECTED, DocumentStatus.UPLOAD_IN_PROGRESS) : ImmutableList.of(DocumentStatus.VERIFICATION_PENDING);
-        boolean documentVerificationPending = false;
+        // TODO - check that this state is correct, I would expect that submitted document is in VERIFICATION_PENDING
+        // state for synchronous processing, which is not sent at the moment
+        List<DocumentStatus> expectedStatuses = ImmutableList.of(DocumentStatus.UPLOAD_IN_PROGRESS);
         for (StepItem item : stepLogger.getItems()) {
             if (item.getName().equals("Decrypted Response")) {
                 String responseData = item.getObject().toString();
@@ -1057,16 +1014,7 @@ class PowerAuthIdentityVerificationTest {
                     assertNotNull(doc.getId());
                     assertTrue(expectedStatuses.contains(doc.getStatus()));
                 }
-                if (!config.isVerificationOnSubmitEnabled()) {
-                    documentVerificationPending = response.getDocuments().stream()
-                            .filter(doc -> DocumentStatus.VERIFICATION_PENDING == doc.getStatus())
-                            .count() == fileSubmits.size();
-                }
-                break;
             }
-        }
-        if (!config.isVerificationOnSubmitEnabled()) {
-            assertTrue(documentVerificationPending);
         }
     }
 

--- a/powerauth-backend-tests/src/test/resources/application.properties
+++ b/powerauth-backend-tests/src/test/resources/application.properties
@@ -23,8 +23,6 @@ powerauth.test.application.version=default
 powerauth.test.identity.presence-check.skip=false
 # Enable/disable additional validations during document submit process
 powerauth.test.identity.additionalDocSubmitValidationsEnabled=true
-# Enable/disable state assertion approach for document submits with verification
-powerauth.test.identity.verificationOnSubmitEnabled=true
 # Maximum number of retries on specific asserts
 powerauth.test.assertMaxRetries=20
 # Retry period between assert retries


### PR DESCRIPTION
I am done with parameter `documentVerificationOnSubmitEnabled`, this is causing neverending confusion and invalid configuration issues.

The document state does not currently reflect exactly what happened on server (document is already uploaded during synchronous processing, `UPLOAD_IN_PROGRESS` is the correct state only for async). I added similar TODO into backend code.