### PR TITLE
Fix #508: FIDO2 Test application: Embeddable form

### DIFF
--- a/powerauth-fido2-tests/src/main/resources/application.properties
+++ b/powerauth-fido2-tests/src/main/resources/application.properties
@@ -28,3 +28,7 @@ server.forward-headers-strategy=framework
 
 # To avoid having JSESSIONID in URI
 server.servlet.session.tracking-modes=cookie
+
+# Handle cookies in iFrame
+server.servlet.session.cookie.same-site=none
+server.servlet.session.cookie.secure=true

--- a/powerauth-fido2-tests/src/main/resources/templates/embeddedLogin.html
+++ b/powerauth-fido2-tests/src/main/resources/templates/embeddedLogin.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>PowerAuth & FIDO2 Demo | Wultra</title>
+
+    <link rel="stylesheet" th:href="@{/resources/css/wultra-theme.min.css}">
+    <link rel="stylesheet" th:href="@{/resources/css/wultra-login.css}">
+    <link rel="shortcut icon" type="image/png" th:href="@{/resources/images/favicon.png}"/>
+
+    <!-- API Path Context of the spring controller -->
+    <script>
+        const SERVLET_CONTEXT_PATH = "[[${servletContextPath}]]";
+        const QUERY_PARAMS = "?embedded=true";
+    </script>
+    <script th:src="@{/resources/js/jquery.min.js}"></script>
+    <script th:src="@{/resources/js/webauthn.js}"></script>
+    <script th:src="@{/resources/js/login.js}"></script>
+</head>
+<body style="background: transparent">
+
+<div class="form-wrapper" th:insert="forms/loginForm.html">
+</div>
+
+</body>
+</html>

--- a/powerauth-fido2-tests/src/main/resources/templates/embeddedPayment.html
+++ b/powerauth-fido2-tests/src/main/resources/templates/embeddedPayment.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>PowerAuth & FIDO2 Demo | Wultra</title>
+
+    <link rel="stylesheet" th:href="@{/resources/css/wultra-theme.min.css}">
+    <link rel="stylesheet" th:href="@{/resources/css/wultra-login.css}">
+    <link rel="shortcut icon" type="image/png" th:href="@{/resources/images/favicon.png}"/>
+
+    <!-- API Path Context of the spring controller -->
+    <script>
+        const SERVLET_CONTEXT_PATH = "[[${servletContextPath}]]";
+        const QUERY_PARAMS = "?embedded=true";
+    </script>
+    <script th:src="@{/resources/js/jquery.min.js}"></script>
+    <script th:src="@{/resources/js/webauthn.js}"></script>
+    <script th:src="@{/resources/js/payment.js}"></script>
+</head>
+<body style="background: transparent">
+
+<div class="form-wrapper" th:insert="forms/paymentForm.html">
+</div>
+
+</body>
+</html>

--- a/powerauth-fido2-tests/src/main/resources/templates/forms/loginForm.html
+++ b/powerauth-fido2-tests/src/main/resources/templates/forms/loginForm.html
@@ -1,0 +1,81 @@
+<div class="form-panel">
+    <!-- On submit, handle form in javascript -->
+    <form class="form-signin" onsubmit="handleLoginSubmit(); return false;">
+
+        <p class="body-copy">Sign in with a passkey or register a new account.</p>
+
+        <!-- Application ID selection -->
+        <div class="form-group" th:attr="hidden=${hideDeveloperOption ? 'hidden' : null}">
+            <select name="applicationId" id="applicationId" class="form-control input-text" required>
+                <option value="" disabled selected hidden th:if="${applicationId == null}">Select application</option>
+                <option th:value="${applicationId}" selected th:text="${applicationId}" th:if="${applicationId != null}"></option>
+                <option th:each="option : ${applications}" th:value="${option}" th:text="${option}"></option>
+            </select>
+        </div>
+        <div class="space" th:unless="${hideDeveloperOption}"></div>
+
+        <!-- User ID input -->
+        <div class="form-group">
+            <input type="text" id="userId" name="userId" autoComplete="username webauthn" th:placeholder="${hideDeveloperOption ? 'Username' : 'User ID'}" class="form-control input-text"/>
+        </div>
+
+        <!-- Info and login banners -->
+        <div id="errorDiv" class="alert alert-danger" hidden="hidden">
+            <span id="errorMessage"></span>
+        </div>
+        <div id="successDiv" class="alert alert-success" hidden="hidden">
+            Success!
+        </div>
+
+        <!-- Submit buttons -->
+        <div class="form-group btn-group" style="width: 100%;">
+            <button type="submit" id="loginBtn" class="btn btn-primary " style="width: 50%;">Log in</button>
+            <button type="submit" id="registerBtn" class="btn btn-danger " style="width: 50%;">Register</button>
+        </div>
+
+        <!-- Advanced settings -->
+        <button type="button" id="settingsBtn" class="btn btn-primary btn-block btn-xs" th:unless="${hideDeveloperOption}">Settings
+        </button>
+        <div id="settingsBlock" class="info block" hidden="hidden">
+            <label for="username" class="label">Username</label>
+            <input type="text" id="username" name="username" class="form-control input-text"/>
+
+            <label for="userDisplayName" class="label">Display Name</label>
+            <input type="text" id="userDisplayName" name="displayName" class="form-control input-text"/>
+
+            <label for="operationTemplate" class="label">Operation Template</label>
+            <select id="operationTemplate" class="form-control input-text">
+                <option th:each="option : ${templates}" th:value="${option}" th:text="${option}" th:selected="${option} == login ? true : false"></option>
+            </select>
+
+            <label for="authenticatorAttachment" class="label">Authenticator Attachment</label>
+            <select id="authenticatorAttachment" class="form-control input-text">
+                <option>platform</option>
+                <option>all supported</option>
+                <option selected>cross-platform</option>
+            </select>
+
+            <label for="residentKey" class="label">Discoverable Credential</label>
+            <select id="residentKey" class="form-control input-text">
+                <option>required</option>
+                <option>preferred</option>
+                <option selected>discouraged</option>
+            </select>
+
+            <label for="userVerification" class="label">User Verification</label>
+            <select id="userVerification" class="form-control input-text">
+                <option selected>required</option>
+                <option>preferred</option>
+                <option>discouraged</option>
+            </select>
+
+            <label for="attestation" class="label">Attestation</label>
+            <select id="attestation" class="form-control input-text">
+                <option>enterprise</option>
+                <option>none</option>
+                <option selected>direct</option>
+                <option>indirect</option>
+            </select>
+        </div>
+    </form>
+</div>

