### PR TITLE
Fix #379: FIDO2 Test application: Backend

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <bc.version>1.77</bc.version>
         <springdoc-openapi-starter-webmvc-ui.version>2.3.0</springdoc-openapi-starter-webmvc-ui.version>
         <logstash.version>7.4</logstash.version>
-        <webauthn4j.version>0.22.1.RELEASE</webauthn4j.version>
+        <webauthn4j.version>0.22.2.RELEASE</webauthn4j.version>
 
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <bc.version>1.77</bc.version>
         <springdoc-openapi-starter-webmvc-ui.version>2.3.0</springdoc-openapi-starter-webmvc-ui.version>
         <logstash.version>7.4</logstash.version>
+        <webauthn4j.version>0.22.1.RELEASE</webauthn4j.version>
 
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>

--- a/powerauth-fido2-tests/pom.xml
+++ b/powerauth-fido2-tests/pom.xml
@@ -29,12 +29,23 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
 
         <!-- Wultra Dependencies -->
         <dependency>
             <groupId>io.getlime.security</groupId>
             <artifactId>powerauth-rest-client-spring</artifactId>
             <version>${powerauth-server.version}</version>
+        </dependency>
+
+        <!-- Other Dependencies -->
+        <dependency>
+            <groupId>com.webauthn4j</groupId>
+            <artifactId>webauthn4j-core</artifactId>
+            <version>${webauthn4j.version}</version>
         </dependency>
 
     </dependencies>

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/AssertionController.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/AssertionController.java
@@ -1,0 +1,60 @@
+/*
+ * PowerAuth test and related software components
+ * Copyright (C) 2024 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.wultra.security.powerauth.fido2.controller;
+
+import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
+import com.wultra.security.powerauth.client.model.response.fido2.AssertionVerificationResponse;
+import com.wultra.security.powerauth.fido2.controller.request.AssertionOptionsRequest;
+import com.wultra.security.powerauth.fido2.controller.request.VerifyAssertionRequest;
+import com.wultra.security.powerauth.fido2.controller.response.AssertionOptionsResponse;
+import com.wultra.security.powerauth.fido2.service.AssertionService;
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * WebAuthn assertion ceremony controller.
+ *
+ * @author Jan Pesek, jan.pesek@wultra.com
+ */
+@Validated
+@RestController
+@RequestMapping("/assertion")
+@AllArgsConstructor
+@Slf4j
+public class AssertionController {
+
+    final AssertionService assertionService;
+
+    @PostMapping("/options")
+    public AssertionOptionsResponse options(@Valid @RequestBody final AssertionOptionsRequest request) throws PowerAuthClientException {
+        return assertionService.assertionOptions(request);
+    }
+
+    @PostMapping
+    public AssertionVerificationResponse verify(@Valid @RequestBody final VerifyAssertionRequest request) throws PowerAuthClientException {
+        return assertionService.authenticate(request);
+    }
+
+}

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/DefaultExceptionHandler.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/DefaultExceptionHandler.java
@@ -1,0 +1,51 @@
+/*
+ * PowerAuth test and related software components
+ * Copyright (C) 2024 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.wultra.security.powerauth.fido2.controller;
+
+import com.wultra.security.powerauth.client.model.error.PowerAuthError;
+import io.getlime.core.rest.model.base.response.ObjectResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Controller to handle exceptions.
+ *
+ * @author Jan Pesek, jan.pesek@wultra.com
+ */
+@ControllerAdvice
+@Slf4j
+public class DefaultExceptionHandler {
+
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public @ResponseBody ObjectResponse<PowerAuthError> handleErrors(Exception ex) {
+        logger.error("Error occurred while processing the request: {}", ex.getMessage());
+        logger.debug("Exception details:", ex);
+        final PowerAuthError error = new PowerAuthError();
+        error.setCode("ERROR");
+        error.setMessage(ex.getMessage());
+        error.setLocalizedMessage(ex.getLocalizedMessage());
+        return new ObjectResponse<>("ERROR", error);
+    }
+
+}

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/RegistrationController.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/RegistrationController.java
@@ -1,0 +1,58 @@
+/*
+ * PowerAuth test and related software components
+ * Copyright (C) 2024 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.wultra.security.powerauth.fido2.controller;
+
+import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
+import com.wultra.security.powerauth.client.model.response.fido2.RegistrationResponse;
+import com.wultra.security.powerauth.fido2.controller.request.RegisterCredentialRequest;
+import com.wultra.security.powerauth.fido2.controller.request.RegistrationOptionsRequest;
+import com.wultra.security.powerauth.fido2.controller.response.RegistrationOptionsResponse;
+import com.wultra.security.powerauth.fido2.service.RegistrationService;
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * WebAuthn registration ceremony controller.
+ *
+ * @author Jan Pesek, jan.pesek@wultra.com
+ */
+@Validated
+@RestController
+@RequestMapping("/registration")
+@AllArgsConstructor
+public class RegistrationController {
+
+    private final RegistrationService registrationService;
+
+    @PostMapping("/options")
+    public RegistrationOptionsResponse options(@Valid @RequestBody final RegistrationOptionsRequest request) throws PowerAuthClientException {
+        return registrationService.registerOptions(request);
+    }
+
+    @PostMapping
+    public RegistrationResponse register(@Valid @RequestBody final RegisterCredentialRequest request) throws PowerAuthClientException {
+        return registrationService.register(request);
+    }
+
+}

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/request/AssertionOptionsRequest.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/request/AssertionOptionsRequest.java
@@ -1,0 +1,36 @@
+/*
+ * PowerAuth test and related software components
+ * Copyright (C) 2024 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.wultra.security.powerauth.fido2.controller.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Request for credential assertion options.
+ *
+ * @author Jan Pesek, jan.pesek@wultra.com
+ */
+public record AssertionOptionsRequest (
+        String username,
+
+        @NotBlank
+        String applicationId,
+
+        @NotBlank
+        String templateName
+) { }

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/request/AssertionOptionsRequest.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/request/AssertionOptionsRequest.java
@@ -20,6 +20,8 @@ package com.wultra.security.powerauth.fido2.controller.request;
 
 import jakarta.validation.constraints.NotBlank;
 
