### PR TITLE
Fix #394: FIDO2 Test Application: Adopt new approach of sharing operation data

### DIFF
--- a/powerauth-fido2-tests/src/main/webapp/resources/js/webauthn.js
+++ b/powerauth-fido2-tests/src/main/webapp/resources/js/webauthn.js
@@ -140,10 +140,6 @@ async function fetchAssertionOptions(username, applicationId, templateName, oper
         }) ),
         extensions: {
             ...options.extensions,
-            hmacGetSecret: {
-                seed1: toBuffer(options.extensions.hmacGetSecret.seed1),
-                seed2: toBuffer(options.extensions.hmacGetSecret.seed2)
-            }
         }
     }
 }


### PR DESCRIPTION
Remove `hmacGetSecret` extension and its relevant code. Keep the `txAuthSimple` for visual inspection of operation data in browser console. Append credential holding operation data if there is usb transport in allow credentials.