### PR TITLE
Fix #435: FIDO2 Test App: Change default webauthn options

### DIFF
--- a/powerauth-fido2-tests/src/main/resources/templates/login.html
+++ b/powerauth-fido2-tests/src/main/resources/templates/login.html
@@ -73,15 +73,15 @@
                     <label for="authenticatorAttachment" class="label">Authenticator Attachment</label>
                     <select id="authenticatorAttachment" class="form-control">
                         <option>platform</option>
-                        <option selected>all supported</option>
-                        <option>cross-platform</option>
+                        <option>all supported</option>
+                        <option selected>cross-platform</option>
                     </select>
 
                     <label for="residentKey" class="label">Discoverable Credential</label>
                     <select id="residentKey" class="form-control">
                         <option>required</option>
-                        <option selected>preferred</option>
-                        <option>discouraged</option>
+                        <option>preferred</option>
+                        <option selected>discouraged</option>
                     </select>
 
                     <label for="userVerification" class="label">User Verification</label>


### PR DESCRIPTION
Change WebAuthN default options to fit wultra authenticator