+import java.util.Map;
+
 /**
  * Request for credential assertion options.
  *
@@ -32,5 +34,7 @@ public record AssertionOptionsRequest (
         String applicationId,
 
         @NotBlank
-        String templateName
+        String templateName,
+
+        Map<String, String> operationParameters
 ) { }

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/request/RegisterCredentialRequest.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/request/RegisterCredentialRequest.java
@@ -34,7 +34,7 @@ public record RegisterCredentialRequest (
         String applicationId,
 
         @NotBlank
-        String activationName,
+        String username,
 
         boolean userVerificationRequired,
 

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/request/RegisterCredentialRequest.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/request/RegisterCredentialRequest.java
@@ -1,0 +1,52 @@
+/*
+ * PowerAuth test and related software components
+ * Copyright (C) 2024 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.wultra.security.powerauth.fido2.controller.request;
+
+import com.webauthn4j.data.AuthenticatorAttachment;
+import com.webauthn4j.data.PublicKeyCredentialType;
+import com.wultra.security.powerauth.client.model.entity.fido2.AuthenticatorAttestationResponse;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Request for register credentials.
+ *
+ * @author Jan Pesek, jan.pesek@wultra.com
+ */
+public record RegisterCredentialRequest (
+        @NotBlank
+        String applicationId,
+
+        @NotBlank
+        String activationName,
+
+        boolean userVerificationRequired,
+
+        @NotBlank
+        String id,
+
+        @NotNull
+        PublicKeyCredentialType type,
+
+        @NotNull
+        AuthenticatorAttachment authenticatorAttachment,
+
+        @NotNull
+        AuthenticatorAttestationResponse response
+) {}

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/request/RegistrationOptionsRequest.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/request/RegistrationOptionsRequest.java
@@ -1,0 +1,34 @@
+/*
+ * PowerAuth test and related software components
+ * Copyright (C) 2024 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.wultra.security.powerauth.fido2.controller.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Request for credential registration options.
+ *
+ * @author Jan Pesek, jan.pesek@wultra.com
+ */
+public record RegistrationOptionsRequest(
+    @NotBlank
+    String username,
+
+    @NotBlank
+    String applicationId
+) {}

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/request/VerifyAssertionRequest.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/request/VerifyAssertionRequest.java
@@ -1,0 +1,51 @@
+/*
+ * PowerAuth test and related software components
+ * Copyright (C) 2024 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.wultra.security.powerauth.fido2.controller.request;
+
+import com.webauthn4j.data.AuthenticatorAttachment;
+import com.webauthn4j.data.PublicKeyCredentialType;
+import com.wultra.security.powerauth.client.model.entity.fido2.AuthenticatorAssertionResponse;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Request for verify credential.
+ *
+ * @author Jan Pesek, jan.pesek@wultra.com
+ */
+public record VerifyAssertionRequest(
+        @NotBlank
+        String applicationId,
+
+        @NotBlank
+        String id,
+
+        @NotNull
+        PublicKeyCredentialType type,
+
+        @NotNull
+        AuthenticatorAttachment authenticatorAttachment,
+
+        @NotNull
+        AuthenticatorAssertionResponse response,
+
+        String expectedChallenge,
+
+        boolean userVerificationRequired
+) {}

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/response/AssertionOptionsResponse.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/response/AssertionOptionsResponse.java
@@ -18,7 +18,6 @@
 
 package com.wultra.security.powerauth.fido2.controller.response;
 
