### PR TITLE
Fix #428: FIDO2 Test: Pass excludeCredentials list from challenge response (backport) (#429)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <powerauth-cmd.version>1.7.0</powerauth-cmd.version>
         <powerauth-crypto.version>1.7.0</powerauth-crypto.version>
         <powerauth-restful-integration.version>1.7.0</powerauth-restful-integration.version>
-        <powerauth-server.version>1.7.0</powerauth-server.version>
+        <powerauth-server.version>1.7.1-SNAPSHOT</powerauth-server.version>
         <powerauth-webflow.version>1.7.0</powerauth-webflow.version>
         <wultra-core.version>1.9.0</wultra-core.version>
 

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/AssertionService.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/AssertionService.java
@@ -18,10 +18,7 @@
 
 package com.wultra.security.powerauth.fido2.service;
 
-import com.webauthn4j.data.AuthenticatorTransport;
-import com.webauthn4j.data.PublicKeyCredentialType;
 import com.wultra.security.powerauth.client.PowerAuthFido2Client;
-import com.wultra.security.powerauth.client.model.entity.fido2.AllowCredentials;
 import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
 import com.wultra.security.powerauth.client.model.request.fido2.AssertionChallengeRequest;
 import com.wultra.security.powerauth.client.model.request.fido2.AssertionVerificationRequest;
@@ -71,17 +68,17 @@ public class AssertionService {
             throw new IllegalStateException("Not registered yet.");
         }
 
-        final List<CredentialDescriptor> existingCredentials = credentialList
+        final List<CredentialDescriptor> allowCredentials = credentialList
                 .orElse(Collections.emptyList())
                 .stream()
-                .map(AssertionService::toCredentialDescriptor)
+                .map(Fido2SharedService::toCredentialDescriptor)
                 .toList();
 
         return AssertionOptionsResponse.builder()
                 .challenge(challengeResponse.getChallenge())
                 .rpId(webAuthNConfig.getRpId())
                 .timeout(webAuthNConfig.getTimeout().toMillis())
-                .allowCredentials(existingCredentials)
+                .allowCredentials(allowCredentials)
                 .extensions(Collections.emptyMap()).build();
     }
 
@@ -128,13 +125,6 @@ public class AssertionService {
         final AssertionChallengeResponse response = fido2Client.requestAssertionChallenge(request);
         logger.debug("Assertion challenge response for userId={}: {}", userId, response);
         return response;
-    }
-
-    public static CredentialDescriptor toCredentialDescriptor(final AllowCredentials allowCredentials) {
-        final List<AuthenticatorTransport> transports = allowCredentials.getTransports().stream()
-                .map(AuthenticatorTransport::create)
-                .toList();
-        return new CredentialDescriptor(PublicKeyCredentialType.create(allowCredentials.getType()), allowCredentials.getCredentialId(), transports);
     }
 
 }

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/RegistrationService.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/service/RegistrationService.java
@@ -32,6 +32,7 @@ import com.wultra.security.powerauth.client.model.response.fido2.RegistrationRes
 import com.wultra.security.powerauth.fido2.configuration.WebAuthnConfiguration;
 import com.wultra.security.powerauth.fido2.controller.request.RegisterCredentialRequest;
 import com.wultra.security.powerauth.fido2.controller.request.RegistrationOptionsRequest;
+import com.wultra.security.powerauth.fido2.controller.response.CredentialDescriptor;
 import com.wultra.security.powerauth.fido2.controller.response.RegistrationOptionsResponse;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -51,7 +52,6 @@ import java.util.List;
 public class RegistrationService {
 
     private final PowerAuthFido2Client fido2Client;
-    private final Fido2SharedService fido2SharedService;
     private final WebAuthnConfiguration webAuthNConfig;
 
     /**
@@ -66,6 +66,10 @@ public class RegistrationService {
 
         final RegistrationChallengeResponse challengeResponse = fetchChallenge(userId, applicationId);
 
+        final List<CredentialDescriptor> excludeCredentials = challengeResponse.getExcludeCredentials().stream()
+                .map(Fido2SharedService::toCredentialDescriptor)
+                .toList();
+
         logger.info("Building registration options for userId={}, applicationId={}", userId, applicationId);
         return RegistrationOptionsResponse.builder()
                 .rp(new PublicKeyCredentialRpEntity(webAuthNConfig.getRpId(), webAuthNConfig.getRpName()))
@@ -75,7 +79,7 @@ public class RegistrationService {
                         new PublicKeyCredentialParameters(PublicKeyCredentialType.PUBLIC_KEY, COSEAlgorithmIdentifier.ES256)
                 ))
                 .timeout(webAuthNConfig.getTimeout().toMillis())
-                .excludeCredentials(fido2SharedService.fetchExistingCredentials(userId, applicationId))
+                .excludeCredentials(excludeCredentials)
                 .build();
     }
 


### PR DESCRIPTION
to have working fido testing app on 1.7.x

(cherry picked from commit df8e9384f13539e3e7ba0c34f3525f684e4e0401)