### PR TITLE
Fix #430: FIDO2 Test: User details input options

### DIFF
--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/AssertionController.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/AssertionController.java
@@ -57,7 +57,7 @@ public class AssertionController {
     public AssertionVerificationResponse verify(@Valid @RequestBody final VerifyAssertionRequest request, final HttpSession session) throws PowerAuthFido2Exception {
         final AssertionVerificationResponse response = assertionService.authenticate(request);
         if (response.isAssertionValid()) {
-            session.setAttribute("username", response.getUserId());
+            session.setAttribute("userId", response.getUserId());
             session.setAttribute("applicationId", response.getApplicationId());
         }
         return response;

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/HomeController.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/HomeController.java
@@ -41,7 +41,7 @@ import java.util.Map;
 @Slf4j
 public class HomeController {
 
-    private static final String SESSION_KEY_USERNAME = "username";
+    private static final String SESSION_KEY_USER_ID = "userId";
     private static final String SESSION_KEY_APPLICATION_ID = "applicationId";
     private static final String REDIRECT_LOGIN = "redirect:login";
     private static final String REDIRECT_PAYMENT = "redirect:payment";
@@ -58,7 +58,7 @@ public class HomeController {
 
     @GetMapping("/")
     public String homePage(Map<String, Object> model, HttpSession session) {
-        if (StringUtils.hasText((String) session.getAttribute(SESSION_KEY_USERNAME))) {
+        if (StringUtils.hasText((String) session.getAttribute(SESSION_KEY_USER_ID))) {
             return REDIRECT_PAYMENT;
         }
         return REDIRECT_LOGIN;
@@ -73,13 +73,13 @@ public class HomeController {
 
     @GetMapping("/payment")
     public String profilePage(Map<String, Object> model, HttpSession session) throws PowerAuthClientException {
-        final String username = (String) session.getAttribute(SESSION_KEY_USERNAME);
+        final String userId = (String) session.getAttribute(SESSION_KEY_USER_ID);
         final String applicationId = (String) session.getAttribute(SESSION_KEY_APPLICATION_ID);
-        if (!StringUtils.hasText(username)) {
+        if (!StringUtils.hasText(userId)) {
             return REDIRECT_LOGIN;
         }
 
-        model.put(SESSION_KEY_USERNAME, username);
+        model.put(SESSION_KEY_USER_ID, userId);
         model.put(SESSION_KEY_APPLICATION_ID, applicationId);
         model.put("templates", sharedService.fetchTemplateNameList());
         return PAYMENT_PAGE;
@@ -87,7 +87,7 @@ public class HomeController {
 
     @GetMapping("/logout")
     public String logoutPage(Map<String, Object> model, HttpSession session) {
-        session.removeAttribute(SESSION_KEY_USERNAME);
+        session.removeAttribute(SESSION_KEY_USER_ID);
        return REDIRECT_LOGIN;
     }
 

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/request/AssertionOptionsRequest.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/request/AssertionOptionsRequest.java
@@ -28,7 +28,7 @@ import java.util.Map;
  * @author Jan Pesek, jan.pesek@wultra.com
  */
 public record AssertionOptionsRequest (
-        String username,
+        String userId,
 
         @NotBlank
         String applicationId,

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/request/RegisterCredentialRequest.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/request/RegisterCredentialRequest.java
@@ -34,7 +34,7 @@ public record RegisterCredentialRequest (
         String applicationId,
 
         @NotBlank
-        String username,
+        String userId,
 
         boolean userVerificationRequired,
 

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/request/RegistrationOptionsRequest.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/request/RegistrationOptionsRequest.java
@@ -27,7 +27,7 @@ import jakarta.validation.constraints.NotBlank;
  */
 public record RegistrationOptionsRequest(
     @NotBlank
-    String username,
+    String userId,
 
     @NotBlank
     String applicationId

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/request/RegistrationOptionsRequest.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/request/RegistrationOptionsRequest.java
@@ -30,5 +30,9 @@ public record RegistrationOptionsRequest(
     String userId,
 
     @NotBlank
-    String applicationId
+    String applicationId,
+
+    String username,
+    String userDisplayName
+
 ) {}

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/AssertionService.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/AssertionService.java
@@ -59,7 +59,7 @@ public class AssertionService {
      * @throws PowerAuthFido2Exception in case of PowerAuth server communication error.
      */
     public AssertionOptionsResponse assertionOptions(final AssertionOptionsRequest request) throws PowerAuthFido2Exception {
-        final String userId = request.username();
+        final String userId = request.userId();
         final String applicationId = request.applicationId();
 
         logger.info("Building assertion options for userId={}, applicationId={}", userId, applicationId);
@@ -67,7 +67,7 @@ public class AssertionService {
         final AssertionChallengeResponse challengeResponse = fetchChallenge(userId, applicationId, request.templateName(), request.operationParameters());
         final var credentialList = Optional.ofNullable(challengeResponse.getAllowCredentials());
         if (credentialList.isEmpty() && StringUtils.hasText(userId))  {
-            logger.info("User {} is not yet registered.", userId);
+            logger.info("User ID {} is not yet registered.", userId);
             throw new IllegalStateException("Not registered yet.");
         }
 

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/RegistrationService.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/RegistrationService.java
@@ -36,6 +36,7 @@ import com.wultra.security.powerauth.fido2.model.response.RegistrationResponse;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 import java.util.Base64;
 import java.util.List;
@@ -61,8 +62,8 @@ public class RegistrationService {
      * @throws PowerAuthFido2Exception in case of PowerAuth server communication error.
      */
     public RegistrationOptionsResponse registerOptions(final RegistrationOptionsRequest request) throws PowerAuthFido2Exception {
-        final String userId = request.username();
         final String applicationId = request.applicationId();
+        final String userId = request.userId();
 
         final RegistrationChallengeResponse challengeResponse = fetchChallenge(userId, applicationId);
 
@@ -86,15 +87,17 @@ public class RegistrationService {
      * @throws PowerAuthFido2Exception in case of PowerAuth server communication error.
      */
     public RegistrationResponse register(final RegisterCredentialRequest credential) throws PowerAuthFido2Exception {
-        logger.info("Registering created credential of userId={}, applicationId={}", credential.username(), credential.applicationId());
+        final String applicationId = credential.applicationId();
+        final String userId = credential.userId();
+        logger.info("Registering created credential of userId={}, applicationId={}", userId, applicationId);
 
         final RegistrationRequest request = new RegistrationRequest();
-        request.setActivationName(credential.username());
-        request.setApplicationId(credential.applicationId());
+        request.setActivationName(userId);
+        request.setApplicationId(applicationId);
         request.setAuthenticatorParameters(buildAuthenticatorParameters(credential));
 
         final RegistrationResponse response = fido2Client.register(request);
-        logger.debug("Credential registration response of userId={}: {}", credential.username(), response);
+        logger.debug("Credential registration response of userId={}: {}", userId, response);
         logger.info("Activation ID {} of userId={}: status={}", response.getActivationId(), response.getUserId(), response.getActivationStatus());
         return response;
     }

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/RegistrationService.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/RegistrationService.java
@@ -64,13 +64,15 @@ public class RegistrationService {
     public RegistrationOptionsResponse registerOptions(final RegistrationOptionsRequest request) throws PowerAuthFido2Exception {
         final String applicationId = request.applicationId();
         final String userId = request.userId();
+        final String username = StringUtils.hasText(request.username()) ? request.username() : userId;
+        final String userDisplayName = StringUtils.hasText(request.userDisplayName()) ? request.userDisplayName() : userId;
 
         final RegistrationChallengeResponse challengeResponse = fetchChallenge(userId, applicationId);
 
         logger.info("Building registration options for userId={}, applicationId={}", userId, applicationId);
         return RegistrationOptionsResponse.builder()
                 .rp(new PublicKeyCredentialRpEntity(webAuthNConfig.getRpId(), webAuthNConfig.getRpName()))
-                .user(new PublicKeyCredentialUserEntity(userId.getBytes(), userId, userId))
+                .user(new PublicKeyCredentialUserEntity(userId.getBytes(), username, userDisplayName))
                 .challenge(challengeResponse.getChallenge())
                 .pubKeyCredParams(List.of(
                         new PublicKeyCredentialParameters(PublicKeyCredentialType.PUBLIC_KEY, COSEAlgorithmIdentifier.ES256)

--- a/powerauth-fido2-tests/src/main/resources/templates/login.html
+++ b/powerauth-fido2-tests/src/main/resources/templates/login.html
@@ -59,6 +59,12 @@
                 <!-- Advanced settings -->
                 <button type="button" id="settingsBtn" class="btn btn-primary btn-block btn-xs">Settings</button>
                 <div id="settingsBlock" class="info block" hidden="hidden">
+                    <label for="username" class="label">Username</label>
+                    <input type="text" id="username" name="username" class="form-control" />
+
+                    <label for="userDisplayName" class="label">Display Name</label>
+                    <input type="text" id="userDisplayName" name="displayName" class="form-control" />
+
                     <label for="operationTemplate" class="label">Operation Template</label>
                     <select id="operationTemplate" class="form-control">
                         <option th:each="option : ${templates}" th:value="${option}" th:text="${option}" th:selected="${option} == login ? true : false"></option>

--- a/powerauth-fido2-tests/src/main/resources/templates/login.html
+++ b/powerauth-fido2-tests/src/main/resources/templates/login.html
@@ -37,9 +37,9 @@
                     </select>
                 </div>
 
-                <!-- Username input -->
+                <!-- User ID input -->
                 <div class="form-group">
-                    <input type="text" id="username" name="username" autoComplete="username webauthn" placeholder="Username" class="form-control" />
+                    <input type="text" id="userId" name="userId" autoComplete="username webauthn" placeholder="User ID" class="form-control" />
                 </div>
 
                 <!-- Info and login banners -->

--- a/powerauth-fido2-tests/src/main/resources/templates/payment.html
+++ b/powerauth-fido2-tests/src/main/resources/templates/payment.html
@@ -27,11 +27,11 @@
                 <div class="text-center form-logo-wrapper">
                     <img th:src="@{/resources/images/logo.png}" class="form-logo">
                 </div>
-                <p class="text-center lead small" style="color: white;" th:text="${'Hello ' + username + ', you can now make a payment in the ' + applicationId + '.'}">Hello!</p>
+                <p class="text-center lead small" style="color: white;" th:text="${'Hello ' + userId + ', you can now make a payment in the ' + applicationId + '.'}">Hello!</p>
 
                 <!-- Main form fields -->
                 <div class="form-group" id="divFormFields">
-                    <input type="text" id="username" th:value="${username}" hidden/>
+                    <input type="text" id="userId" th:value="${userId}" hidden/>
                     <input type="text" id="applicationId" th:value="${applicationId}" hidden/>
 
                     <label for="iban" class="label">IBAN</label>

--- a/powerauth-fido2-tests/src/main/webapp/resources/js/login.js
+++ b/powerauth-fido2-tests/src/main/webapp/resources/js/login.js
@@ -15,7 +15,12 @@ async function handleLoginSubmit() {
 
     try {
         if (CEREMONY === REGISTRATION_CEREMONY) {
-            await createCredential(userId, applicationId);
+            const userDetails = {
+                "username": $("#username").val(),
+                "userDisplayName": $("#userDisplayName").val(),
+                "userId": userId
+            };
+            await createCredential(userDetails, applicationId);
         } else if (CEREMONY === AUTHENTICATION_CEREMONY) {
             const templateName = $("#operationTemplate").val();
             await requestCredential(userId, applicationId, templateName, {});
@@ -80,6 +85,13 @@ $(function() {
         } else {
             settingsBlock.show();
         }
+    });
+
+    // Hint the userId == username == displayName if not overwritten
+    const userIdField = $("#userId");
+    userIdField.keyup(function () {
+        $('#username').attr("placeholder", userIdField.val());
+        $('#userDisplayName').attr("placeholder",  userIdField.val());
     });
 
 });

--- a/powerauth-fido2-tests/src/main/webapp/resources/js/login.js
+++ b/powerauth-fido2-tests/src/main/webapp/resources/js/login.js
@@ -10,15 +10,15 @@ async function handleLoginSubmit() {
     errorDiv.hide();
     successDiv.hide();
 
-    const username = $("#username").val();
+    const userId = $("#userId").val();
     const applicationId = $("#applicationId").val();
 
     try {
         if (CEREMONY === REGISTRATION_CEREMONY) {
-            await createCredential(username, applicationId);
+            await createCredential(userId, applicationId);
         } else if (CEREMONY === AUTHENTICATION_CEREMONY) {
             const templateName = $("#operationTemplate").val();
-            await requestCredential(username, applicationId, templateName, {});
+            await requestCredential(userId, applicationId, templateName, {});
             window.location.href = SERVLET_CONTEXT_PATH;
         } else {
             console.error("Unknown ceremony " + CEREMONY);
@@ -62,13 +62,13 @@ $(function() {
 
     // Set action on Register button click
     $('#registerBtn').click(function(){
-        $("#username").prop('required', true);
+        $("#userId").prop('required', true);
         CEREMONY = REGISTRATION_CEREMONY;
     });
 
     // Set action on Login button click
     $('#loginBtn').click(function(){
-        $("#username").prop('required', false);
+        $("#userId").prop('required', false);
         CEREMONY = AUTHENTICATION_CEREMONY;
     });
 

--- a/powerauth-fido2-tests/src/main/webapp/resources/js/payment.js
+++ b/powerauth-fido2-tests/src/main/webapp/resources/js/payment.js
@@ -13,7 +13,7 @@ async function handlePaymentSubmit() {
     errorDiv.hide();
     successDiv.hide();
 
-    const username = $("#username").val();
+    const userId = $("#userId").val();
     const applicationId = $("#applicationId").val();
     const templateName = $("#operationTemplate").val();
     let operationParameters = {
@@ -27,7 +27,7 @@ async function handlePaymentSubmit() {
     }
 
     try {
-        await requestCredential(username, applicationId, templateName, operationParameters);
+        await requestCredential(userId, applicationId, templateName, operationParameters);
         successDiv.show();
 
     } catch (e) {

--- a/powerauth-fido2-tests/src/main/webapp/resources/js/webauthn.js
+++ b/powerauth-fido2-tests/src/main/webapp/resources/js/webauthn.js
@@ -6,15 +6,15 @@ let CEREMONY;
 /**
  * WebAuthn ceremony to create a new credential on register request.
  */
-async function createCredential(username, applicationId) {
-    const options = await fetchRegistrationOptions(username, applicationId);
+async function createCredential(userId, applicationId) {
+    const options = await fetchRegistrationOptions(userId, applicationId);
     const credential = await navigator.credentials.create({
         publicKey: options
     });
     console.log("Public Key Credential")
     console.log(JSON.stringify(credential, null, 2));
 
-    const registerResponse = await registerCredentials(username, applicationId, credential)
+    const registerResponse = await registerCredentials(userId, applicationId, credential)
     console.log("PowerAuth Registration Response")
     console.log(JSON.stringify(registerResponse, null, 2));
     if (registerResponse.activationStatus !== "ACTIVE") {
@@ -25,8 +25,8 @@ async function createCredential(username, applicationId) {
 /**
  * WebAuthn ceremony to request an existing credential on login request.
  */
-async function requestCredential(username, applicationId, templateName, operationParameters) {
-    const options = await fetchAssertionOptions(username, applicationId, templateName, operationParameters);
+async function requestCredential(userId, applicationId, templateName, operationParameters) {
+    const options = await fetchAssertionOptions(userId, applicationId, templateName, operationParameters);
     const credential = await navigator.credentials.get({
         publicKey: options
     });
@@ -44,14 +44,14 @@ async function requestCredential(username, applicationId, templateName, operatio
 
 /**
  * Fetch and return public key credential creation options.
- * @param username Username from user input.
+ * @param userId User ID from user input.
  * @param applicationId Application ID from user input.
  * @returns public key credential creation options
  */
-async function fetchRegistrationOptions(username, applicationId) {
+async function fetchRegistrationOptions(userId, applicationId) {
 
     const fetchOptionsRequest = {
-        "username": username,
+        "userId": userId,
         "applicationId": applicationId
     };
 
@@ -104,16 +104,16 @@ async function fetchRegistrationOptions(username, applicationId) {
 
 /**
  * Fetch and return public key credential request options.
- * @param username Username from user input, may be empty.
+ * @param userId User ID from user input, may be empty.
  * @param applicationId Application ID from user input.
  * @param templateName Template name to use.
  * @param operationParameters Parameters of the operation.
  * @returns public key credential request options
  */
-async function fetchAssertionOptions(username, applicationId, templateName, operationParameters) {
+async function fetchAssertionOptions(userId, applicationId, templateName, operationParameters) {
 
     const fetchOptionsRequest = {
-        "username": username,
+        "userId": userId,
         "applicationId": applicationId,
         "templateName": templateName,
         "operationParameters": operationParameters
@@ -146,12 +146,12 @@ async function fetchAssertionOptions(username, applicationId, templateName, oper
 
 /**
  * Send register credential request to PowerAuth Server
- * @param username Username from user input.
+ * @param userId User ID from user input.
  * @param applicationId Application ID from user input.
  * @param credential Newly created credential.
  * @returns JSON response from PowerAuth Server.
  */
-async function registerCredentials(username, applicationId, credential) {
+async function registerCredentials(userId, applicationId, credential) {
     const userVerification = $("#userVerification").val();
 
     // Although getTransports() is required by WebAuthn specification, some browsers do not support it
@@ -163,7 +163,7 @@ async function registerCredentials(username, applicationId, credential) {
     // RP entity and allowedOrigins are added on backend level
     const requestBody = {
         applicationId: applicationId,
-        username: username,
+        userId: userId,
         userVerificationRequired: userVerification === "required",
         id: credential.id,
         type: credential.type,

--- a/powerauth-fido2-tests/src/main/webapp/resources/js/webauthn.js
+++ b/powerauth-fido2-tests/src/main/webapp/resources/js/webauthn.js
@@ -6,15 +6,15 @@ let CEREMONY;
 /**
  * WebAuthn ceremony to create a new credential on register request.
  */
-async function createCredential(userId, applicationId) {
-    const options = await fetchRegistrationOptions(userId, applicationId);
+async function createCredential(userDetails, applicationId) {
+    const options = await fetchRegistrationOptions(userDetails, applicationId);
     const credential = await navigator.credentials.create({
         publicKey: options
     });
     console.log("Public Key Credential")
     console.log(JSON.stringify(credential, null, 2));
 
-    const registerResponse = await registerCredentials(userId, applicationId, credential)
+    const registerResponse = await registerCredentials(userDetails.userId, applicationId, credential)
     console.log("PowerAuth Registration Response")
     console.log(JSON.stringify(registerResponse, null, 2));
     if (registerResponse.activationStatus !== "ACTIVE") {
@@ -44,14 +44,16 @@ async function requestCredential(userId, applicationId, templateName, operationP
 
 /**
  * Fetch and return public key credential creation options.
- * @param userId User ID from user input.
+ * @param userDetails User ID, Username and User Display Name from user input.
  * @param applicationId Application ID from user input.
  * @returns public key credential creation options
  */
-async function fetchRegistrationOptions(userId, applicationId) {
+async function fetchRegistrationOptions(userDetails, applicationId) {
 
     const fetchOptionsRequest = {
-        "userId": userId,
+        "userId": userDetails.userId,
+        "username": userDetails.username,
+        "userDisplayName": userDetails.userDisplayName,
         "applicationId": applicationId
     };
 


### PR DESCRIPTION
In previous version username was the primary identificator of a user. A user could include username only, which was then in registration process used as user.id, user.name and user.displayName in registration ceremony.    
Now the role of primary identificator is User ID, but user is able to change their username or display name for the registration process.  
If only user ID is set, username and display name is set to user ID.

<img src="https://github.com/wultra/powerauth-tests/assets/66425344/93fbbb51-d93c-4c39-98e5-e87734a6d92c" width="300"  />