-import com.webauthn4j.data.UserVerificationRequirement;
 import lombok.Builder;
 
 import java.util.List;
@@ -35,6 +34,5 @@ public record AssertionOptionsResponse(
     String challenge,
     Long timeout,
     List<CredentialDescriptor> allowCredentials,
-    UserVerificationRequirement userVerification,
     Map<String, Object> extensions
 ) {}

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/response/AssertionOptionsResponse.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/response/AssertionOptionsResponse.java
@@ -20,7 +20,6 @@ package com.wultra.security.powerauth.fido2.controller.response;
 
 import com.webauthn4j.data.UserVerificationRequirement;
 import lombok.Builder;
-import lombok.Data;
 
 import java.util.List;
 import java.util.Map;
@@ -30,13 +29,12 @@ import java.util.Map;
  *
  * @author Jan Pesek, jan.pesek@wultra.com
  */
-@Data
 @Builder
-public class AssertionOptionsResponse {
-    private String rpId;
-    private String challenge;
-    private Long timeout;
-    private List<CredentialDescriptor> allowCredentials;
-    private UserVerificationRequirement userVerification;
-    private Map<String, Object> extensions;
-}
+public record AssertionOptionsResponse(
+    String rpId,
+    String challenge,
+    Long timeout,
+    List<CredentialDescriptor> allowCredentials,
+    UserVerificationRequirement userVerification,
+    Map<String, Object> extensions
+) {}

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/response/AssertionOptionsResponse.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/response/AssertionOptionsResponse.java
@@ -1,0 +1,42 @@
+/*
+ * PowerAuth test and related software components
+ * Copyright (C) 2024 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.wultra.security.powerauth.fido2.controller.response;
+
+import com.webauthn4j.data.UserVerificationRequirement;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Public key credential assertion options.
+ *
+ * @author Jan Pesek, jan.pesek@wultra.com
+ */
+@Data
+@Builder
+public class AssertionOptionsResponse {
+    private String rpId;
+    private String challenge;
+    private Long timeout;
+    private List<CredentialDescriptor> allowCredentials;
+    private UserVerificationRequirement userVerification;
+    private Map<String, Object> extensions;
+}

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/response/CredentialDescriptor.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/response/CredentialDescriptor.java
@@ -1,0 +1,35 @@
+/*
+ * PowerAuth test and related software components
+ * Copyright (C) 2024 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.wultra.security.powerauth.fido2.controller.response;
+
+import com.webauthn4j.data.AuthenticatorTransport;
+import com.webauthn4j.data.PublicKeyCredentialType;
+
+import java.util.List;
+
+/**
+ * Structure used in allowCredentials and excludeCredentials.
+ *
+ * @author Jan Pesek, jan.pesek@wultra.com
+ */
+public record CredentialDescriptor(
+        PublicKeyCredentialType type,
+        String id,
+        List<AuthenticatorTransport> transports
+) {}

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/response/RegistrationOptionsResponse.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/response/RegistrationOptionsResponse.java
@@ -1,0 +1,43 @@
+/*
+ * PowerAuth test and related software components
+ * Copyright (C) 2024 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.wultra.security.powerauth.fido2.controller.response;
+
+import com.webauthn4j.data.PublicKeyCredentialParameters;
+import com.webauthn4j.data.PublicKeyCredentialRpEntity;
+import com.webauthn4j.data.PublicKeyCredentialUserEntity;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * Public key credential creation options.
+ *
+ * @author Jan Pesek, jan.pesek@wultra.com
+ */
+@Builder
+@Getter
+public class RegistrationOptionsResponse {
+    private PublicKeyCredentialRpEntity rp;
+    private PublicKeyCredentialUserEntity user;
+    private String challenge;
+    private List<PublicKeyCredentialParameters> pubKeyCredParams;
+    private Long timeout;
+    private List<CredentialDescriptor> excludeCredentials;
+}

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/response/RegistrationOptionsResponse.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/response/RegistrationOptionsResponse.java
@@ -22,7 +22,6 @@ import com.webauthn4j.data.PublicKeyCredentialParameters;
 import com.webauthn4j.data.PublicKeyCredentialRpEntity;
 import com.webauthn4j.data.PublicKeyCredentialUserEntity;
 import lombok.Builder;
-import lombok.Getter;
 
 import java.util.List;
 
