### PR TITLE
Fix #147: Create token with other factors than possession+knowledge

### DIFF
--- a/powerauth-test-server/src/main/java/com/wultra/security/powerauth/app/testserver/model/request/CreateTokenRequest.java
+++ b/powerauth-test-server/src/main/java/com/wultra/security/powerauth/app/testserver/model/request/CreateTokenRequest.java
@@ -30,5 +30,5 @@ public class CreateTokenRequest {
     private String activationId;
     private String applicationId;
     private String password;
-
+    private String signatureType;
 }

--- a/powerauth-test-server/src/main/java/com/wultra/security/powerauth/app/testserver/service/TokenService.java
+++ b/powerauth-test-server/src/main/java/com/wultra/security/powerauth/app/testserver/service/TokenService.java
@@ -93,13 +93,17 @@ public class TokenService extends BaseService {
         final TestConfigEntity appConfig = getTestAppConfig(applicationId);
         final PublicKey publicKey = getMasterPublicKey(appConfig);
         final JSONObject resultStatusObject = resultStatusUtil.getTestStatus(request.getActivationId());
-
+        PowerAuthSignatureTypes signatureType = PowerAuthSignatureTypes.getEnumFromString(request.getSignatureType());
+        if (signatureType == null) {
+            // Fallback to previous behavior when there was no signatureType property in the request.
+            signatureType = PowerAuthSignatureTypes.POSSESSION_KNOWLEDGE;
+        }
         final CreateTokenStepModel model = new CreateTokenStepModel();
         model.setApplicationKey(appConfig.getApplicationKey());
         model.setApplicationSecret(appConfig.getApplicationSecret());
         model.setPassword(request.getPassword());
         model.setMasterPublicKey(publicKey);
-        model.setSignatureType(PowerAuthSignatureTypes.POSSESSION_KNOWLEDGE);
+        model.setSignatureType(signatureType);
         model.setVersion(config.getVersion());
         model.setUriString(config.getEnrollmentServiceUrl());
         model.setResultStatusObject(resultStatusObject);


### PR DESCRIPTION
This PR adds ability to create token with other than POSSESSION_KNOWLEDGE factors to Test Server.

There's new optional param `signatureType` and if it's omitted, then `POSSESSION_KNOWLEDGE` is used. This achieves a backward compatibility with previous tests. 