### PR TITLE
Fix #391: FIDO2 Test application: Names refactoring

### DIFF
--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/AssertionService.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/AssertionService.java
@@ -98,7 +98,7 @@ public class AssertionService {
      */
     public AssertionVerificationResponse authenticate(final VerifyAssertionRequest credential) throws PowerAuthClientException {
         final AssertionVerificationRequest request = new AssertionVerificationRequest();
-        request.setCredentialId(credential.id());
+        request.setCredentialId(Base64.getEncoder().encodeToString(credential.id().getBytes()));
         request.setType(credential.type().getValue());
         request.setAuthenticatorAttachment(credential.authenticatorAttachment().getValue());
         request.setResponse(credential.response());

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/AssertionService.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/AssertionService.java
@@ -98,7 +98,7 @@ public class AssertionService {
      */
     public AssertionVerificationResponse authenticate(final VerifyAssertionRequest credential) throws PowerAuthClientException {
         final AssertionVerificationRequest request = new AssertionVerificationRequest();
-        request.setId(credential.id());
+        request.setCredentialId(credential.id());
         request.setType(credential.type().getValue());
         request.setAuthenticatorAttachment(credential.authenticatorAttachment().getValue());
         request.setResponse(credential.response());

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/Fido2SharedService.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/Fido2SharedService.java
@@ -98,7 +98,7 @@ public class Fido2SharedService {
 
     @SuppressWarnings("unchecked")
     private static CredentialDescriptor toCredentialDescriptor(final AuthenticatorDetail authenticatorDetail) {
-        final String credentialId = authenticatorDetail.getExternalId();
+        final String credentialId = authenticatorDetail.getCredentialId();
         final List<AuthenticatorTransport> transports = (List<AuthenticatorTransport>) authenticatorDetail.getExtras().getOrDefault(EXTRAS_TRANSPORT_KEY, Collections.emptyList());
         return new CredentialDescriptor(CREDENTIAL_TYPE, credentialId, transports);
     }

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/RegistrationService.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/RegistrationService.java
@@ -37,6 +37,7 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.Base64;
 import java.util.List;
 
 /**
@@ -107,7 +108,7 @@ public class RegistrationService {
 
     private AuthenticatorParameters buildAuthenticatorParameters(final RegisterCredentialRequest credential) {
         final AuthenticatorParameters parameters = new AuthenticatorParameters();
-        parameters.setCredentialId(credential.id());
+        parameters.setCredentialId(Base64.getEncoder().encodeToString(credential.id().getBytes()));
         parameters.setAuthenticatorAttachment(credential.authenticatorAttachment().getValue());
         parameters.setType(credential.type().getValue());
         parameters.setResponse(credential.response());

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/RegistrationService.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/RegistrationService.java
@@ -107,7 +107,7 @@ public class RegistrationService {
 
     private AuthenticatorParameters buildAuthenticatorParameters(final RegisterCredentialRequest credential) {
         final AuthenticatorParameters parameters = new AuthenticatorParameters();
-        parameters.setId(credential.id());
+        parameters.setCredentialId(credential.id());
         parameters.setAuthenticatorAttachment(credential.authenticatorAttachment().getValue());
         parameters.setType(credential.type().getValue());
         parameters.setResponse(credential.response());


### PR DESCRIPTION
Reflect changes introduced in https://github.com/wultra/powerauth-server/issues/1374 and https://github.com/wultra/powerauth-server/issues/1391

On top of that the credential ID is not transported to the remote server in base64