@@ -32,12 +31,11 @@ import java.util.List;
  * @author Jan Pesek, jan.pesek@wultra.com
  */
 @Builder
-@Getter
-public class RegistrationOptionsResponse {
-    private PublicKeyCredentialRpEntity rp;
-    private PublicKeyCredentialUserEntity user;
-    private String challenge;
-    private List<PublicKeyCredentialParameters> pubKeyCredParams;
-    private Long timeout;
-    private List<CredentialDescriptor> excludeCredentials;
-}
+public record RegistrationOptionsResponse(
+    PublicKeyCredentialRpEntity rp,
+    PublicKeyCredentialUserEntity user,
+    String challenge,
+    List<PublicKeyCredentialParameters> pubKeyCredParams,
+    Long timeout,
+    List<CredentialDescriptor> excludeCredentials
+) {}

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/AssertionService.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/AssertionService.java
@@ -1,0 +1,123 @@
+/*
+ * PowerAuth test and related software components
+ * Copyright (C) 2024 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.wultra.security.powerauth.fido2.service;
+
+import com.webauthn4j.data.UserVerificationRequirement;
+import com.wultra.security.powerauth.client.PowerAuthFido2Client;
+import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
+import com.wultra.security.powerauth.client.model.request.fido2.AssertionChallengeRequest;
+import com.wultra.security.powerauth.client.model.request.fido2.AssertionVerificationRequest;
+import com.wultra.security.powerauth.client.model.response.fido2.AssertionChallengeResponse;
+import com.wultra.security.powerauth.client.model.response.fido2.AssertionVerificationResponse;
+import com.wultra.security.powerauth.fido2.configuration.WebAuthnConfiguration;
+import com.wultra.security.powerauth.fido2.controller.request.AssertionOptionsRequest;
+import com.wultra.security.powerauth.fido2.controller.request.VerifyAssertionRequest;
+import com.wultra.security.powerauth.fido2.controller.response.AssertionOptionsResponse;
+import com.wultra.security.powerauth.fido2.controller.response.CredentialDescriptor;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Service for WebAuthn authentication tasks.
+ *
+ * @author Jan Pesek, jan.pesek@wultra.com
+ */
+@Service
+@AllArgsConstructor
+@Slf4j
+public class AssertionService {
+
+    private static final String OPERATION_DATA_EXTENSION_KEY = "txAuthSimple";
+
+    private final PowerAuthFido2Client fido2Client;
+    private final SharedService sharedService;
+    private final WebAuthnConfiguration webauthnConfig;
+
+    /**
+     * Build public key assertion options.
+     * @param request Request form with user input.
+     * @return Public key assertion options.
+     * @throws PowerAuthClientException in case of PowerAuth server communication error.
+     */
+    public AssertionOptionsResponse assertionOptions(final AssertionOptionsRequest request) throws PowerAuthClientException {
+        final String userId = request.username();
+        final String applicationId = request.applicationId();
+
+        logger.info("Building assertion options for userId={}, applicationId={}", userId, applicationId);
+
+        final List<CredentialDescriptor> existingCredentials = sharedService.fetchExistingCredentials(userId, applicationId);
+        if (existingCredentials.isEmpty() && StringUtils.hasText(userId))  {
+            throw new IllegalStateException("Not registered yet.");
+        }
+
+        final AssertionChallengeResponse challengeResponse = fetchChallenge(applicationId, request.templateName());
+        final String challenge = challengeResponse.getChallenge();
+        final String operationData = extractOperationData(challenge);
+
+        return AssertionOptionsResponse.builder()
+                .challenge(challenge)
+                .rpId(webauthnConfig.getRpId())
+                .timeout(webauthnConfig.getTimeout().toMillis())
+                .allowCredentials(existingCredentials)
+                .userVerification(UserVerificationRequirement.PREFERRED)
+                .extensions(Map.of(OPERATION_DATA_EXTENSION_KEY, operationData))
+                .build();
+    }
+
+    /**
+     * Verify credential at PowerAuth server.
+     * @param credential Received public key credential.
+     * @return PowerAuth authentication response.
+     * @throws PowerAuthClientException in case of PowerAuth server communication error.
+     */
+    public AssertionVerificationResponse authenticate(final VerifyAssertionRequest credential) throws PowerAuthClientException {
+        final AssertionVerificationRequest request = new AssertionVerificationRequest();
+        request.setId(credential.id());
+        request.setType(credential.type().getValue());
+        request.setAuthenticatorAttachment(credential.authenticatorAttachment().getValue());
+        request.setResponse(credential.response());
+        request.setApplicationId(credential.applicationId());
+        request.setExpectedChallenge(credential.expectedChallenge());
+        request.setRelyingPartyId(webauthnConfig.getRpId());
+        request.setAllowedOrigins(webauthnConfig.getAllowedOrigins());
+        request.setRequiresUserVerification(credential.userVerificationRequired());
+        return fido2Client.authenticate(request);
+    }
+
+    private AssertionChallengeResponse fetchChallenge(final String applicationId, final String templateName) throws PowerAuthClientException {
+        final AssertionChallengeRequest request = new AssertionChallengeRequest();
+        request.setApplicationIds(List.of(applicationId));
+        request.setTemplateName(templateName);
+        return fido2Client.requestAssertionChallenge(request);
+    }
+
+    private static String extractOperationData(final String challenge) {
+        final String[] split = challenge.split("&", 2);
+        if (split.length != 2) {
+            throw new IllegalStateException("Invalid challenge.");
+        }
+        return split[1];
+    }
+
+}

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/AssertionService.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/AssertionService.java
@@ -52,7 +52,7 @@ public class AssertionService {
 
     private final PowerAuthFido2Client fido2Client;
     private final SharedService sharedService;
-    private final WebAuthnConfiguration webauthnConfig;
+    private final WebAuthnConfiguration webAuthNConfig;
 
     /**
      * Build public key assertion options.
@@ -77,8 +77,8 @@ public class AssertionService {
 
         return AssertionOptionsResponse.builder()
                 .challenge(challenge)
-                .rpId(webauthnConfig.getRpId())
-                .timeout(webauthnConfig.getTimeout().toMillis())
+                .rpId(webAuthNConfig.getRpId())
+                .timeout(webAuthNConfig.getTimeout().toMillis())
                 .allowCredentials(existingCredentials)
                 .userVerification(UserVerificationRequirement.PREFERRED)
                 .extensions(Map.of(OPERATION_DATA_EXTENSION_KEY, operationData))
@@ -99,8 +99,8 @@ public class AssertionService {
         request.setResponse(credential.response());
         request.setApplicationId(credential.applicationId());
         request.setExpectedChallenge(credential.expectedChallenge());
-        request.setRelyingPartyId(webauthnConfig.getRpId());
-        request.setAllowedOrigins(webauthnConfig.getAllowedOrigins());
+        request.setRelyingPartyId(webAuthNConfig.getRpId());
+        request.setAllowedOrigins(webAuthNConfig.getAllowedOrigins());
         request.setRequiresUserVerification(credential.userVerificationRequired());
         return fido2Client.authenticate(request);
     }

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/AssertionService.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/AssertionService.java
@@ -51,7 +51,7 @@ public class AssertionService {
     private static final String OPERATION_DATA_EXTENSION_KEY = "txAuthSimple";
 
     private final PowerAuthFido2Client fido2Client;
-    private final SharedService sharedService;
+    private final Fido2SharedService fido2SharedService;
     private final WebAuthnConfiguration webAuthNConfig;
 
     /**
@@ -66,7 +66,7 @@ public class AssertionService {
 
         logger.info("Building assertion options for userId={}, applicationId={}", userId, applicationId);
 
-        final List<CredentialDescriptor> existingCredentials = sharedService.fetchExistingCredentials(userId, applicationId);
+        final List<CredentialDescriptor> existingCredentials = fido2SharedService.fetchExistingCredentials(userId, applicationId);
         if (existingCredentials.isEmpty() && StringUtils.hasText(userId))  {
             throw new IllegalStateException("Not registered yet.");
         }

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/AssertionService.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/AssertionService.java
@@ -18,7 +18,6 @@
 
 package com.wultra.security.powerauth.fido2.service;
 
-import com.webauthn4j.data.UserVerificationRequirement;
 import com.wultra.security.powerauth.client.PowerAuthFido2Client;
 import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
 import com.wultra.security.powerauth.client.model.request.fido2.AssertionChallengeRequest;
@@ -71,7 +70,7 @@ public class AssertionService {
             throw new IllegalStateException("Not registered yet.");
         }
 
-        final AssertionChallengeResponse challengeResponse = fetchChallenge(applicationId, request.templateName());
+        final AssertionChallengeResponse challengeResponse = fetchChallenge(applicationId, request.templateName(), request.operationParameters());
         final String challenge = challengeResponse.getChallenge();
         final String operationData = extractOperationData(challenge);
 
@@ -104,10 +103,13 @@ public class AssertionService {
         return fido2Client.authenticate(request);
     }
 
-    private AssertionChallengeResponse fetchChallenge(final String applicationId, final String templateName) throws PowerAuthClientException {
+    private AssertionChallengeResponse fetchChallenge(final String applicationId, final String templateName, final Map<String, String> operationParameters) throws PowerAuthClientException {
         final AssertionChallengeRequest request = new AssertionChallengeRequest();
         request.setApplicationIds(List.of(applicationId));
         request.setTemplateName(templateName);
+        if (operationParameters != null) {
+            request.setParameters(operationParameters);
+        }
         return fido2Client.requestAssertionChallenge(request);
     }
 

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/AssertionService.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/AssertionService.java
@@ -80,7 +80,6 @@ public class AssertionService {
                 .rpId(webAuthNConfig.getRpId())
                 .timeout(webAuthNConfig.getTimeout().toMillis())
                 .allowCredentials(existingCredentials)
-                .userVerification(UserVerificationRequirement.PREFERRED)
                 .extensions(Map.of(OPERATION_DATA_EXTENSION_KEY, operationData))
                 .build();
     }

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/Fido2SharedService.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/Fido2SharedService.java
@@ -43,7 +43,7 @@ import java.util.List;
 @Service
 @AllArgsConstructor
 @Slf4j
-public class SharedService {
+public class Fido2SharedService {
 
     private static final String EXTRAS_TRANSPORT_KEY = "transports";
     private static final PublicKeyCredentialType CREDENTIAL_TYPE = PublicKeyCredentialType.PUBLIC_KEY;
@@ -64,7 +64,7 @@ public class SharedService {
         }
 
         return listAuthenticators(userId, applicationId).stream()
-                .map(SharedService::toCredentialDescriptor)
+                .map(Fido2SharedService::toCredentialDescriptor)
                 .toList();
     }
 

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/RegistrationService.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/RegistrationService.java
@@ -1,0 +1,116 @@
+/*
+ * PowerAuth test and related software components
+ * Copyright (C) 2024 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.wultra.security.powerauth.fido2.service;
+
+import com.webauthn4j.data.PublicKeyCredentialParameters;
+import com.webauthn4j.data.PublicKeyCredentialRpEntity;
+import com.webauthn4j.data.PublicKeyCredentialType;
+import com.webauthn4j.data.PublicKeyCredentialUserEntity;
+import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier;
+import com.wultra.security.powerauth.client.PowerAuthFido2Client;
+import com.wultra.security.powerauth.client.model.entity.fido2.AuthenticatorParameters;
+import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
+import com.wultra.security.powerauth.client.model.request.fido2.RegistrationRequest;
+import com.wultra.security.powerauth.client.model.response.fido2.RegistrationChallengeResponse;
+import com.wultra.security.powerauth.client.model.response.fido2.RegistrationResponse;
+import com.wultra.security.powerauth.fido2.configuration.WebAuthnConfiguration;
+import com.wultra.security.powerauth.fido2.controller.request.RegisterCredentialRequest;
+import com.wultra.security.powerauth.fido2.controller.request.RegistrationOptionsRequest;
+import com.wultra.security.powerauth.fido2.controller.response.RegistrationOptionsResponse;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * Service for WebAuthn registration tasks.
+ *
+ * @author Jan Pesek, jan.pesek@wultra.com
+ */
+@Service
+@AllArgsConstructor
+@Slf4j
+public class RegistrationService {
+
+    private final PowerAuthFido2Client fido2Client;
+    private final SharedService sharedService;
+    private final WebAuthnConfiguration webauthnConfig;
+
+    /**
+     * Build public key registration options.
+     * @param request Request form with user input.
+     * @return Public key registration options.
+     * @throws PowerAuthClientException in case of PowerAuth server communication error.
+     */
+    public RegistrationOptionsResponse registerOptions(final RegistrationOptionsRequest request) throws PowerAuthClientException {
+        final String userId = request.username();
+        final String applicationId = request.applicationId();
+
+        final RegistrationChallengeResponse challengeResponse = fetchChallenge(userId, applicationId);
+
+        logger.info("Building registration options for userId={}, applicationId={}", userId, applicationId);
+        return RegistrationOptionsResponse.builder()
+                .rp(new PublicKeyCredentialRpEntity(webauthnConfig.getRpId(), webauthnConfig.getRpName()))
+                .user(new PublicKeyCredentialUserEntity(userId.getBytes(), userId, userId))
+                .challenge(challengeResponse.getChallenge())
+                .pubKeyCredParams(List.of(
+                        new PublicKeyCredentialParameters(PublicKeyCredentialType.PUBLIC_KEY, COSEAlgorithmIdentifier.ES256)
+                ))
+                .timeout(webauthnConfig.getTimeout().toMillis())
+                .excludeCredentials(sharedService.fetchExistingCredentials(userId, applicationId))
+                .build();
+    }
+
+    /**
+     * Register credential at PowerAuth server.
+     * @param credential Newly created public key credential
+     * @return PowerAuth registration response.
+     * @throws PowerAuthClientException in case of PowerAuth server communication error.
+     */
+    public RegistrationResponse register(final RegisterCredentialRequest credential) throws PowerAuthClientException {
+        logger.info("Registering created credential of userId={}, applicationId={}", credential.activationName(), credential.applicationId());
+
+        final RegistrationRequest request = new RegistrationRequest();
+        request.setActivationName(credential.activationName());
+        request.setApplicationId(credential.applicationId());
+        request.setAuthenticatorParameters(buildAuthenticatorParameters(credential));
+        return fido2Client.register(request);
+    }
+
+    private RegistrationChallengeResponse fetchChallenge(final String userId, final String applicationId) throws PowerAuthClientException {
+        logger.info("Getting registration challenge for user {}, applicationId={}", userId, applicationId);
+        final RegistrationChallengeResponse response = fido2Client.requestRegistrationChallenge(userId, applicationId);
+        logger.debug("Got response={}", response);
+        return response;
+    }
+
+    private AuthenticatorParameters buildAuthenticatorParameters(final RegisterCredentialRequest credential) {
+        final AuthenticatorParameters parameters = new AuthenticatorParameters();
+        parameters.setId(credential.id());
+        parameters.setAuthenticatorAttachment(credential.authenticatorAttachment().getValue());
+        parameters.setType(credential.type().getValue());
+        parameters.setResponse(credential.response());
+        parameters.setAllowedOrigins(webauthnConfig.getAllowedOrigins());
+        parameters.setRelyingPartyId(webauthnConfig.getRpId());
+        parameters.setRequiresUserVerification(credential.userVerificationRequired());
+        return parameters;
+    }
+
+}

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/RegistrationService.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/RegistrationService.java
@@ -50,7 +50,7 @@ import java.util.List;
 public class RegistrationService {
 
     private final PowerAuthFido2Client fido2Client;
-    private final SharedService sharedService;
+    private final Fido2SharedService fido2SharedService;
     private final WebAuthnConfiguration webAuthNConfig;
 
     /**
@@ -74,7 +74,7 @@ public class RegistrationService {
                         new PublicKeyCredentialParameters(PublicKeyCredentialType.PUBLIC_KEY, COSEAlgorithmIdentifier.ES256)
                 ))
                 .timeout(webAuthNConfig.getTimeout().toMillis())
-                .excludeCredentials(sharedService.fetchExistingCredentials(userId, applicationId))
+                .excludeCredentials(fido2SharedService.fetchExistingCredentials(userId, applicationId))
                 .build();
     }
 

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/RegistrationService.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/RegistrationService.java
@@ -85,10 +85,10 @@ public class RegistrationService {
      * @throws PowerAuthClientException in case of PowerAuth server communication error.
      */
     public RegistrationResponse register(final RegisterCredentialRequest credential) throws PowerAuthClientException {
-        logger.info("Registering created credential of userId={}, applicationId={}", credential.activationName(), credential.applicationId());
+        logger.info("Registering created credential of userId={}, applicationId={}", credential.username(), credential.applicationId());
 
         final RegistrationRequest request = new RegistrationRequest();
-        request.setActivationName(credential.activationName());
+        request.setActivationName(credential.username());
         request.setApplicationId(credential.applicationId());
         request.setAuthenticatorParameters(buildAuthenticatorParameters(credential));
         return fido2Client.register(request);

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/RegistrationService.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/RegistrationService.java
@@ -51,7 +51,7 @@ public class RegistrationService {
 
     private final PowerAuthFido2Client fido2Client;
     private final SharedService sharedService;
-    private final WebAuthnConfiguration webauthnConfig;
+    private final WebAuthnConfiguration webAuthNConfig;
 
     /**
      * Build public key registration options.
@@ -67,13 +67,13 @@ public class RegistrationService {
 
         logger.info("Building registration options for userId={}, applicationId={}", userId, applicationId);
         return RegistrationOptionsResponse.builder()
-                .rp(new PublicKeyCredentialRpEntity(webauthnConfig.getRpId(), webauthnConfig.getRpName()))
+                .rp(new PublicKeyCredentialRpEntity(webAuthNConfig.getRpId(), webAuthNConfig.getRpName()))
                 .user(new PublicKeyCredentialUserEntity(userId.getBytes(), userId, userId))
                 .challenge(challengeResponse.getChallenge())
                 .pubKeyCredParams(List.of(
                         new PublicKeyCredentialParameters(PublicKeyCredentialType.PUBLIC_KEY, COSEAlgorithmIdentifier.ES256)
                 ))
-                .timeout(webauthnConfig.getTimeout().toMillis())
+                .timeout(webAuthNConfig.getTimeout().toMillis())
                 .excludeCredentials(sharedService.fetchExistingCredentials(userId, applicationId))
                 .build();
     }
@@ -107,8 +107,8 @@ public class RegistrationService {
         parameters.setAuthenticatorAttachment(credential.authenticatorAttachment().getValue());
         parameters.setType(credential.type().getValue());
         parameters.setResponse(credential.response());
-        parameters.setAllowedOrigins(webauthnConfig.getAllowedOrigins());
-        parameters.setRelyingPartyId(webauthnConfig.getRpId());
+        parameters.setAllowedOrigins(webAuthNConfig.getAllowedOrigins());
+        parameters.setRelyingPartyId(webAuthNConfig.getRpId());
         parameters.setRequiresUserVerification(credential.userVerificationRequired());
         return parameters;
     }

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/SharedService.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/SharedService.java
@@ -1,0 +1,106 @@
+/*
+ * PowerAuth test and related software components
+ * Copyright (C) 2024 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.wultra.security.powerauth.fido2.service;
+
+import com.webauthn4j.data.AuthenticatorTransport;
+import com.webauthn4j.data.PublicKeyCredentialType;
+import com.wultra.security.powerauth.client.PowerAuthClient;
+import com.wultra.security.powerauth.client.PowerAuthFido2Client;
+import com.wultra.security.powerauth.client.model.entity.Application;
+import com.wultra.security.powerauth.client.model.entity.fido2.AuthenticatorDetail;
+import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
+import com.wultra.security.powerauth.client.model.response.OperationTemplateDetailResponse;
+import com.wultra.security.powerauth.fido2.controller.response.CredentialDescriptor;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Service shared for registration and authentication.
+ *
+ * @author Jan Pesek, jan.pesek@wultra.com
+ */
+@Service
+@AllArgsConstructor
+@Slf4j
+public class SharedService {
+
+    private static final String EXTRAS_TRANSPORT_KEY = "transports";
+    private static final PublicKeyCredentialType CREDENTIAL_TYPE = PublicKeyCredentialType.PUBLIC_KEY;
+
+    private final PowerAuthFido2Client fido2Client;
+    private final PowerAuthClient powerAuthClient;
+
+    /**
+     * Fetch all registered credentials.
+     * @param userId User to whom the credentials belong.
+     * @param applicationId Of the used application.
+     * @return List of credentials.
+     * @throws PowerAuthClientException if there is an error in PowerAuth communication.
+     */
+    public List<CredentialDescriptor> fetchExistingCredentials(final String userId, final String applicationId) throws PowerAuthClientException {
+        if (!StringUtils.hasText(userId) || !StringUtils.hasText(applicationId)) {
+            return Collections.emptyList();
+        }
+
+        return listAuthenticators(userId, applicationId).stream()
+                .map(SharedService::toCredentialDescriptor)
+                .toList();
+    }
+
+    /**
+     * Fetch list of all existing applications.
+     * @return List of application ids.
+     * @throws PowerAuthClientException if there is an error in PowerAuth communication.
+     */
+    public List<String> fetchApplicationNameList() throws PowerAuthClientException {
+        return powerAuthClient.getApplicationList().getApplications()
+                .stream()
+                .map(Application::getApplicationId)
+                .sorted().toList();
+    }
+
+    /**
+     * Fetch all existing operation templates.
+     * @return List of operation template names.
+     * @throws PowerAuthClientException if there is an error in PowerAuth communication.
+     */
+    public List<String> fetchTemplateNameList() throws PowerAuthClientException {
+        return powerAuthClient.operationTemplateList()
+                .stream()
+                .map(OperationTemplateDetailResponse::getTemplateName)
+                .sorted().toList();
+    }
+
+    private List<AuthenticatorDetail> listAuthenticators(final String userId, final String applicationId) throws PowerAuthClientException {
+        return fido2Client.getRegisteredAuthenticatorList(userId, applicationId).getAuthenticators();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static CredentialDescriptor toCredentialDescriptor(final AuthenticatorDetail authenticatorDetail) {
+        final String credentialId = authenticatorDetail.getExternalId();
+        final List<AuthenticatorTransport> transports = (List<AuthenticatorTransport>) authenticatorDetail.getExtras().getOrDefault(EXTRAS_TRANSPORT_KEY, Collections.emptyList());
+        return new CredentialDescriptor(CREDENTIAL_TYPE, credentialId, transports);
+    }
+
+}


### PR DESCRIPTION
Backend part of the FIDO test app. The endpoints are called from javascript to build webauthn ceremony options or to make assertion / registration at the server.  
The shared service contains methods to list templates or applications name, which are further used in the UI.

Frontend part will be added in the next issue.