--- a/powerauth-fido2-tests/src/main/resources/templates/forms/paymentForm.html
+++ b/powerauth-fido2-tests/src/main/resources/templates/forms/paymentForm.html
@@ -1,0 +1,60 @@
+<div class="form-panel">
+    <!-- On submit, handle form in javascript -->
+    <form class="form-signin" onsubmit="handlePaymentSubmit(); return false;">
+        <p class="body-copy">Try to process a payment now.</p>
+        <p class="body-copy tiny" th:unless="${hideDeveloperOption}">
+            Logged in as <strong th:text="${userId}"></strong>
+            in application <strong th:text="${applicationId}"></strong>.
+        </p>
+
+        <!-- Main form fields -->
+        <div class="form-group" id="divFormFields">
+            <input type="text" id="userId" th:value="${userId}" hidden/>
+
+            <input type="text" id="applicationId" th:value="${applicationId}" hidden/>
+
+            <label for="iban" class="label">IBAN</label>
+            <input type="text" id="iban" value="CZ5508000000001234567899" placeholder="IBAN" class="form-control input-text" required/>
+
+            <label for="amount" class="label">Amount</label>
+            <input type="text" id="amount" value="21" placeholder="Amount" class="form-control input-text" required/>
+
+            <label for="currency" class="label">Currency</label>
+            <input type="text" id="currency" value="CZK" placeholder="Currency" class="form-control input-text" required/>
+
+            <div class="form-group" th:unless="${hideDeveloperOption}">
+                <button type="button" id="addFieldBtn" class="btn btn-primary btn-block btn-xs">Add operation parameter</button>
+            </div>
+        </div>
+
+        <!-- Operation template and user verification selection -->
+        <div class="form-group" th:attr="hidden=${hideDeveloperOption ? 'hidden' : null}">
+            <label for="operationTemplate" class="label">Operation Template</label>
+            <select id="operationTemplate" class="form-control input-text">
+                <option th:each="option : ${templates}" th:value="${option}" th:text="${option}" th:selected="${option} == payment ? true : false"></option>
+            </select>
+
+            <label for="userVerification" class="label">User Verification</label>
+            <select id="userVerification" class="form-control input-text">
+                <option selected>required</option>
+                <option>preferred</option>
+                <option>discouraged</option>
+            </select>
+        </div>
+
+        <!-- Info and error banners -->
+        <div id="errorDiv" class="alert alert-danger" hidden="hidden">
+            <span id="errorMessage"></span>
+        </div>
+        <div id="successDiv" class="alert alert-success" hidden="hidden">
+            Success!
+        </div>
+
+        <!-- Submit or logout button -->
+        <div class="form-group">
+            <button type="submit" id="payBtn" class="btn btn-primary btn-block">Pay</button>
+        </div>
+
+        <button type="button" id="logoutBtn" class="btn btn-danger btn-block btn-xs">Logout</button>
+    </form>
+</div>

