### PR TITLE
Fix #418: Refactor BouncyCastle dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,6 @@
         <powerauth-webflow.version>1.8.0-SNAPSHOT</powerauth-webflow.version>
         <wultra-core.version>1.10.0-SNAPSHOT</wultra-core.version>
 
-        <bc.version>1.78</bc.version>
         <springdoc-openapi-starter-webmvc-ui.version>2.5.0</springdoc-openapi-starter-webmvc-ui.version>
         <logstash.version>7.4</logstash.version>
         <webauthn4j.version>0.23.0.RELEASE</webauthn4j.version>
@@ -71,12 +70,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bcprov-jdk18on</artifactId>
-                <version>${bc.version}</version>
-            </dependency>
-
             <!-- PowerAuth Webflow -->
             <dependency>
                 <groupId>io.getlime.security</groupId>

--- a/powerauth-backend-tests/pom.xml
+++ b/powerauth-backend-tests/pom.xml
@@ -92,11 +92,6 @@
             </exclusions>
         </dependency>
 
-        <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk18on</artifactId>
-        </dependency>
-
         <!-- For run at Apple M1 architecture -->
         <dependency>
             <groupId>io.netty</groupId>

--- a/powerauth-load-tests/pom.xml
+++ b/powerauth-load-tests/pom.xml
@@ -51,10 +51,6 @@
             <groupId>io.getlime.security</groupId>
             <artifactId>powerauth-java-cmd-lib</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk18on</artifactId>
-        </dependency>
 
         <!-- Gatling -->
         <dependency>

--- a/powerauth-test-server/pom.xml
+++ b/powerauth-test-server/pom.xml
@@ -127,10 +127,6 @@
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk18on</artifactId>
-        </dependency>
 
         <!-- Logging -->
         <dependency>

--- a/powerauth-webflow-tests/pom.xml
+++ b/powerauth-webflow-tests/pom.xml
@@ -97,11 +97,6 @@
             </exclusions>
         </dependency>
 
-        <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk18on</artifactId>
-        </dependency>
-
     </dependencies>
 
 </project>


### PR DESCRIPTION
Use transient dependency from `powerauth-crypto`.

- [x] Depends on https://github.com/wultra/powerauth-crypto/pull/606