### PR TITLE
Fix #509: FIDO2 Test application: Username validation

### DIFF
--- a/powerauth-fido2-tests/README.md
+++ b/powerauth-fido2-tests/README.md
@@ -16,9 +16,10 @@ the PowerAuth Server on the [Developer Portal](https://developers.wultra.com/com
 
 ### PowerAuth FIDO2 Tests Configuration
 
-| Property                                            | Default | Note                                         |
-|-----------------------------------------------------|---------|----------------------------------------------|
-| `powerauth.fido2.test.service.hideDeveloperOptions` | `false` | Whether to hide advanced settings in the UI. |
+| Property                                            | Default | Note                                                      |
+|-----------------------------------------------------|---------|-----------------------------------------------------------|
+| `powerauth.fido2.test.service.hideDeveloperOptions` | `false` | Whether to hide advanced settings in the UI.              |
+| `powerauth.fido2.test.service.emailAddressRequired` | `false` | Whether to require email address instead of any username. |
 
 ### PowerAuth Service Configuration
 

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/configuration/PowerAuthFido2TestsConfigProperties.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/configuration/PowerAuthFido2TestsConfigProperties.java
@@ -33,6 +33,7 @@ import org.springframework.context.annotation.Configuration;
 public class PowerAuthFido2TestsConfigProperties {
 
     private boolean hideDeveloperOptions = false;
+    private boolean emailAddressRequired = false;
 
     public boolean shouldHideDeveloperOptions() {
         return hideDeveloperOptions;

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/DefaultExceptionHandler.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/DefaultExceptionHandler.java
@@ -21,11 +21,15 @@ package com.wultra.security.powerauth.fido2.controller;
 import com.wultra.security.powerauth.client.model.error.PowerAuthError;
 import io.getlime.core.rest.model.base.response.ObjectResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
+
+import java.util.stream.Collectors;
 
 /**
  * Controller to handle exceptions.
@@ -45,6 +49,19 @@ public class DefaultExceptionHandler {
         error.setCode("ERROR");
         error.setMessage(ex.getMessage());
         error.setLocalizedMessage(ex.getLocalizedMessage());
+        return new ObjectResponse<>("ERROR", error);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public @ResponseBody ObjectResponse<PowerAuthError> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
+        logger.error("Error occurred while processing the request: {}", ex.getMessage());
+        logger.debug("Exception details:", ex);
+        final PowerAuthError error = new PowerAuthError();
+        error.setCode("ERROR");
+        error.setMessage(ex.getBindingResult().getFieldErrors().stream()
+                .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                .collect(Collectors.joining(" ")));
         return new ObjectResponse<>("ERROR", error);
     }
 

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/HomeController.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/HomeController.java
@@ -63,6 +63,7 @@ public class HomeController {
     public void addAttributes(Map<String, Object> model) {
         model.put("servletContextPath", context.getContextPath());
         model.put("hideDeveloperOption", powerAuthFido2TestsConfigProperties.shouldHideDeveloperOptions());
+        model.put("emailRequired", powerAuthFido2TestsConfigProperties.isEmailAddressRequired());
     }
 
     @GetMapping

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/request/RegisterCredentialRequest.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/request/RegisterCredentialRequest.java
@@ -20,6 +20,7 @@ package com.wultra.security.powerauth.fido2.controller.request;
 
 import com.webauthn4j.data.AuthenticatorAttachment;
 import com.webauthn4j.data.PublicKeyCredentialType;
+import com.wultra.security.powerauth.fido2.controller.validation.EmailConditional;
 import com.wultra.security.powerauth.fido2.model.entity.AuthenticatorAttestationResponse;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -33,7 +34,7 @@ public record RegisterCredentialRequest (
         @NotBlank
         String applicationId,
 
-        @NotBlank
+        @NotBlank @EmailConditional
         String userId,
 
         boolean userVerificationRequired,

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/validation/EmailConditional.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/validation/EmailConditional.java
@@ -16,24 +16,28 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.wultra.security.powerauth.fido2.controller.request;
+package com.wultra.security.powerauth.fido2.controller.validation;
 
-import com.wultra.security.powerauth.fido2.controller.validation.EmailConditional;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
- * Request for credential registration options.
+ * Validation annotation to validate email address. Allow null or empty values.
  *
  * @author Jan Pesek, jan.pesek@wultra.com
  */
-public record RegistrationOptionsRequest(
-    @NotBlank @EmailConditional
-    String userId,
+@Constraint(validatedBy = EmailConditionalValidator.class)
+@Target({ ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface EmailConditional {
+    String message() default "Invalid email address.";
 
-    @NotBlank
-    String applicationId,
+    Class<?>[] groups() default {};
 
-    String username,
-    String userDisplayName
-
-) {}
+    Class<? extends Payload>[] payload() default {};
+}

--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/validation/EmailConditionalValidator.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/controller/validation/EmailConditionalValidator.java
@@ -1,0 +1,52 @@
+/*
+ * PowerAuth test and related software components
+ * Copyright (C) 2024 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.wultra.security.powerauth.fido2.controller.validation;
+
+import com.wultra.security.powerauth.fido2.configuration.PowerAuthFido2TestsConfigProperties;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.AllArgsConstructor;
+import org.springframework.util.StringUtils;
+
+import java.util.regex.Pattern;
+
+/**
+ * Validator to validate email address. Allow null or empty values.
+ *
+ * @author Jan Pesek, jan.pesek@wultra.com
+ */
+@AllArgsConstructor
+public class EmailConditionalValidator implements ConstraintValidator<EmailConditional, String> {
+
+    private static final Pattern EMAIL_PATTERN = Pattern.compile(
+            "(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])"
+    );
+
+    private final PowerAuthFido2TestsConfigProperties powerAuthFido2TestsConfigProperties;
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (!StringUtils.hasLength(value) || !powerAuthFido2TestsConfigProperties.isEmailAddressRequired()) {
+            return true;
+        }
+
+        return EMAIL_PATTERN.matcher(value).matches();
+    }
+
+}

--- a/powerauth-fido2-tests/src/main/resources/application.properties
+++ b/powerauth-fido2-tests/src/main/resources/application.properties
@@ -16,6 +16,7 @@ powerauth.fido2.test.service.applicationName=powerauth-fido2-tests
 powerauth.fido2.test.service.applicationDisplayName=PowerAuth FIDO2 Test
 powerauth.fido2.test.service.applicationEnvironment=
 powerauth.fido2.test.service.hideDeveloperOptions=false
+powerauth.fido2.test.service.emailAddressRequired=false
 
 banner.application.name=${powerauth.fido2.test.service.applicationName}
 banner.application.version=@project.version@

--- a/powerauth-fido2-tests/src/main/resources/templates/embeddedLogin.html
+++ b/powerauth-fido2-tests/src/main/resources/templates/embeddedLogin.html
@@ -19,7 +19,7 @@
 </head>
 <body style="background: transparent">
 
-<div class="form-wrapper" th:insert="forms/loginForm.html">
+<div class="form-wrapper" th:insert="~{forms/loginForm.html}">
 </div>
 
 </body>

--- a/powerauth-fido2-tests/src/main/resources/templates/embeddedPayment.html
+++ b/powerauth-fido2-tests/src/main/resources/templates/embeddedPayment.html
@@ -19,7 +19,7 @@
 </head>
 <body style="background: transparent">
 
-<div class="form-wrapper" th:insert="forms/paymentForm.html">
+<div class="form-wrapper" th:insert="~{forms/paymentForm.html}">
 </div>
 
 </body>

--- a/powerauth-fido2-tests/src/main/resources/templates/forms/loginForm.html
+++ b/powerauth-fido2-tests/src/main/resources/templates/forms/loginForm.html
@@ -16,7 +16,8 @@
 
         <!-- User ID input -->
         <div class="form-group">
-            <input type="text" id="userId" name="userId" autoComplete="username webauthn" th:placeholder="${hideDeveloperOption ? 'Username' : 'User ID'}" class="form-control input-text"/>
+            <input type="text" th:unless="${emailRequired}" id="userId" name="userId" autoComplete="username webauthn" th:placeholder="${hideDeveloperOption ? 'Username' : 'User ID'}" class="form-control input-text"/>
+            <input type="email" th:if="${emailRequired}" id="userId" name="userId" autoComplete="username webauthn" placeholder="Email address" class="form-control input-text" pattern="[^@\s]+@[^@\s]+\.[^@\s]+" title="Enter email address."/>
         </div>
 
         <!-- Info and login banners -->

--- a/powerauth-fido2-tests/src/main/resources/templates/login.html
+++ b/powerauth-fido2-tests/src/main/resources/templates/login.html
@@ -46,7 +46,7 @@
         </div>
 
         <div class="col2">
-            <div class="form-wrapper" th:insert="forms/loginForm.html">
+            <div class="form-wrapper" th:insert="~{forms/loginForm.html}">
             </div>
         </div>
     </div>

--- a/powerauth-fido2-tests/src/main/resources/templates/payment.html
+++ b/powerauth-fido2-tests/src/main/resources/templates/payment.html
@@ -46,7 +46,7 @@
         </div>
 
         <div class="col2">
-            <div class="form-wrapper" th:insert="forms/paymentForm.html">
+            <div class="form-wrapper" th:insert="~{forms/paymentForm.html}">
             </div>
         </div>
     </div>


### PR DESCRIPTION
When `emailAddressRequired` application property is set to true, instead of any username, require valid email address string as a user input.