--- a/powerauth-fido2-tests/src/main/resources/templates/login.html
+++ b/powerauth-fido2-tests/src/main/resources/templates/login.html
@@ -11,6 +11,7 @@
     <!-- API Path Context of the spring controller -->
     <script>
         const SERVLET_CONTEXT_PATH = "[[${servletContextPath}]]";
+        const QUERY_PARAMS = "";
     </script>
     <script th:src="@{/resources/js/jquery.min.js}"></script>
     <script th:src="@{/resources/js/webauthn.js}"></script>
@@ -45,87 +46,7 @@
         </div>
 
         <div class="col2">
-            <div class="form-wrapper">
-                <div class="form-panel">
-                    <!-- On submit, handle form in javascript -->
-                    <form class="form-signin" onsubmit="handleLoginSubmit(); return false;">
-
-                        <p class="body-copy">Sign in with a passkey or register a new account.</p>
-
-                        <!-- Application ID selection -->
-                        <div class="form-group" th:attr="hidden=${hideDeveloperOption ? 'hidden' : null}">
-                            <select name="applicationId" id="applicationId" class="form-control input-text" required>
-                                <option value="" disabled selected hidden th:if="${applicationId == null}">Select application</option>
-                                <option th:value="${applicationId}" selected th:text="${applicationId}" th:if="${applicationId != null}"></option>
-                                <option th:each="option : ${applications}" th:value="${option}" th:text="${option}"></option>
-                            </select>
-                        </div>
-                        <div class="space" th:unless="${hideDeveloperOption}"></div>
-
-                        <!-- User ID input -->
-                        <div class="form-group">
-                            <input type="text" id="userId" name="userId" autoComplete="username webauthn" th:placeholder="${hideDeveloperOption ? 'Username' : 'User ID'}" class="form-control input-text"/>
-                        </div>
-
-                        <!-- Info and login banners -->
-                        <div id="errorDiv" class="alert alert-danger" hidden="hidden">
-                            <span id="errorMessage"></span>
-                        </div>
-                        <div id="successDiv" class="alert alert-success" hidden="hidden">
-                            Success!
-                        </div>
-
-                        <!-- Submit buttons -->
-                        <div class="form-group btn-group" style="width: 100%;">
-                            <button type="submit" id="loginBtn" class="btn btn-primary " style="width: 50%;">Log in</button>
-                            <button type="submit" id="registerBtn" class="btn btn-danger " style="width: 50%;">Register</button>
-                        </div>
-
-                        <!-- Advanced settings -->
-                        <button type="button" id="settingsBtn" class="btn btn-primary btn-block btn-xs" th:unless="${hideDeveloperOption}">Settings</button>
-                        <div id="settingsBlock" class="info block" hidden="hidden">
-                            <label for="username" class="label">Username</label>
-                            <input type="text" id="username" name="username" class="form-control input-text"/>
-
-                            <label for="userDisplayName" class="label">Display Name</label>
-                            <input type="text" id="userDisplayName" name="displayName" class="form-control input-text"/>
-
-                            <label for="operationTemplate" class="label">Operation Template</label>
-                            <select id="operationTemplate" class="form-control input-text">
-                                <option th:each="option : ${templates}" th:value="${option}" th:text="${option}" th:selected="${option} == login ? true : false"></option>
-                            </select>
-
-                            <label for="authenticatorAttachment" class="label">Authenticator Attachment</label>
-                            <select id="authenticatorAttachment" class="form-control input-text">
-                                <option>platform</option>
-                                <option>all supported</option>
-                                <option selected>cross-platform</option>
-                            </select>
-
-                            <label for="residentKey" class="label">Discoverable Credential</label>
-                            <select id="residentKey" class="form-control input-text">
-                                <option>required</option>
-                                <option>preferred</option>
-                                <option selected>discouraged</option>
-                            </select>
-
-                            <label for="userVerification" class="label">User Verification</label>
-                            <select id="userVerification" class="form-control input-text">
-                                <option selected>required</option>
-                                <option>preferred</option>
-                                <option>discouraged</option>
-                            </select>
-
-                            <label for="attestation" class="label">Attestation</label>
-                            <select id="attestation" class="form-control input-text">
-                                <option>enterprise</option>
-                                <option>none</option>
-                                <option selected>direct</option>
-                                <option>indirect</option>
-                            </select>
-                        </div>
-                    </form>
-                </div>
+            <div class="form-wrapper" th:insert="forms/loginForm.html">
             </div>
         </div>
     </div>

--- a/powerauth-fido2-tests/src/main/resources/templates/payment.html
+++ b/powerauth-fido2-tests/src/main/resources/templates/payment.html
@@ -11,6 +11,7 @@
     <!-- API Path Context of the spring controller -->
     <script>
         const SERVLET_CONTEXT_PATH = "[[${servletContextPath}]]";
