### PR TITLE
Fix #401: FIDO2 Test Application: nullable parameters

### DIFF
--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/request/RegisterCredentialRequest.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/request/RegisterCredentialRequest.java
@@ -44,7 +44,6 @@ public record RegisterCredentialRequest (
         @NotNull
         PublicKeyCredentialType type,
 
-        @NotNull
         AuthenticatorAttachment authenticatorAttachment,
 
         @NotNull

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/request/VerifyAssertionRequest.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/request/VerifyAssertionRequest.java
@@ -39,7 +39,6 @@ public record VerifyAssertionRequest(
         @NotNull
         PublicKeyCredentialType type,
 
-        @NotNull
         AuthenticatorAttachment authenticatorAttachment,
 
         @NotNull

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/AssertionService.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/AssertionService.java
@@ -97,7 +97,9 @@ public class AssertionService {
         final AssertionVerificationRequest request = new AssertionVerificationRequest();
         request.setCredentialId(Base64.getEncoder().encodeToString(credentialId));
         request.setType(credential.type().getValue());
-        request.setAuthenticatorAttachment(credential.authenticatorAttachment().getValue());
+        if (credential.authenticatorAttachment() != null) {
+            request.setAuthenticatorAttachment(credential.authenticatorAttachment().getValue());
+        }
         request.setResponse(credential.response());
         request.setApplicationId(credential.applicationId());
         request.setExpectedChallenge(credential.expectedChallenge());

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/RegistrationService.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/RegistrationService.java
@@ -111,7 +111,9 @@ public class RegistrationService {
 
         final AuthenticatorParameters parameters = new AuthenticatorParameters();
         parameters.setCredentialId(Base64.getEncoder().encodeToString(credentialId));
-        parameters.setAuthenticatorAttachment(credential.authenticatorAttachment().getValue());
+        if (credential.authenticatorAttachment() != null) {
+            parameters.setAuthenticatorAttachment(credential.authenticatorAttachment().getValue());
+        }
         parameters.setType(credential.type().getValue());
         parameters.setResponse(credential.response());
         parameters.setAllowedOrigins(webAuthNConfig.getAllowedOrigins());

--- a/powerauth-fido2-tests/src/main/webapp/resources/js/webauthn.js
+++ b/powerauth-fido2-tests/src/main/webapp/resources/js/webauthn.js
@@ -191,7 +191,7 @@ async function verifyAssertion(applicationId, challenge, credential) {
             clientDataJSON: toBase64(credential.response.clientDataJSON),
             authenticatorData: toBase64(credential.response.authenticatorData),
             signature: toBase64(credential.response.signature),
-            userHandle: decoder.decode(credential.response.userHandle)
+            userHandle: credential.response.userHandle == null ? null : decoder.decode(credential.response.userHandle)
         },
         expectedChallenge: decoder.decode(challenge),
         userVerificationRequired: $("#userVerification").val() === "required"


### PR DESCRIPTION
- `userHandle` in attestation [can be null](https://w3c.github.io/webauthn/#iface-authenticatorassertionresponse).
- `authenticatorAttachement` in both ceremonies [can be null](https://w3c.github.io/webauthn/#iface-pkcredential).