+        const QUERY_PARAMS = "";
     </script>
     <script th:src="@{/resources/js/jquery.min.js}"></script>
     <script th:src="@{/resources/js/webauthn.js}"></script>
@@ -45,68 +46,7 @@
         </div>
 
         <div class="col2">
-            <div class="form-wrapper">
-                <div class="form-panel">
-
-                    <!-- On submit, handle form in javascript -->
-                    <form class="form-signin" onsubmit="handlePaymentSubmit(); return false;">
-                        <p class="body-copy">Try to process a payment now.</p>
-                        <p class="body-copy tiny" th:unless="${hideDeveloperOption}">
-                            Logged in as <strong th:text="${userId}"></strong>
-                            in application <strong th:text="${applicationId}"></strong>.
-                        </p>
-
-                        <!-- Main form fields -->
-                        <div class="form-group" id="divFormFields">
-                            <input type="text" id="userId" th:value="${userId}" hidden/>
-
-                            <input type="text" id="applicationId" th:value="${applicationId}" hidden/>
-
-                            <label for="iban" class="label">IBAN</label>
-                            <input type="text" id="iban" value="CZ5508000000001234567899" placeholder="IBAN" class="form-control input-text" required/>
-
-                            <label for="amount" class="label">Amount</label>
-                            <input type="text" id="amount" value="21" placeholder="Amount" class="form-control input-text" required/>
-
-                            <label for="currency" class="label">Currency</label>
-                            <input type="text" id="currency" value="CZK" placeholder="Currency" class="form-control input-text" required/>
-
-                            <div class="form-group" th:unless="${hideDeveloperOption}">
-                                <button type="button" id="addFieldBtn" class="btn btn-primary btn-block btn-xs">Add operation parameter</button>
-                            </div>
-                        </div>
-
-                        <!-- Operation template and user verification selection -->
-                        <div class="form-group" th:attr="hidden=${hideDeveloperOption ? 'hidden' : null}">
-                            <label for="operationTemplate" class="label">Operation Template</label>
-                            <select id="operationTemplate" class="form-control input-text">
-                                <option th:each="option : ${templates}" th:value="${option}" th:text="${option}" th:selected="${option} == payment ? true : false"></option>
-                            </select>
-
-                            <label for="userVerification" class="label">User Verification</label>
-                            <select id="userVerification" class="form-control input-text">
-                                <option selected>required</option>
-                                <option>preferred</option>
-                                <option>discouraged</option>
-                            </select>
-                        </div>
-
-                        <!-- Info and error banners -->
-                        <div id="errorDiv" class="alert alert-danger" hidden="hidden">
-                            <span id="errorMessage"></span>
-                        </div>
-                        <div id="successDiv" class="alert alert-success" hidden="hidden">
-                            Success!
-                        </div>
-
-                        <!-- Submit or logout button -->
-                        <div class="form-group">
-                            <button type="submit" id="payBtn" class="btn btn-primary btn-block">Pay</button>
-                        </div>
-
-                        <button type="button" id="logoutBtn" class="btn btn-danger btn-block btn-xs">Logout</button>
-                    </form>
-                </div>
+            <div class="form-wrapper" th:insert="forms/paymentForm.html">
             </div>
         </div>
     </div>

--- a/powerauth-fido2-tests/src/main/webapp/resources/js/login.js
+++ b/powerauth-fido2-tests/src/main/webapp/resources/js/login.js
@@ -24,7 +24,7 @@ async function handleLoginSubmit() {
         } else if (CEREMONY === AUTHENTICATION_CEREMONY) {
             const templateName = $("#operationTemplate").val();
             await requestCredential(userId, applicationId, templateName, {});
-            window.location.href = SERVLET_CONTEXT_PATH;
+            window.location.href = SERVLET_CONTEXT_PATH + QUERY_PARAMS
         } else {
             console.error("Unknown ceremony " + CEREMONY);
         }

--- a/powerauth-fido2-tests/src/main/webapp/resources/js/payment.js
+++ b/powerauth-fido2-tests/src/main/webapp/resources/js/payment.js
@@ -90,7 +90,7 @@ $(function() {
 
     // Set action on Logout button click
     $('#logoutBtn').click(function(){
-        window.location.href = SERVLET_CONTEXT_PATH + "/logout";
+        window.location.href = SERVLET_CONTEXT_PATH + "/logout" + QUERY_PARAMS;
     });
 
     // Set action on Add operation parameter button click


### PR DESCRIPTION
When a page is loaded with `?embedded=true` query parameter, only the form with transparent background is shown for convenient iframe embedding. 

Added setting `SameSite=None` for cookies, otherwise the interactive login in embedded frame would not work properly because of 3rd party cookie blocking. 