### PR TITLE
Update tests for crypto4

### DIFF
--- a/powerauth-backend-tests/src/main/java/com/wultra/security/powerauth/test/PowerAuthTestSetUp.java
+++ b/powerauth-backend-tests/src/main/java/com/wultra/security/powerauth/test/PowerAuthTestSetUp.java
@@ -190,7 +190,7 @@ public class PowerAuthTestSetUp {
             confirmModel.setUriString(config.getPowerAuthIntegrationUrl());
             ObjectStepLogger stepLoggerConfirm = new ObjectStepLogger(System.out);
             new ConfirmActivationStep().execute(stepLoggerConfirm, confirmModel.toMap());
-            assertTrue(stepLogger.getResult().success());
+            assertTrue(stepLoggerConfirm.getResult().success());
         }
 
         // Commit activation

--- a/powerauth-backend-tests/src/main/java/com/wultra/security/powerauth/test/PowerAuthTestSetUp.java
+++ b/powerauth-backend-tests/src/main/java/com/wultra/security/powerauth/test/PowerAuthTestSetUp.java
@@ -27,6 +27,7 @@ import com.wultra.security.powerauth.client.model.request.InitActivationRequest;
 import com.wultra.security.powerauth.client.model.request.OperationTemplateCreateRequest;
 import com.wultra.security.powerauth.client.model.response.*;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
+import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
 import com.wultra.security.powerauth.lib.cmd.steps.model.PrepareActivationStepModel;
@@ -63,8 +64,7 @@ public class PowerAuthTestSetUp {
 
     public void execute() throws Exception {
         createApplication();
-        // TODO - add v4
-        PowerAuthVersion.VERSION_3.forEach(version -> {
+        PowerAuthVersion.ALL_VERSIONS.forEach(version -> {
             try {
                 createActivation(version);
             } catch (Exception e) {
@@ -158,13 +158,18 @@ public class PowerAuthTestSetUp {
         model.setApplicationKey(config.getApplicationKey());
         model.setApplicationSecret(config.getApplicationSecret());
         model.setMasterPublicKeyP256(config.getMasterPublicKeyP256());
-        model.setMasterPublicKeyP384(config.getMasterPublicKeyP384());
-        model.setMasterPublicKeyMlDsa65(config.getMasterPublicKeyMlDsa65());
+        if (version == PowerAuthVersion.V4_0) {
+            model.setMasterPublicKeyP384(config.getMasterPublicKeyP384());
+            model.setMasterPublicKeyMlDsa65(config.getMasterPublicKeyMlDsa65());
+        }
         model.setHeaders(new HashMap<>());
         model.setPassword(config.getPassword());
         model.setStatusFileName(config.getStatusFile(version).getAbsolutePath());
         model.setResultStatusObject(config.getResultStatusObject(version));
         model.setUriString(config.getPowerAuthIntegrationUrl());
+        if (version == PowerAuthVersion.V4_0) {
+            model.setSharedSecretAlgorithm(SharedSecretAlgorithm.EC_P384_ML_L3);
+        }
         model.setVersion(version);
         model.setDeviceInfo("backend-tests");
 

--- a/powerauth-backend-tests/src/main/java/com/wultra/security/powerauth/test/PowerAuthTestSetUp.java
+++ b/powerauth-backend-tests/src/main/java/com/wultra/security/powerauth/test/PowerAuthTestSetUp.java
@@ -30,6 +30,8 @@ import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
 import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
+import com.wultra.security.powerauth.lib.cmd.steps.ConfirmActivationStep;
+import com.wultra.security.powerauth.lib.cmd.steps.model.ConfirmActivationStepModel;
 import com.wultra.security.powerauth.lib.cmd.steps.model.PrepareActivationStepModel;
 import com.wultra.security.powerauth.lib.cmd.steps.PrepareActivationStep;
 import com.wultra.security.powerauth.lib.cmd.util.config.SdkConfiguration;
@@ -158,24 +160,38 @@ public class PowerAuthTestSetUp {
         model.setApplicationKey(config.getApplicationKey());
         model.setApplicationSecret(config.getApplicationSecret());
         model.setMasterPublicKeyP256(config.getMasterPublicKeyP256());
-        if (version == PowerAuthVersion.V4_0) {
+        if (version.getMajorVersion() > 3) {
             model.setMasterPublicKeyP384(config.getMasterPublicKeyP384());
             model.setMasterPublicKeyMlDsa65(config.getMasterPublicKeyMlDsa65());
+            model.setSharedSecretAlgorithm(SharedSecretAlgorithm.EC_P384_ML_L3);
         }
         model.setHeaders(new HashMap<>());
         model.setPassword(config.getPassword());
         model.setStatusFileName(config.getStatusFile(version).getAbsolutePath());
         model.setResultStatusObject(config.getResultStatusObject(version));
         model.setUriString(config.getPowerAuthIntegrationUrl());
-        if (version == PowerAuthVersion.V4_0) {
-            model.setSharedSecretAlgorithm(SharedSecretAlgorithm.EC_P384_ML_L3);
-        }
         model.setVersion(version);
         model.setDeviceInfo("backend-tests");
 
         ObjectStepLogger stepLogger = new ObjectStepLogger(System.out);
         new PrepareActivationStep().execute(stepLogger, model.toMap());
         assertTrue(stepLogger.getResult().success());
+
+        // Confirm v4 activations to enable biometry
+        if (version.getMajorVersion() > 3) {
+            ConfirmActivationStepModel confirmModel = new ConfirmActivationStepModel();
+            confirmModel.setApplicationKey(config.getApplicationKey());
+            confirmModel.setApplicationSecret(config.getApplicationSecret());
+            confirmModel.setEnableBiometry(true);
+            confirmModel.setPassword(config.getPassword());
+            confirmModel.setVersion(version);
+            confirmModel.setStatusFileName(config.getStatusFile(version).getAbsolutePath());
+            confirmModel.setResultStatusObject(config.getResultStatusObject(version));
+            confirmModel.setUriString(config.getPowerAuthIntegrationUrl());
+            ObjectStepLogger stepLoggerConfirm = new ObjectStepLogger(System.out);
+            new ConfirmActivationStep().execute(stepLoggerConfirm, confirmModel.toMap());
+            assertTrue(stepLogger.getResult().success());
+        }
 
         // Commit activation
         CommitActivationResponse commitResponse = powerAuthClient.commitActivation(initResponse.getActivationId(), "test");

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/PowerAuthConfigurationTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/PowerAuthConfigurationTest.java
@@ -46,6 +46,8 @@ public class PowerAuthConfigurationTest {
         assertNotNull(config.getApplicationId());
         assertNotNull(config.getApplicationVersionId());
         assertNotNull(config.getMasterPublicKeyP256());
+        assertNotNull(config.getMasterPublicKeyP384());
+        assertNotNull(config.getMasterPublicKeyMlDsa65());
         assertNotNull(config.getApplicationKey());
         assertNotEquals("", config.getApplicationKey());
         assertNotNull(config.getApplicationSecret());

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/PowerAuthConfigurationTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/PowerAuthConfigurationTest.java
@@ -50,8 +50,7 @@ public class PowerAuthConfigurationTest {
         assertNotEquals("", config.getApplicationKey());
         assertNotNull(config.getApplicationSecret());
         assertNotEquals("", config.getApplicationSecret());
-        // TODO - add v4
-        for (PowerAuthVersion version: PowerAuthVersion.VERSION_3) {
+        for (PowerAuthVersion version: PowerAuthVersion.ALL_VERSIONS) {
             assertNotNull(config.getActivationId(version));
         }
     }

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/PowerAuthActivationCommitPhaseShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/PowerAuthActivationCommitPhaseShared.java
@@ -17,7 +17,7 @@
  */
 package com.wultra.security.powerauth.test.shared;
 
-import com.wultra.security.powerauth.client.v3.PowerAuthClient;
+import com.wultra.security.powerauth.client.v4.PowerAuthClient;
 import com.wultra.security.powerauth.client.model.enumeration.ActivationOtpValidation;
 import com.wultra.security.powerauth.client.model.enumeration.ActivationStatus;
 import com.wultra.security.powerauth.client.model.enumeration.CommitPhase;
@@ -25,7 +25,7 @@ import com.wultra.security.powerauth.client.model.error.PowerAuthClientException
 import com.wultra.security.powerauth.client.model.request.CommitActivationRequest;
 import com.wultra.security.powerauth.client.model.request.InitActivationRequest;
 import com.wultra.security.powerauth.client.model.response.CommitActivationResponse;
-import com.wultra.security.powerauth.client.model.response.v3.GetActivationStatusResponse;
+import com.wultra.security.powerauth.client.model.response.v4.GetActivationStatusResponse;
 import com.wultra.security.powerauth.client.model.response.InitActivationResponse;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
 import com.wultra.security.powerauth.crypto.lib.model.ActivationStatusBlobInfo;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/PowerAuthActivationOtpShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/PowerAuthActivationOtpShared.java
@@ -17,14 +17,14 @@
  */
 package com.wultra.security.powerauth.test.shared;
 
-import com.wultra.security.powerauth.client.v3.PowerAuthClient;
+import com.wultra.security.powerauth.client.v4.PowerAuthClient;
 import com.wultra.security.powerauth.client.model.enumeration.ActivationOtpValidation;
 import com.wultra.security.powerauth.client.model.enumeration.ActivationStatus;
 import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
 import com.wultra.security.powerauth.client.model.request.CommitActivationRequest;
 import com.wultra.security.powerauth.client.model.request.InitActivationRequest;
 import com.wultra.security.powerauth.client.model.response.CommitActivationResponse;
-import com.wultra.security.powerauth.client.model.response.v3.GetActivationStatusResponse;
+import com.wultra.security.powerauth.client.model.response.v4.GetActivationStatusResponse;
 import com.wultra.security.powerauth.client.model.response.InitActivationResponse;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
 import com.wultra.security.powerauth.crypto.lib.model.ActivationStatusBlobInfo;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/PowerAuthActivationShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/PowerAuthActivationShared.java
@@ -32,6 +32,7 @@ import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedResponse;
 import com.wultra.security.powerauth.crypto.lib.enums.EcCurve;
 import com.wultra.security.powerauth.crypto.lib.enums.ProtocolVersion;
+import com.wultra.security.powerauth.crypto.lib.v4.encryptor.model.response.AeadEncryptedResponse;
 import com.wultra.security.powerauth.test.shared.util.ResponseVerificationUtil;
 import com.wultra.core.rest.model.base.response.ErrorResponse;
 import com.wultra.core.rest.model.base.response.ObjectResponse;
@@ -49,6 +50,7 @@ import com.wultra.security.powerauth.lib.cmd.util.CounterUtil;
 import com.wultra.security.powerauth.rest.api.model.request.v3.ActivationStatusRequest;
 import com.wultra.security.powerauth.rest.api.model.response.v3.ActivationStatusResponse;
 import org.json.simple.JSONObject;
+import org.junit.jupiter.api.AssertionFailureBuilder;
 
 import javax.crypto.SecretKey;
 import java.security.KeyPair;
@@ -87,9 +89,7 @@ public class PowerAuthActivationShared {
         assertTrue(stepLoggerPrepare.getResult().success());
         assertEquals(200, stepLoggerPrepare.getResponse().statusCode());
 
-        final EciesEncryptedResponse eciesResponse = (EciesEncryptedResponse) stepLoggerPrepare.getResponse().responseObject();
-        assertNotNull(eciesResponse.getEncryptedData());
-        assertNotNull(eciesResponse.getMac());
+        checkEncryptedResponse(version, stepLoggerPrepare.getResponse().responseObject());
 
         // Verify decrypted activationId
         String activationIdPrepareResponse = null;
@@ -277,130 +277,192 @@ public class PowerAuthActivationShared {
         assertTrue(stepLoggerPrepare.getResult().success());
         assertEquals(200, stepLoggerPrepare.getResponse().statusCode());
 
-        final EciesEncryptedResponse eciesResponse = (EciesEncryptedResponse) stepLoggerPrepare.getResponse().responseObject();
-        assertNotNull(eciesResponse.getEncryptedData());
-        assertNotNull(eciesResponse.getMac());
+        checkEncryptedResponse(version, stepLoggerPrepare.getResponse().responseObject());
 
         // Verify activation status
         GetStatusStepModel statusModel = new GetStatusStepModel();
         statusModel.setResultStatusObject(resultStatusObject);
         statusModel.setHeaders(new HashMap<>());
         statusModel.setUriString(config.getPowerAuthIntegrationUrl());
+        statusModel.setApplicationKey(config.getApplicationKey());
+        statusModel.setApplicationSecret(config.getApplicationSecret());
         statusModel.setVersion(version);
 
         ObjectStepLogger stepLoggerStatus = new ObjectStepLogger(System.out);
         new GetStatusStep().execute(stepLoggerStatus, statusModel.toMap());
         assertTrue(stepLoggerStatus.getResult().success());
         assertEquals(200, stepLoggerStatus.getResponse().statusCode());
-        ActivationStatusRequest request = (ActivationStatusRequest) stepLoggerStatus.getRequest().requestObject();
-        if (version != PowerAuthVersion.V3_0) {
-            assertNotNull(request.getChallenge());
-        }
-        ObjectResponse<ActivationStatusResponse> responseObject = (ObjectResponse<ActivationStatusResponse>) stepLoggerStatus.getResponse().responseObject();
-        ActivationStatusResponse response = responseObject.getResponseObject();
-        assertEquals(initResponse.getActivationId(), response.getActivationId());
-        if (version != PowerAuthVersion.V3_0) {
-            assertNotNull(response.getNonce());
-        }
 
-        // Get transport key
-        String transportMasterKeyBase64 = (String) model.getResultStatusObject().get("transportMasterKey");
-        SecretKey transportMasterKey = config.getKeyConvertor().convertBytesToSharedSecretKey(Base64.getDecoder().decode(transportMasterKeyBase64));
-        byte[] cStatusBlob = Base64.getDecoder().decode(response.getEncryptedStatusBlob());
+        if (version.getMajorVersion() == 3) {
+            ActivationStatusBlobInfo statusBlob;
+            ActivationStatusRequest request = (ActivationStatusRequest) stepLoggerStatus.getRequest().requestObject();
+            if (version != PowerAuthVersion.V3_0) {
+                assertNotNull(request.getChallenge());
+            }
+            ObjectResponse<ActivationStatusResponse> responseObject = (ObjectResponse<ActivationStatusResponse>) stepLoggerStatus.getResponse().responseObject();
+            ActivationStatusResponse response = responseObject.getResponseObject();
+            assertEquals(initResponse.getActivationId(), response.getActivationId());
+            if (version != PowerAuthVersion.V3_0) {
+                assertNotNull(response.getNonce());
+            }
 
-        // Verify activation status blob
-        ActivationStatusBlobInfo statusBlob;
-        byte[] challengeData = null;
-        byte[] nonceData = null;
-        if (version == PowerAuthVersion.V3_0) {
-            statusBlob = CLIENT_ACTIVATION.getStatusFromEncryptedBlob(cStatusBlob, null, null, transportMasterKey);
-        } else {
-            challengeData = Base64.getDecoder().decode(request.getChallenge());
-            nonceData = Base64.getDecoder().decode(response.getNonce());
+            // Get transport key
+            String transportMasterKeyBase64 = (String) model.getResultStatusObject().get("transportMasterKey");
+            SecretKey transportMasterKey = config.getKeyConvertor().convertBytesToSharedSecretKey(Base64.getDecoder().decode(transportMasterKeyBase64));
+            byte[] cStatusBlob = Base64.getDecoder().decode(response.getEncryptedStatusBlob());
+
+            // Verify activation status blob
+            byte[] challengeData = null;
+            byte[] nonceData = null;
+            if (version == PowerAuthVersion.V3_0) {
+                statusBlob = CLIENT_ACTIVATION.getStatusFromEncryptedBlob(cStatusBlob, null, null, transportMasterKey);
+            } else {
+                challengeData = Base64.getDecoder().decode(request.getChallenge());
+                nonceData = Base64.getDecoder().decode(response.getNonce());
+                statusBlob = CLIENT_ACTIVATION.getStatusFromEncryptedBlob(cStatusBlob, challengeData, nonceData, transportMasterKey);
+                // Added in V3.1
+                assertEquals(20, statusBlob.getCtrLookAhead());
+                assertTrue(CLIENT_ACTIVATION.verifyHashForHashBasedCounter(statusBlob.getCtrDataHash(), CounterUtil.getCtrData(model, stepLoggerStatus), transportMasterKey, ProtocolVersion.fromValue(version.value())));
+            }
+            assertTrue(statusBlob.isValid());
+            assertEquals(0x2, statusBlob.getActivationStatus());
+            assertEquals(10, statusBlob.getMaxFailedAttempts());
+            assertEquals(0, statusBlob.getFailedAttempts());
+            assertEquals(3, statusBlob.getCurrentVersion());
+            assertEquals(3, statusBlob.getUpgradeVersion());
+
+            // Commit activation
+            CommitActivationResponse commitResponse = powerAuthClient.commitActivation(initResponse.getActivationId(), "test");
+            assertEquals(initResponse.getActivationId(), commitResponse.getActivationId());
+
+            // Get status
+            stepLoggerStatus = new ObjectStepLogger(System.out);
+            new GetStatusStep().execute(stepLoggerStatus, statusModel.toMap());
+            assertTrue(stepLoggerStatus.getResult().success());
+            assertEquals(200, stepLoggerStatus.getResponse().statusCode());
+            request = (ActivationStatusRequest) stepLoggerStatus.getRequest().requestObject();
+            responseObject = (ObjectResponse<ActivationStatusResponse>) stepLoggerStatus.getResponse().responseObject();
+            response = responseObject.getResponseObject();
+            assertEquals(initResponse.getActivationId(), response.getActivationId());
+
+            // Verify activation status blob
+            if (version != PowerAuthVersion.V3_0) {
+                challengeData = Base64.getDecoder().decode(request.getChallenge());
+                nonceData = Base64.getDecoder().decode(response.getNonce());
+            }
+            cStatusBlob = Base64.getDecoder().decode(response.getEncryptedStatusBlob());
             statusBlob = CLIENT_ACTIVATION.getStatusFromEncryptedBlob(cStatusBlob, challengeData, nonceData, transportMasterKey);
-            // Added in V3.1
-            assertEquals(20, statusBlob.getCtrLookAhead());
-            assertTrue(CLIENT_ACTIVATION.verifyHashForHashBasedCounter(statusBlob.getCtrDataHash(), CounterUtil.getCtrData(model, stepLoggerStatus), transportMasterKey, ProtocolVersion.fromValue(version.value())));
+            assertTrue(statusBlob.isValid());
+            assertEquals(0x3, statusBlob.getActivationStatus());
+
+            // Block activation
+            BlockActivationResponse blockResponse = powerAuthClient.blockActivation(initResponse.getActivationId(), "test", "test");
+            assertEquals(initResponse.getActivationId(), blockResponse.getActivationId());
+            assertEquals("test", blockResponse.getBlockedReason());
+
+            // Get status
+            stepLoggerStatus = new ObjectStepLogger(System.out);
+            new GetStatusStep().execute(stepLoggerStatus, statusModel.toMap());
+            assertTrue(stepLoggerStatus.getResult().success());
+            assertEquals(200, stepLoggerStatus.getResponse().statusCode());
+            request = (ActivationStatusRequest) stepLoggerStatus.getRequest().requestObject();
+            responseObject = (ObjectResponse<ActivationStatusResponse>) stepLoggerStatus.getResponse().responseObject();
+            response = responseObject.getResponseObject();
+            assertEquals(initResponse.getActivationId(), response.getActivationId());
+
+            // Verify activation status blob
+            if (version != PowerAuthVersion.V3_0) {
+                challengeData = Base64.getDecoder().decode(request.getChallenge());
+                nonceData = Base64.getDecoder().decode(response.getNonce());
+            }
+            cStatusBlob = Base64.getDecoder().decode(response.getEncryptedStatusBlob());
+            statusBlob = CLIENT_ACTIVATION.getStatusFromEncryptedBlob(cStatusBlob, challengeData, nonceData, transportMasterKey);
+            assertTrue(statusBlob.isValid());
+            assertEquals(0x4, statusBlob.getActivationStatus());
+
+            // Remove activation
+            powerAuthClient.removeActivation(initResponse.getActivationId(), "test");
+
+            // Get status
+            stepLoggerStatus = new ObjectStepLogger(System.out);
+            new GetStatusStep().execute(stepLoggerStatus, statusModel.toMap());
+            assertTrue(stepLoggerStatus.getResult().success());
+            assertEquals(200, stepLoggerStatus.getResponse().statusCode());
+            request = (ActivationStatusRequest) stepLoggerStatus.getRequest().requestObject();
+            responseObject = (ObjectResponse<ActivationStatusResponse>) stepLoggerStatus.getResponse().responseObject();
+            response = responseObject.getResponseObject();
+            assertEquals(initResponse.getActivationId(), response.getActivationId());
+
+            // Verify activation status blob
+            if (version != PowerAuthVersion.V3_0) {
+                challengeData = Base64.getDecoder().decode(request.getChallenge());
+                nonceData = Base64.getDecoder().decode(response.getNonce());
+            }
+            cStatusBlob = Base64.getDecoder().decode(response.getEncryptedStatusBlob());
+            statusBlob = CLIENT_ACTIVATION.getStatusFromEncryptedBlob(cStatusBlob, challengeData, nonceData, transportMasterKey);
+            assertTrue(statusBlob.isValid());
+            assertEquals(0x5, statusBlob.getActivationStatus());
+        } else {
+            ActivationStatusBlobInfo statusBlob = extractStatusBlob(stepLoggerStatus);
+            assertTrue(statusBlob.isValid());
+            assertEquals(0x2, statusBlob.getActivationStatus());
+            assertEquals(10, statusBlob.getMaxFailedAttempts());
+            assertEquals(0, statusBlob.getFailedAttempts());
+            assertEquals(4, statusBlob.getCurrentVersion());
+            assertEquals(4, statusBlob.getUpgradeVersion());
+
+            // Commit activation
+            CommitActivationResponse commitResponse = powerAuthClient.commitActivation(initResponse.getActivationId(), "test");
+            assertEquals(initResponse.getActivationId(), commitResponse.getActivationId());
+
+            // Check status
+            stepLoggerStatus = new ObjectStepLogger(System.out);
+            new GetStatusStep().execute(stepLoggerStatus, statusModel.toMap());
+            assertTrue(stepLoggerStatus.getResult().success());
+            assertEquals(200, stepLoggerStatus.getResponse().statusCode());
+            statusBlob = extractStatusBlob(stepLoggerStatus);
+            assertTrue(statusBlob.isValid());
+            assertEquals(0x3, statusBlob.getActivationStatus());
+
+            // Block activation
+            BlockActivationResponse blockResponse = powerAuthClient.blockActivation(initResponse.getActivationId(), "test", "test");
+            assertEquals(initResponse.getActivationId(), blockResponse.getActivationId());
+            assertEquals("test", blockResponse.getBlockedReason());
+
+            // Check status
+            stepLoggerStatus = new ObjectStepLogger(System.out);
+            new GetStatusStep().execute(stepLoggerStatus, statusModel.toMap());
+            assertTrue(stepLoggerStatus.getResult().success());
+            assertEquals(200, stepLoggerStatus.getResponse().statusCode());
+            statusBlob = extractStatusBlob(stepLoggerStatus);
+            assertTrue(statusBlob.isValid());
+            assertEquals(0x4, statusBlob.getActivationStatus());
+
+            // Remove activation
+            powerAuthClient.removeActivation(initResponse.getActivationId(), "test");
+
+            // Check status
+            stepLoggerStatus = new ObjectStepLogger(System.out);
+            new GetStatusStep().execute(stepLoggerStatus, statusModel.toMap());
+            assertTrue(stepLoggerStatus.getResult().success());
+            assertEquals(200, stepLoggerStatus.getResponse().statusCode());
+            statusBlob = extractStatusBlob(stepLoggerStatus);
+            assertTrue(statusBlob.isValid());
+            assertEquals(0x5, statusBlob.getActivationStatus());
         }
 
-        assertTrue(statusBlob.isValid());
-        assertEquals(0x2, statusBlob.getActivationStatus());
-        assertEquals(10, statusBlob.getMaxFailedAttempts());
-        assertEquals(0, statusBlob.getFailedAttempts());
-        assertEquals(3, statusBlob.getCurrentVersion());
-        assertEquals(3, statusBlob.getUpgradeVersion());
+    }
 
-        // Commit activation
-        CommitActivationResponse commitResponse = powerAuthClient.commitActivation(initResponse.getActivationId(), "test");
-        assertEquals(initResponse.getActivationId(), commitResponse.getActivationId());
+    private static ActivationStatusBlobInfo extractStatusBlob(ObjectStepLogger stepLogger) {
+        Object responseObject = stepLogger.getItems().stream()
+                .filter(item -> "Activation Status".equals(item.name()))
+                .map(StepItem::object)
+                .findAny()
+                .orElseThrow(() -> AssertionFailureBuilder.assertionFailure().message("Activation Status response is invalid").build());
 
-        // Get status
-        stepLoggerStatus = new ObjectStepLogger(System.out);
-        new GetStatusStep().execute(stepLoggerStatus, statusModel.toMap());
-        assertTrue(stepLoggerStatus.getResult().success());
-        assertEquals(200, stepLoggerStatus.getResponse().statusCode());
-        request = (ActivationStatusRequest) stepLoggerStatus.getRequest().requestObject();
-        responseObject = (ObjectResponse<ActivationStatusResponse>) stepLoggerStatus.getResponse().responseObject();
-        response = responseObject.getResponseObject();
-        assertEquals(initResponse.getActivationId(), response.getActivationId());
-
-        // Verify activation status blob
-        if (version != PowerAuthVersion.V3_0) {
-            challengeData = Base64.getDecoder().decode(request.getChallenge());
-            nonceData = Base64.getDecoder().decode(response.getNonce());
-        }
-        cStatusBlob = Base64.getDecoder().decode(response.getEncryptedStatusBlob());
-        statusBlob = CLIENT_ACTIVATION.getStatusFromEncryptedBlob(cStatusBlob, challengeData, nonceData, transportMasterKey);
-        assertTrue(statusBlob.isValid());
-        assertEquals(0x3, statusBlob.getActivationStatus());
-
-        // Block activation
-        BlockActivationResponse blockResponse = powerAuthClient.blockActivation(initResponse.getActivationId(), "test", "test");
-        assertEquals(initResponse.getActivationId(), blockResponse.getActivationId());
-        assertEquals("test", blockResponse.getBlockedReason());
-
-        // Get status
-        stepLoggerStatus = new ObjectStepLogger(System.out);
-        new GetStatusStep().execute(stepLoggerStatus, statusModel.toMap());
-        assertTrue(stepLoggerStatus.getResult().success());
-        assertEquals(200, stepLoggerStatus.getResponse().statusCode());
-        request = (ActivationStatusRequest) stepLoggerStatus.getRequest().requestObject();
-        responseObject = (ObjectResponse<ActivationStatusResponse>) stepLoggerStatus.getResponse().responseObject();
-        response = responseObject.getResponseObject();
-        assertEquals(initResponse.getActivationId(), response.getActivationId());
-
-        // Verify activation status blob
-        if (version != PowerAuthVersion.V3_0) {
-            challengeData = Base64.getDecoder().decode(request.getChallenge());
-            nonceData = Base64.getDecoder().decode(response.getNonce());
-        }
-        cStatusBlob = Base64.getDecoder().decode(response.getEncryptedStatusBlob());
-        statusBlob = CLIENT_ACTIVATION.getStatusFromEncryptedBlob(cStatusBlob, challengeData, nonceData, transportMasterKey);
-        assertTrue(statusBlob.isValid());
-        assertEquals(0x4, statusBlob.getActivationStatus());
-
-        // Remove activation
-        powerAuthClient.removeActivation(initResponse.getActivationId(), "test");
-
-        // Get status
-        stepLoggerStatus = new ObjectStepLogger(System.out);
-        new GetStatusStep().execute(stepLoggerStatus, statusModel.toMap());
-        assertTrue(stepLoggerStatus.getResult().success());
-        assertEquals(200, stepLoggerStatus.getResponse().statusCode());
-        request = (ActivationStatusRequest) stepLoggerStatus.getRequest().requestObject();
-        responseObject = (ObjectResponse<ActivationStatusResponse>) stepLoggerStatus.getResponse().responseObject();
-        response = responseObject.getResponseObject();
-        assertEquals(initResponse.getActivationId(), response.getActivationId());
-
-        // Verify activation status blob
-        if (version != PowerAuthVersion.V3_0) {
-            challengeData = Base64.getDecoder().decode(request.getChallenge());
-            nonceData = Base64.getDecoder().decode(response.getNonce());
-        }
-        cStatusBlob = Base64.getDecoder().decode(response.getEncryptedStatusBlob());
-        statusBlob = CLIENT_ACTIVATION.getStatusFromEncryptedBlob(cStatusBlob, challengeData, nonceData, transportMasterKey);
-        assertTrue(statusBlob.isValid());
-        assertEquals(0x5, statusBlob.getActivationStatus());
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> responseObjectMap = (Map<String, Object>) responseObject;
+        return (ActivationStatusBlobInfo) responseObjectMap.get("statusBlob");
     }
 
     public static void activationInvalidApplicationKeyTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
@@ -553,54 +615,60 @@ public class PowerAuthActivationShared {
         assertTrue(stepLoggerPrepare.getResult().success());
         assertEquals(200, stepLoggerPrepare.getResponse().statusCode());
 
-        final EciesEncryptedResponse eciesResponse = (EciesEncryptedResponse) stepLoggerPrepare.getResponse().responseObject();
-        assertNotNull(eciesResponse.getEncryptedData());
-        assertNotNull(eciesResponse.getMac());
+        checkEncryptedResponse(version, stepLoggerPrepare.getResponse().responseObject());
 
         // Verify activation status
         GetStatusStepModel statusModel = new GetStatusStepModel();
         statusModel.setResultStatusObject(resultStatusObject);
         statusModel.setHeaders(new HashMap<>());
         statusModel.setUriString(config.getPowerAuthIntegrationUrl());
+        statusModel.setApplicationKey(config.getApplicationKey());
+        statusModel.setApplicationSecret(config.getApplicationSecret());
         statusModel.setVersion(version);
-
         ObjectStepLogger stepLoggerStatus = new ObjectStepLogger(System.out);
         new GetStatusStep().execute(stepLoggerStatus, statusModel.toMap());
         assertTrue(stepLoggerStatus.getResult().success());
         assertEquals(200, stepLoggerStatus.getResponse().statusCode());
-        final ActivationStatusRequest request = (ActivationStatusRequest) stepLoggerStatus.getRequest().requestObject();
-        if (version != PowerAuthVersion.V3_0) {
-            assertNotNull(request.getChallenge());
-        }
-        final ObjectResponse<ActivationStatusResponse> responseObject = (ObjectResponse<ActivationStatusResponse>) stepLoggerStatus.getResponse().responseObject();
-        ActivationStatusResponse response = responseObject.getResponseObject();
-        assertEquals(initResponse.getActivationId(), response.getActivationId());
-        if (version != PowerAuthVersion.V3_0) {
-            assertNotNull(response.getNonce());
-        }
 
-        // Get transport key
-        String transportMasterKeyBase64 = (String) model.getResultStatusObject().get("transportMasterKey");
-        SecretKey transportMasterKey = config.getKeyConvertor().convertBytesToSharedSecretKey(Base64.getDecoder().decode(transportMasterKeyBase64));
+        if (version.getMajorVersion() == 3) {
+            final ActivationStatusRequest request = (ActivationStatusRequest) stepLoggerStatus.getRequest().requestObject();
+            if (version != PowerAuthVersion.V3_0) {
+                assertNotNull(request.getChallenge());
+            }
+            final ObjectResponse<ActivationStatusResponse> responseObject = (ObjectResponse<ActivationStatusResponse>) stepLoggerStatus.getResponse().responseObject();
+            ActivationStatusResponse response = responseObject.getResponseObject();
+            assertEquals(initResponse.getActivationId(), response.getActivationId());
+            if (version != PowerAuthVersion.V3_0) {
+                assertNotNull(response.getNonce());
+            }
 
-        // Verify activation status blob
-        byte[] challengeData = null;
-        byte[] nonceData = null;
-        byte[] cStatusBlob = Base64.getDecoder().decode(response.getEncryptedStatusBlob());
-        ActivationStatusBlobInfo statusBlob;
-        if (version == PowerAuthVersion.V3_0) {
-            statusBlob = CLIENT_ACTIVATION.getStatusFromEncryptedBlob(cStatusBlob, null, null, transportMasterKey);
+            // Get transport key
+            String transportMasterKeyBase64 = (String) model.getResultStatusObject().get("transportMasterKey");
+            SecretKey transportMasterKey = config.getKeyConvertor().convertBytesToSharedSecretKey(Base64.getDecoder().decode(transportMasterKeyBase64));
+
+            // Verify activation status blob
+            byte[] challengeData = null;
+            byte[] nonceData = null;
+            byte[] cStatusBlob = Base64.getDecoder().decode(response.getEncryptedStatusBlob());
+            ActivationStatusBlobInfo statusBlob;
+            if (version == PowerAuthVersion.V3_0) {
+                statusBlob = CLIENT_ACTIVATION.getStatusFromEncryptedBlob(cStatusBlob, null, null, transportMasterKey);
+            } else {
+                challengeData = Base64.getDecoder().decode(request.getChallenge());
+                nonceData = Base64.getDecoder().decode(response.getNonce());
+                statusBlob = CLIENT_ACTIVATION.getStatusFromEncryptedBlob(cStatusBlob, challengeData, nonceData, transportMasterKey);
+                // Added in V3.1
+                assertEquals(20, statusBlob.getCtrLookAhead());
+                assertTrue(CLIENT_ACTIVATION.verifyHashForHashBasedCounter(statusBlob.getCtrDataHash(), CounterUtil.getCtrData(model, stepLoggerStatus), transportMasterKey, ProtocolVersion.fromValue(version.value())));
+            }
+
+            assertTrue(statusBlob.isValid());
+            assertEquals(0x2, statusBlob.getActivationStatus());
         } else {
-            challengeData = Base64.getDecoder().decode(request.getChallenge());
-            nonceData = Base64.getDecoder().decode(response.getNonce());
-            statusBlob = CLIENT_ACTIVATION.getStatusFromEncryptedBlob(cStatusBlob, challengeData, nonceData, transportMasterKey);
-            // Added in V3.1
-            assertEquals(20, statusBlob.getCtrLookAhead());
-            assertTrue(CLIENT_ACTIVATION.verifyHashForHashBasedCounter(statusBlob.getCtrDataHash(), CounterUtil.getCtrData(model, stepLoggerStatus), transportMasterKey, ProtocolVersion.fromValue(version.value())));
+            ActivationStatusBlobInfo statusBlob = extractStatusBlob(stepLoggerStatus);
+            assertTrue(statusBlob.isValid());
+            assertEquals(0x2, statusBlob.getActivationStatus());
         }
-
-        assertTrue(statusBlob.isValid());
-        assertEquals(0x2, statusBlob.getActivationStatus());
 
         // Commit activation
         CommitActivationResponse commitResponse = powerAuthClient.commitActivation(initResponse.getActivationId(), "test");
@@ -617,6 +685,18 @@ public class PowerAuthActivationShared {
 
         GetActivationStatusResponse statusResponseActive = powerAuthClient.getActivationStatus(initResponse.getActivationId());
         assertEquals(ActivationStatus.ACTIVE, statusResponseActive.getActivationStatus());
+    }
+
+    private static void checkEncryptedResponse(PowerAuthVersion version, Object response) {
+        if (version.getMajorVersion() == 3) {
+            final EciesEncryptedResponse eciesResponse = (EciesEncryptedResponse) response;
+            assertNotNull(eciesResponse.getEncryptedData());
+            assertNotNull(eciesResponse.getMac());
+        } else {
+            final AeadEncryptedResponse aeadResponse = (AeadEncryptedResponse) response;
+            assertNotNull(aeadResponse.getEncryptedData());
+            assertNotNull(aeadResponse.getTimestamp());
+        }
     }
 
 }

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/PowerAuthSignatureShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/PowerAuthSignatureShared.java
@@ -39,6 +39,7 @@ import com.wultra.security.powerauth.crypto.lib.generator.HashBasedCounter;
 import com.wultra.security.powerauth.crypto.lib.generator.KeyGenerator;
 import com.wultra.security.powerauth.crypto.lib.util.AuthenticationCodeLegacyUtils;
 import com.wultra.security.powerauth.crypto.lib.util.SignatureUtils;
+import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
 import com.wultra.security.powerauth.http.PowerAuthHttpBody;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
@@ -203,7 +204,11 @@ public class PowerAuthSignatureShared {
 
     public static void signatureValidGetTest(final PowerAuthTestConfiguration config, final VerifyAuthenticationStepModel model, final ObjectStepLogger stepLogger) throws Exception {
         model.setHttpMethod("GET");
-        model.setUriString(config.getPowerAuthIntegrationUrl() + "/pa/v3/signature/validate?who=John_Tramonta&when=now");
+        if (model.getVersion().getMajorVersion() == 3) {
+            model.setUriString(config.getPowerAuthIntegrationUrl() + "/pa/v3/signature/validate?who=John_Tramonta&when=now");
+        } else {
+            model.setUriString(config.getPowerAuthIntegrationUrl() + "/pa/v4/auth/validate?who=John_Tramonta&when=now");
+        }
         new VerifyAuthenticationStep().execute(stepLogger, model.toMap());
         assertTrue(stepLogger.getResult().success());
         assertEquals(200, stepLogger.getResponse().statusCode());
@@ -214,7 +219,6 @@ public class PowerAuthSignatureShared {
 
     public static void signatureValidGetNoParamTest(final PowerAuthTestConfiguration config, final VerifyAuthenticationStepModel model, final ObjectStepLogger stepLogger) throws Exception {
         model.setHttpMethod("GET");
-        model.setUriString(config.getPowerAuthIntegrationUrl() + "/pa/v3/signature/validate");
         new VerifyAuthenticationStep().execute(stepLogger, model.toMap());
         assertTrue(stepLogger.getResult().success());
         assertEquals(200, stepLogger.getResponse().statusCode());
@@ -282,6 +286,11 @@ public class PowerAuthSignatureShared {
         modelPrepare.setApplicationKey(config.getApplicationKey());
         modelPrepare.setApplicationSecret(config.getApplicationSecret());
         modelPrepare.setMasterPublicKeyP256(config.getMasterPublicKeyP256());
+        if (version.getMajorVersion() == 4) {
+            modelPrepare.setMasterPublicKeyP384(config.getMasterPublicKeyP384());
+            modelPrepare.setMasterPublicKeyMlDsa65(config.getMasterPublicKeyMlDsa65());
+            modelPrepare.setSharedSecretAlgorithm(SharedSecretAlgorithm.EC_P384_ML_L3);
+        }
         modelPrepare.setHeaders(new HashMap<>());
         modelPrepare.setPassword(config.getPassword());
         modelPrepare.setStatusFileName(tempStatusFile.getAbsolutePath());
@@ -357,6 +366,11 @@ public class PowerAuthSignatureShared {
         modelPrepare.setApplicationKey(config.getApplicationKey());
         modelPrepare.setApplicationSecret(config.getApplicationSecret());
         modelPrepare.setMasterPublicKeyP256(config.getMasterPublicKeyP256());
+        if (version.getMajorVersion() == 4) {
+            modelPrepare.setMasterPublicKeyP384(config.getMasterPublicKeyP384());
+            modelPrepare.setMasterPublicKeyMlDsa65(config.getMasterPublicKeyMlDsa65());
+            modelPrepare.setSharedSecretAlgorithm(SharedSecretAlgorithm.EC_P384_ML_L3);
+        }
         modelPrepare.setHeaders(new HashMap<>());
         modelPrepare.setPassword(config.getPassword());
         modelPrepare.setStatusFileName(tempStatusFile.getAbsolutePath());

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/PowerAuthTokenShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/PowerAuthTokenShared.java
@@ -18,11 +18,12 @@
 package com.wultra.security.powerauth.test.shared;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.wultra.security.powerauth.client.v3.PowerAuthClient;
+import com.wultra.security.powerauth.client.v4.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
 import com.wultra.core.rest.model.base.response.ErrorResponse;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedResponse;
 import com.wultra.security.powerauth.crypto.lib.generator.HashBasedCounter;
+import com.wultra.security.powerauth.crypto.lib.v4.encryptor.model.response.AeadEncryptedResponse;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
 import com.wultra.security.powerauth.lib.cmd.logging.model.StepItem;
@@ -209,9 +210,7 @@ public class PowerAuthTokenShared {
         assertTrue(stepLogger2.getResult().success());
         assertEquals(200, stepLogger2.getResponse().statusCode());
 
-        final EciesEncryptedResponse responseOK = (EciesEncryptedResponse) stepLogger2.getResponse().responseObject();
-        assertNotNull(responseOK.getEncryptedData());
-        assertNotNull(responseOK.getMac());
+        checkResponse(model.getVersion(), stepLogger2);
     }
 
     public static void tokenCounterIncrementTest(final CreateTokenStepModel model, final ObjectStepLogger stepLogger, final PowerAuthVersion version) throws Exception {
@@ -234,4 +233,16 @@ public class PowerAuthTokenShared {
         return config.getPowerAuthIntegrationUrl() + "/api/auth/token/app/operation/list";
     }
 
+    private static void checkResponse(PowerAuthVersion version, ObjectStepLogger stepLogger) {
+        if (version.getMajorVersion() == 3) {
+            final EciesEncryptedResponse responseOK = (EciesEncryptedResponse) stepLogger.getResponse().responseObject();
+            assertNotNull(responseOK.getEncryptedData());
+            assertNotNull(responseOK.getMac());
+        } else {
+            final AeadEncryptedResponse responseOK = (AeadEncryptedResponse) stepLogger.getResponse().responseObject();
+            assertNotNull(responseOK.getEncryptedData());
+            assertNotNull(responseOK.getTimestamp());
+        }
+
+    }
 }

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthActivationCommitPhaseShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthActivationCommitPhaseShared.java
@@ -48,7 +48,7 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 public class PowerAuthActivationCommitPhaseShared {
 
-    public static void validOtpOnKeysExchangeTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
+    public static void validOtpOnKeyExchangeTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
                                                   PrepareActivationStepModel model, String validOtpValue, PowerAuthVersion version) throws Exception {
 
         final JSONObject resultStatusObject = new JSONObject();
@@ -80,7 +80,7 @@ public class PowerAuthActivationCommitPhaseShared {
         powerAuthClient.removeActivation(initResponse.getActivationId(), "test");
     }
 
-    public static void invalidOtpOnKeysExchangeTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
+    public static void invalidOtpOnKeyExchangeTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
                                                     PrepareActivationStepModel model, String validOtpValue,
                                                     String invalidOtpValue, PowerAuthVersion version) throws Exception {
 

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthActivationCommitPhaseShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthActivationCommitPhaseShared.java
@@ -15,9 +15,9 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.wultra.security.powerauth.test.shared;
+package com.wultra.security.powerauth.test.shared.v3;
 
-import com.wultra.security.powerauth.client.v4.PowerAuthClient;
+import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.client.model.enumeration.ActivationOtpValidation;
 import com.wultra.security.powerauth.client.model.enumeration.ActivationStatus;
 import com.wultra.security.powerauth.client.model.enumeration.CommitPhase;
@@ -25,7 +25,7 @@ import com.wultra.security.powerauth.client.model.error.PowerAuthClientException
 import com.wultra.security.powerauth.client.model.request.CommitActivationRequest;
 import com.wultra.security.powerauth.client.model.request.InitActivationRequest;
 import com.wultra.security.powerauth.client.model.response.CommitActivationResponse;
-import com.wultra.security.powerauth.client.model.response.v4.GetActivationStatusResponse;
+import com.wultra.security.powerauth.client.model.response.v3.GetActivationStatusResponse;
 import com.wultra.security.powerauth.client.model.response.InitActivationResponse;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
 import com.wultra.security.powerauth.crypto.lib.model.ActivationStatusBlobInfo;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthActivationFlagsShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthActivationFlagsShared.java
@@ -1,0 +1,181 @@
+/*
+ * PowerAuth test and related software components
+ * Copyright (C) 2023 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.security.powerauth.test.shared.v3;
+
+import com.wultra.security.powerauth.client.model.response.v3.GetActivationStatusResponse;
+import com.wultra.security.powerauth.client.v3.PowerAuthClient;
+import com.wultra.security.powerauth.client.model.request.InitActivationRequest;
+import com.wultra.security.powerauth.client.model.request.LookupActivationsRequest;
+import com.wultra.security.powerauth.client.model.response.*;
+import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
+import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
+import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
+import com.wultra.security.powerauth.lib.cmd.steps.model.CreateActivationStepModel;
+import com.wultra.security.powerauth.lib.cmd.steps.model.PrepareActivationStepModel;
+import com.wultra.security.powerauth.lib.cmd.steps.CreateActivationStep;
+import com.wultra.security.powerauth.lib.cmd.steps.PrepareActivationStep;
+import com.wultra.security.powerauth.rest.api.model.response.v3.ActivationLayer2Response;
+
+import java.io.File;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Activation flag test shared logic.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class PowerAuthActivationFlagsShared {
+
+    public static void activationFlagCrudTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config, PrepareActivationStepModel model, PowerAuthVersion version) throws Exception {
+        // Init activation
+        final InitActivationRequest initRequest = new InitActivationRequest();
+        initRequest.setApplicationId(config.getApplicationId());
+        initRequest.setUserId(config.getUser(version));
+        final InitActivationResponse initResponse = powerAuthClient.initActivation(initRequest);
+
+        // Prepare activation
+        model.setActivationCode(initResponse.getActivationCode());
+        ObjectStepLogger stepLoggerPrepare = new ObjectStepLogger(System.out);
+        new PrepareActivationStep().execute(stepLoggerPrepare, model.toMap());
+
+        // Commit activation
+        final CommitActivationResponse commitResponse = powerAuthClient.commitActivation(initResponse.getActivationId(), "test");
+        assertEquals(initResponse.getActivationId(), commitResponse.getActivationId());
+
+        // Test flags CRUD
+        String activationId = initResponse.getActivationId();
+        powerAuthClient.addActivationFlags(activationId, Arrays.asList("FLAG1", "FLAG2"));
+
+        final GetActivationStatusResponse status = powerAuthClient.getActivationStatus(activationId);
+        assertEquals(Arrays.asList("FLAG1", "FLAG2"), status.getActivationFlags());
+
+        final ListActivationFlagsResponse listResponse = powerAuthClient.listActivationFlags(activationId);
+        assertEquals(Arrays.asList("FLAG1", "FLAG2"), listResponse.getActivationFlags());
+
+        powerAuthClient.updateActivationFlags(activationId, Arrays.asList("FLAG3", "FLAG4"));
+
+        ListActivationFlagsResponse listResponse2 = powerAuthClient.listActivationFlags(activationId);
+        assertEquals(Arrays.asList("FLAG3", "FLAG4"), listResponse2.getActivationFlags());
+
+        powerAuthClient.removeActivationFlags(activationId, Collections.singletonList("FLAG4"));
+
+        ListActivationFlagsResponse listResponse3 = powerAuthClient.listActivationFlags(activationId);
+        assertEquals(Collections.singletonList("FLAG3"), listResponse3.getActivationFlags());
+
+        powerAuthClient.addActivationFlags(activationId, Arrays.asList("FLAG3", "FLAG4"));
+
+        ListActivationFlagsResponse listResponse4 = powerAuthClient.listActivationFlags(activationId);
+        assertEquals(Arrays.asList("FLAG3", "FLAG4"), listResponse4.getActivationFlags());
+    }
+
+    public static void activationFlagLookupTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config, PrepareActivationStepModel model, PowerAuthVersion version) throws Exception {
+        // Init activation
+        InitActivationRequest initRequest = new InitActivationRequest();
+        initRequest.setApplicationId(config.getApplicationId());
+        initRequest.setUserId(config.getUser(version));
+        InitActivationResponse initResponse = powerAuthClient.initActivation(initRequest);
+
+        // Prepare activation
+        model.setActivationCode(initResponse.getActivationCode());
+        ObjectStepLogger stepLoggerPrepare = new ObjectStepLogger(System.out);
+        new PrepareActivationStep().execute(stepLoggerPrepare, model.toMap());
+
+        // Obtain timestamp created
+        GetActivationStatusResponse statusResponse = powerAuthClient.getActivationStatus(initResponse.getActivationId());
+        final Date timestampCreated = statusResponse.getTimestampCreated();
+
+        // Commit activation
+        CommitActivationResponse commitResponse = powerAuthClient.commitActivation(initResponse.getActivationId(), "test");
+        assertEquals(initResponse.getActivationId(), commitResponse.getActivationId());
+
+        // Test flag lookup
+        String activationId = initResponse.getActivationId();
+        final LookupActivationsRequest lookupRequest = new LookupActivationsRequest();
+        lookupRequest.getUserIds().add(config.getUser(version));
+        lookupRequest.setTimestampLastUsedAfter(timestampCreated);
+        lookupRequest.getActivationFlags().add("FLAG1");
+        final LookupActivationsResponse response = powerAuthClient.lookupActivations(lookupRequest);
+        assertTrue(response.getActivations().isEmpty());
+
+        powerAuthClient.addActivationFlags(activationId, Arrays.asList("FLAG1", "FLAG2"));
+        LookupActivationsResponse response2 = powerAuthClient.lookupActivations(lookupRequest);
+        assertEquals(1, response2.getActivations().size());
+
+        powerAuthClient.removeActivationFlags(activationId, Collections.singletonList("FLAG1"));
+        LookupActivationsResponse response3 = powerAuthClient.lookupActivations(lookupRequest);
+        assertTrue(response3.getActivations().isEmpty());
+
+        powerAuthClient.addActivationFlags(activationId, Arrays.asList("FLAG3", "FLAG4"));
+        lookupRequest.getActivationFlags().clear();
+        lookupRequest.getActivationFlags().add("FLAG3");
+        lookupRequest.getActivationFlags().add("FLAG4");
+        LookupActivationsResponse response4 = powerAuthClient.lookupActivations(lookupRequest);
+        assertEquals(1, response4.getActivations().size());
+
+        powerAuthClient.addActivationFlags(activationId, Arrays.asList("FLAG3", "FLAG4"));
+        lookupRequest.getActivationFlags().add("FLAG5");
+        LookupActivationsResponse response5 = powerAuthClient.lookupActivations(lookupRequest);
+        assertTrue(response5.getActivations().isEmpty());
+    }
+
+    public static void activationProviderFlagTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config, File tempStatusFile, int port, PowerAuthVersion version) throws Exception {
+        // Create custom activation with test provider
+        CreateActivationStepModel model = new CreateActivationStepModel();
+        model.setActivationName("test v" + version);
+        model.setApplicationKey(config.getApplicationKey());
+        model.setApplicationSecret(config.getApplicationSecret());
+        model.setMasterPublicKeyP256(config.getMasterPublicKeyP256());
+        model.setHeaders(new HashMap<>());
+        model.setPassword(config.getPassword());
+        model.setStatusFileName(tempStatusFile.getAbsolutePath());
+        model.setResultStatusObject(config.getResultStatusObject(version));
+        model.setUriString("http://localhost:" + port);
+        model.setVersion(version);
+        model.setDeviceInfo("backend-tests");
+
+        // Set unique user identity
+        final String userIdSuffix = UUID.randomUUID().toString();
+        final String userId = "TestUser_Flags_"+userIdSuffix;
+        Map<String, String> identityAttributes = new HashMap<>();
+        identityAttributes.put("test_id", "TEST_1_SIMPLE_LOOKUP_COMMIT_PROCESS");
+        identityAttributes.put("username", userId);
+        model.setIdentityAttributes(identityAttributes);
+        ObjectStepLogger stepLogger = new ObjectStepLogger(System.out);
+        new CreateActivationStep().execute(stepLogger, model.toMap());
+
+        assertTrue(stepLogger.getResult().success());
+        assertEquals(200, stepLogger.getResponse().statusCode());
+
+        final String activationId = stepLogger.getItems().stream()
+                .filter(item -> "Decrypted Layer 2 Response".equals(item.name()))
+                .map(item -> (ActivationLayer2Response) item.object())
+                .map(ActivationLayer2Response::getActivationId)
+                .findAny()
+                .orElse(null);
+
+        LookupActivationsRequest lookupRequest = new LookupActivationsRequest();
+        lookupRequest.getUserIds().add(userId);
+        lookupRequest.getActivationFlags().add("TEST-PROVIDER");
+        LookupActivationsResponse response = powerAuthClient.lookupActivations(lookupRequest);
+        assertEquals(1, response.getActivations().size());
+        assertEquals(activationId, response.getActivations().get(0).getActivationId());
+    }
+}

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthActivationOtpShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthActivationOtpShared.java
@@ -1,0 +1,465 @@
+/*
+ * PowerAuth test and related software components
+ * Copyright (C) 2023 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.security.powerauth.test.shared.v3;
+
+import com.wultra.security.powerauth.client.v3.PowerAuthClient;
+import com.wultra.security.powerauth.client.model.enumeration.ActivationOtpValidation;
+import com.wultra.security.powerauth.client.model.enumeration.ActivationStatus;
+import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
+import com.wultra.security.powerauth.client.model.request.CommitActivationRequest;
+import com.wultra.security.powerauth.client.model.request.InitActivationRequest;
+import com.wultra.security.powerauth.client.model.response.CommitActivationResponse;
+import com.wultra.security.powerauth.client.model.response.v3.GetActivationStatusResponse;
+import com.wultra.security.powerauth.client.model.response.InitActivationResponse;
+import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
+import com.wultra.security.powerauth.crypto.lib.model.ActivationStatusBlobInfo;
+import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
+import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
+import com.wultra.security.powerauth.lib.cmd.steps.model.GetStatusStepModel;
+import com.wultra.security.powerauth.lib.cmd.steps.model.PrepareActivationStepModel;
+import com.wultra.security.powerauth.lib.cmd.steps.GetStatusStep;
+import com.wultra.security.powerauth.lib.cmd.steps.PrepareActivationStep;
+import org.json.simple.JSONObject;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * PowerAuth activation OTP test shared logic.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class PowerAuthActivationOtpShared {
+
+    public static void validOtpOnKeysExchangeTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
+                                                  PrepareActivationStepModel model, String validOtpValue, PowerAuthVersion version) throws Exception {
+
+        final JSONObject resultStatusObject = new JSONObject();
+
+        // Init activation
+        final InitActivationRequest initRequest = new InitActivationRequest();
+        initRequest.setApplicationId(config.getApplicationId());
+        initRequest.setUserId(config.getUser(version));
+        initRequest.setMaxFailureCount(5L);
+        initRequest.setActivationOtpValidation(ActivationOtpValidation.ON_KEY_EXCHANGE);
+        initRequest.setActivationOtp(validOtpValue);
+        final InitActivationResponse initResponse = powerAuthClient.initActivation(initRequest);
+
+        // Prepare activation
+        model.setActivationCode(initResponse.getActivationCode());
+        model.setResultStatusObject(resultStatusObject);
+        model.setAdditionalActivationOtp(validOtpValue);
+        ObjectStepLogger stepLoggerPrepare = new ObjectStepLogger(System.out);
+        new PrepareActivationStep().execute(stepLoggerPrepare, model.toMap());
+        assertTrue(stepLoggerPrepare.getResult().success());
+        assertEquals(200, stepLoggerPrepare.getResponse().statusCode());
+
+        // Verify activation status
+        final GetActivationStatusResponse activationStatusResponse = powerAuthClient.getActivationStatus(initResponse.getActivationId());
+        assertNotNull(activationStatusResponse);
+        assertEquals(ActivationStatus.ACTIVE, activationStatusResponse.getActivationStatus());
+
+        // Remove activation
+        powerAuthClient.removeActivation(initResponse.getActivationId(), "test");
+    }
+
+    public static void invalidOtpOnKeysExchangeTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
+                                                    PrepareActivationStepModel model, String validOtpValue,
+                                                    String invalidOtpValue, PowerAuthVersion version) throws Exception {
+
+        final JSONObject resultStatusObject = new JSONObject();
+
+        // Init activation
+        InitActivationRequest initRequest = new InitActivationRequest();
+        initRequest.setApplicationId(config.getApplicationId());
+        initRequest.setUserId(config.getUser(version));
+        initRequest.setMaxFailureCount(5L);
+        initRequest.setActivationOtpValidation(ActivationOtpValidation.ON_KEY_EXCHANGE);
+        initRequest.setActivationOtp(validOtpValue);
+        InitActivationResponse initResponse = powerAuthClient.initActivation(initRequest);
+
+        for (int iteration = 1; iteration <= 5; iteration++) {
+            final boolean lastIteration = iteration == 5;
+            // Prepare activation
+            model.setActivationCode(initResponse.getActivationCode());
+            model.setResultStatusObject(resultStatusObject);
+            model.setAdditionalActivationOtp(invalidOtpValue);
+            ObjectStepLogger stepLoggerPrepare = new ObjectStepLogger(System.out);
+            new PrepareActivationStep().execute(stepLoggerPrepare, model.toMap());
+            assertFalse(stepLoggerPrepare.getResult().success());
+            assertEquals(400, stepLoggerPrepare.getResponse().statusCode());
+
+            // Verify activation status
+            ActivationStatus expectedActivationStatus = lastIteration ? ActivationStatus.REMOVED : ActivationStatus.CREATED;
+            GetActivationStatusResponse activationStatusResponse = powerAuthClient.getActivationStatus(initResponse.getActivationId());
+            assertNotNull(activationStatusResponse);
+            assertEquals(expectedActivationStatus, activationStatusResponse.getActivationStatus());
+        }
+    }
+
+    public static void validOtpOnCommitTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config, PrepareActivationStepModel model,
+                                            String validOtpValue, String invalidOtpValue, PowerAuthVersion version) throws Exception {
+
+        final JSONObject resultStatusObject = new JSONObject();
+
+        // Init activation
+        InitActivationRequest initRequest = new InitActivationRequest();
+        initRequest.setApplicationId(config.getApplicationId());
+        initRequest.setUserId(config.getUser(version));
+        initRequest.setMaxFailureCount(5L);
+        initRequest.setActivationOtpValidation(ActivationOtpValidation.ON_COMMIT);
+        initRequest.setActivationOtp(validOtpValue);
+        InitActivationResponse initResponse = powerAuthClient.initActivation(initRequest);
+
+        // Prepare activation
+        model.setActivationCode(initResponse.getActivationCode());
+        model.setResultStatusObject(resultStatusObject);
+        ObjectStepLogger stepLoggerPrepare = new ObjectStepLogger(System.out);
+        new PrepareActivationStep().execute(stepLoggerPrepare, model.toMap());
+        assertTrue(stepLoggerPrepare.getResult().success());
+        assertEquals(200, stepLoggerPrepare.getResponse().statusCode());
+
+        // Verify activation status
+        GetActivationStatusResponse activationStatusResponse = powerAuthClient.getActivationStatus(initResponse.getActivationId());
+        assertNotNull(activationStatusResponse);
+        assertEquals(ActivationStatus.PENDING_COMMIT, activationStatusResponse.getActivationStatus());
+
+        // Try commit activation with wrong OTP. Last attempt is valid.
+        for (int iteration = 1; iteration <= 5; iteration++) {
+            boolean lastIteration = iteration == 5;
+            final CommitActivationRequest commitRequest = new CommitActivationRequest();
+            commitRequest.setActivationId(initResponse.getActivationId());
+            commitRequest.setActivationOtp(lastIteration ? validOtpValue : invalidOtpValue);
+
+            boolean isActivated;
+            try {
+                final CommitActivationResponse commitResponse = powerAuthClient.commitActivation(commitRequest);
+                isActivated = commitResponse.isActivated();
+            } catch (PowerAuthClientException ex) {
+                isActivated = false;
+            }
+            assertEquals(lastIteration, isActivated);
+
+            // Verify activation status
+            activationStatusResponse = powerAuthClient.getActivationStatus(initResponse.getActivationId());
+            assertEquals(lastIteration ? ActivationStatus.ACTIVE : ActivationStatus.PENDING_COMMIT, activationStatusResponse.getActivationStatus());
+        }
+
+        // Remove activation
+        powerAuthClient.removeActivation(initResponse.getActivationId(), "test");
+    }
+
+    public static void invalidOtpOnCommitTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
+                                              PrepareActivationStepModel model, String validOtpValue,
+                                              String invalidOtpValue, PowerAuthVersion version) throws Exception {
+
+        final JSONObject resultStatusObject = new JSONObject();
+
+        // Init activation
+        InitActivationRequest initRequest = new InitActivationRequest();
+        initRequest.setApplicationId(config.getApplicationId());
+        initRequest.setUserId(config.getUser(version));
+        initRequest.setMaxFailureCount(5L);
+        initRequest.setActivationOtpValidation(ActivationOtpValidation.ON_COMMIT);
+        initRequest.setActivationOtp(validOtpValue);
+        InitActivationResponse initResponse = powerAuthClient.initActivation(initRequest);
+
+        // Prepare activation
+        model.setActivationCode(initResponse.getActivationCode());
+        model.setResultStatusObject(resultStatusObject);
+        ObjectStepLogger stepLoggerPrepare = new ObjectStepLogger(System.out);
+        new PrepareActivationStep().execute(stepLoggerPrepare, model.toMap());
+        assertTrue(stepLoggerPrepare.getResult().success());
+        assertEquals(200, stepLoggerPrepare.getResponse().statusCode());
+
+        // Verify activation status
+        GetActivationStatusResponse activationStatusResponse = powerAuthClient.getActivationStatus(initResponse.getActivationId());
+        assertNotNull(activationStatusResponse);
+        assertEquals(ActivationStatus.PENDING_COMMIT, activationStatusResponse.getActivationStatus());
+
+        // Try commit activation with wrong OTP. Last attempt is valid.
+        for (int iteration = 1; iteration <= 5; iteration++) {
+            boolean lastIteration = iteration == 5;
+            CommitActivationRequest commitRequest = new CommitActivationRequest();
+            commitRequest.setActivationId(initResponse.getActivationId());
+            commitRequest.setActivationOtp(invalidOtpValue);
+
+            boolean isActivated;
+            try {
+                CommitActivationResponse commitResponse = powerAuthClient.commitActivation(commitRequest);
+                isActivated = commitResponse.isActivated();
+            } catch (PowerAuthClientException ex) {
+                isActivated = false;
+            }
+            assertFalse(isActivated);
+
+            // Verify activation status
+            ActivationStatus expectedActivationStatus = lastIteration ? ActivationStatus.REMOVED : ActivationStatus.PENDING_COMMIT;
+            activationStatusResponse = powerAuthClient.getActivationStatus(initResponse.getActivationId());
+            assertEquals(expectedActivationStatus, activationStatusResponse.getActivationStatus());
+        }
+    }
+
+    public static void updateValidOtpOnCommitTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
+                                                  PrepareActivationStepModel model, GetStatusStepModel statusModel,
+                                                  String validOtpValue, String invalidOtpValue, PowerAuthVersion version) throws Exception {
+
+        final JSONObject resultStatusObject = new JSONObject();
+
+        // Init activation
+        InitActivationRequest initRequest = new InitActivationRequest();
+        initRequest.setApplicationId(config.getApplicationId());
+        initRequest.setUserId(config.getUser(version));
+        initRequest.setMaxFailureCount(5L);
+        InitActivationResponse initResponse = powerAuthClient.initActivation(initRequest);
+
+        // Prepare activation
+        model.setActivationCode(initResponse.getActivationCode());
+        model.setResultStatusObject(resultStatusObject);
+        ObjectStepLogger stepLoggerPrepare = new ObjectStepLogger(System.out);
+        new PrepareActivationStep().execute(stepLoggerPrepare, model.toMap());
+        assertTrue(stepLoggerPrepare.getResult().success());
+        assertEquals(200, stepLoggerPrepare.getResponse().statusCode());
+
+        // Verify activation status
+        GetActivationStatusResponse activationStatusResponse = powerAuthClient.getActivationStatus(initResponse.getActivationId());
+        assertEquals(ActivationStatus.PENDING_COMMIT, activationStatusResponse.getActivationStatus());
+
+        // Update OTP
+        powerAuthClient.updateActivationOtp(initResponse.getActivationId(), null, validOtpValue);
+
+        // Try commit activation with wrong OTP. Last attempt is valid.
+        for (int iteration = 1; iteration <= 5; iteration++) {
+            boolean lastIteration = iteration == 5;
+            boolean isActivated;
+            try {
+                CommitActivationRequest commitRequest = new CommitActivationRequest();
+                commitRequest.setActivationId(initResponse.getActivationId());
+                commitRequest.setActivationOtp(lastIteration ? validOtpValue : invalidOtpValue);
+                CommitActivationResponse commitResponse = powerAuthClient.commitActivation(commitRequest);
+                isActivated = commitResponse.isActivated();
+            } catch (PowerAuthClientException ex) {
+                isActivated = false;
+            }
+            assertEquals(lastIteration, isActivated);
+
+            // Verify activation status
+            ActivationStatus expectedActivationStatus = lastIteration ? ActivationStatus.ACTIVE : ActivationStatus.PENDING_COMMIT;
+            activationStatusResponse = powerAuthClient.getActivationStatus(initResponse.getActivationId());
+            assertEquals(expectedActivationStatus, activationStatusResponse.getActivationStatus());
+        }
+
+        // Try to get activation status via RESTful API
+        ObjectStepLogger stepLoggerStatus = new ObjectStepLogger(System.out);
+        statusModel.setResultStatusObject(resultStatusObject);
+        new GetStatusStep().execute(stepLoggerStatus, statusModel.toMap());
+        assertTrue(stepLoggerStatus.getResult().success());
+        assertEquals(200, stepLoggerStatus.getResponse().statusCode());
+
+        // Validate failed and max failed attempts.
+        final Map<String, Object> statusResponseMap = (Map<String, Object>) stepLoggerStatus.getFirstItem("activation-status-obtained").object();
+        ActivationStatusBlobInfo statusBlobInfo = (ActivationStatusBlobInfo) statusResponseMap.get("statusBlob");
+        assertEquals(5L, statusBlobInfo.getMaxFailedAttempts());
+        assertEquals(0L, statusBlobInfo.getFailedAttempts());
+
+        // Remove activation
+        powerAuthClient.removeActivation(initResponse.getActivationId(), "test");
+    }
+
+    public static void updateInvalidOtpOnCommitTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
+                                                    PrepareActivationStepModel model, String validOtpValue,
+                                                    String invalidOtpValue, PowerAuthVersion version) throws Exception {
+
+        final JSONObject resultStatusObject = new JSONObject();
+
+        // Init activation
+        InitActivationRequest initRequest = new InitActivationRequest();
+        initRequest.setApplicationId(config.getApplicationId());
+        initRequest.setUserId(config.getUser(version));
+        initRequest.setMaxFailureCount(5L);
+        InitActivationResponse initResponse = powerAuthClient.initActivation(initRequest);
+
+        // Prepare activation
+        model.setActivationCode(initResponse.getActivationCode());
+        model.setResultStatusObject(resultStatusObject);
+        ObjectStepLogger stepLoggerPrepare = new ObjectStepLogger(System.out);
+        new PrepareActivationStep().execute(stepLoggerPrepare, model.toMap());
+        assertTrue(stepLoggerPrepare.getResult().success());
+        assertEquals(200, stepLoggerPrepare.getResponse().statusCode());
+
+        // Verify activation status
+        GetActivationStatusResponse activationStatusResponse = powerAuthClient.getActivationStatus(initResponse.getActivationId());
+        assertEquals(ActivationStatus.PENDING_COMMIT, activationStatusResponse.getActivationStatus());
+
+        // Update OTP
+        powerAuthClient.updateActivationOtp(initResponse.getActivationId(), null, validOtpValue);
+
+        // Try commit activation with wrong OTP. Last attempt is valid.
+        for (int iteration = 1; iteration <= 5; iteration++) {
+            boolean lastIteration = iteration == 5;
+            boolean isActivated;
+            try {
+                CommitActivationRequest commitRequest = new CommitActivationRequest();
+                commitRequest.setActivationId(initResponse.getActivationId());
+                commitRequest.setActivationOtp(invalidOtpValue);
+                CommitActivationResponse commitResponse = powerAuthClient.commitActivation(commitRequest);
+                isActivated = commitResponse.isActivated();
+            } catch (PowerAuthClientException ex) {
+                isActivated = false;
+            }
+            assertFalse(isActivated);
+
+            // Verify activation status
+            ActivationStatus expectedActivationStatus = lastIteration ? ActivationStatus.REMOVED : ActivationStatus.PENDING_COMMIT;
+            activationStatusResponse = powerAuthClient.getActivationStatus(initResponse.getActivationId());
+            assertEquals(expectedActivationStatus, activationStatusResponse.getActivationStatus());
+        }
+    }
+
+    public static void wrongActivationInitParamTest1(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config, PowerAuthVersion version) {
+        assertThrows(PowerAuthClientException.class, () -> {
+            // Init activation
+            InitActivationRequest initRequest = new InitActivationRequest();
+            initRequest.setApplicationId(config.getApplicationId());
+            initRequest.setUserId(config.getUser(version));
+            initRequest.setMaxFailureCount(5L);
+            // Set ON_KEY_EXCHANGE but no OTP
+            initRequest.setActivationOtpValidation(ActivationOtpValidation.ON_KEY_EXCHANGE);
+            powerAuthClient.initActivation(initRequest);
+        });
+    }
+
+    public static void wrongActivationInitParamTest2(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config, PowerAuthVersion version) {
+        assertThrows(PowerAuthClientException.class, () -> {
+            // Init activation
+            InitActivationRequest initRequest = new InitActivationRequest();
+            initRequest.setApplicationId(config.getApplicationId());
+            initRequest.setUserId(config.getUser(version));
+            initRequest.setMaxFailureCount(5L);
+            // Set ON_COMMIT but no OTP
+            initRequest.setActivationOtpValidation(ActivationOtpValidation.ON_COMMIT);
+            powerAuthClient.initActivation(initRequest);
+        });
+    }
+
+    public static void wrongActivationInitParamTest3(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config, PowerAuthVersion version) {
+        assertThrows(PowerAuthClientException.class, () -> {
+            // Init activation
+            InitActivationRequest initRequest = new InitActivationRequest();
+            initRequest.setApplicationId(config.getApplicationId());
+            initRequest.setUserId(config.getUser(version));
+            initRequest.setMaxFailureCount(5L);
+            // Set ON_KEY_EXCHANGE but empty OTP
+            initRequest.setActivationOtpValidation(ActivationOtpValidation.ON_KEY_EXCHANGE);
+            initRequest.setActivationOtp("");
+            powerAuthClient.initActivation(initRequest);
+        });
+    }
+
+    public static void wrongActivationInitParamTest4(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config, PowerAuthVersion version) {
+        assertThrows(PowerAuthClientException.class, () -> {
+            // Init activation
+            InitActivationRequest initRequest = new InitActivationRequest();
+            initRequest.setApplicationId(config.getApplicationId());
+            initRequest.setUserId(config.getUser(version));
+            initRequest.setMaxFailureCount(5L);
+            // Set ON_COMMIT but empty OTP
+            initRequest.setActivationOtpValidation(ActivationOtpValidation.ON_COMMIT);
+            initRequest.setActivationOtp("");
+            powerAuthClient.initActivation(initRequest);
+        });
+    }
+
+    public static void missingOtpOnCommitTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
+                                              PrepareActivationStepModel model, String validOtpValue, PowerAuthVersion version) throws Exception {
+
+        final JSONObject resultStatusObject = new JSONObject();
+
+        // Init activation
+        InitActivationRequest initRequest = new InitActivationRequest();
+        initRequest.setApplicationId(config.getApplicationId());
+        initRequest.setUserId(config.getUser(version));
+        initRequest.setMaxFailureCount(5L);
+        initRequest.setActivationOtpValidation(ActivationOtpValidation.ON_COMMIT);
+        initRequest.setActivationOtp(validOtpValue);
+        InitActivationResponse initResponse = powerAuthClient.initActivation(initRequest);
+
+        // Prepare activation
+        model.setActivationCode(initResponse.getActivationCode());
+        model.setResultStatusObject(resultStatusObject);
+        ObjectStepLogger stepLoggerPrepare = new ObjectStepLogger(System.out);
+        new PrepareActivationStep().execute(stepLoggerPrepare, model.toMap());
+        assertTrue(stepLoggerPrepare.getResult().success());
+        assertEquals(200, stepLoggerPrepare.getResponse().statusCode());
+
+        // Verify activation status
+        GetActivationStatusResponse activationStatusResponse = powerAuthClient.getActivationStatus(initResponse.getActivationId());
+        assertEquals(ActivationStatus.PENDING_COMMIT, activationStatusResponse.getActivationStatus());
+
+        // Try commit with no OTP for more than max failed attempts. Use OTP in the last iteration, that should pass.
+        for (int iteration = 1; iteration <= 6; iteration++) {
+            boolean lastIteration = iteration == 6;
+            boolean isActivated;
+            try {
+                CommitActivationRequest commitRequest = new CommitActivationRequest();
+                commitRequest.setActivationId(initResponse.getActivationId());
+                if (lastIteration) {
+                    commitRequest.setActivationOtp(validOtpValue);
+                }
+                CommitActivationResponse commitResponse = powerAuthClient.commitActivation(commitRequest);
+                isActivated = commitResponse.isActivated();
+            } catch (PowerAuthClientException ex) {
+                isActivated = false;
+            }
+            assertEquals(lastIteration, isActivated);
+
+            // Verify activation status again
+            ActivationStatus expectedActivationStatus = lastIteration ? ActivationStatus.ACTIVE : ActivationStatus.PENDING_COMMIT;
+            activationStatusResponse = powerAuthClient.getActivationStatus(initResponse.getActivationId());
+            assertEquals(expectedActivationStatus, activationStatusResponse.getActivationStatus());
+        }
+
+        // Remove activation
+        powerAuthClient.removeActivation(initResponse.getActivationId(), "test");
+    }
+
+    public static void missingOtpOnKeysExchangeTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
+                                                    PrepareActivationStepModel model, String validOtpValue, PowerAuthVersion version) throws Exception {
+
+        final JSONObject resultStatusObject = new JSONObject();
+
+        // Init activation
+        InitActivationRequest initRequest = new InitActivationRequest();
+        initRequest.setApplicationId(config.getApplicationId());
+        initRequest.setUserId(config.getUser(version));
+        initRequest.setMaxFailureCount(5L);
+        initRequest.setActivationOtpValidation(ActivationOtpValidation.ON_KEY_EXCHANGE);
+        initRequest.setActivationOtp(validOtpValue);
+        InitActivationResponse initResponse = powerAuthClient.initActivation(initRequest);
+
+        // Prepare activation
+        model.setActivationCode(initResponse.getActivationCode());
+        model.setResultStatusObject(resultStatusObject);
+        model.setAdditionalActivationOtp(null);
+        ObjectStepLogger stepLoggerPrepare = new ObjectStepLogger(System.out);
+        new PrepareActivationStep().execute(stepLoggerPrepare, model.toMap());
+        assertFalse(stepLoggerPrepare.getResult().success());
+        assertEquals(400, stepLoggerPrepare.getResponse().statusCode());
+    }
+}

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthActivationOtpShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthActivationOtpShared.java
@@ -47,7 +47,7 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 public class PowerAuthActivationOtpShared {
 
-    public static void validOtpOnKeysExchangeTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
+    public static void validOtpOnKeyExchangeTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
                                                   PrepareActivationStepModel model, String validOtpValue, PowerAuthVersion version) throws Exception {
 
         final JSONObject resultStatusObject = new JSONObject();
@@ -79,7 +79,7 @@ public class PowerAuthActivationOtpShared {
         powerAuthClient.removeActivation(initResponse.getActivationId(), "test");
     }
 
-    public static void invalidOtpOnKeysExchangeTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
+    public static void invalidOtpOnKeyExchangeTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
                                                     PrepareActivationStepModel model, String validOtpValue,
                                                     String invalidOtpValue, PowerAuthVersion version) throws Exception {
 
@@ -439,7 +439,7 @@ public class PowerAuthActivationOtpShared {
         powerAuthClient.removeActivation(initResponse.getActivationId(), "test");
     }
 
-    public static void missingOtpOnKeysExchangeTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
+    public static void missingOtpOnKeyExchangeTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
                                                     PrepareActivationStepModel model, String validOtpValue, PowerAuthVersion version) throws Exception {
 
         final JSONObject resultStatusObject = new JSONObject();

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthActivationShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthActivationShared.java
@@ -1,6 +1,6 @@
 /*
  * PowerAuth test and related software components
- * Copyright (C) 2023 Wultra s.r.o.
+ * Copyright (C) 2025 Wultra s.r.o.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.wultra.security.powerauth.test.shared;
+package com.wultra.security.powerauth.test.shared.v3;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wultra.security.powerauth.client.model.response.v3.GetActivationStatusResponse;
@@ -32,7 +32,6 @@ import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedResponse;
 import com.wultra.security.powerauth.crypto.lib.enums.EcCurve;
 import com.wultra.security.powerauth.crypto.lib.enums.ProtocolVersion;
-import com.wultra.security.powerauth.crypto.lib.v4.encryptor.model.response.AeadEncryptedResponse;
 import com.wultra.security.powerauth.test.shared.util.ResponseVerificationUtil;
 import com.wultra.core.rest.model.base.response.ErrorResponse;
 import com.wultra.core.rest.model.base.response.ObjectResponse;
@@ -293,164 +292,114 @@ public class PowerAuthActivationShared {
         assertTrue(stepLoggerStatus.getResult().success());
         assertEquals(200, stepLoggerStatus.getResponse().statusCode());
 
-        if (version.getMajorVersion() == 3) {
-            ActivationStatusBlobInfo statusBlob;
-            ActivationStatusRequest request = (ActivationStatusRequest) stepLoggerStatus.getRequest().requestObject();
-            if (version != PowerAuthVersion.V3_0) {
-                assertNotNull(request.getChallenge());
-            }
-            ObjectResponse<ActivationStatusResponse> responseObject = (ObjectResponse<ActivationStatusResponse>) stepLoggerStatus.getResponse().responseObject();
-            ActivationStatusResponse response = responseObject.getResponseObject();
-            assertEquals(initResponse.getActivationId(), response.getActivationId());
-            if (version != PowerAuthVersion.V3_0) {
-                assertNotNull(response.getNonce());
-            }
-
-            // Get transport key
-            String transportMasterKeyBase64 = (String) model.getResultStatusObject().get("transportMasterKey");
-            SecretKey transportMasterKey = config.getKeyConvertor().convertBytesToSharedSecretKey(Base64.getDecoder().decode(transportMasterKeyBase64));
-            byte[] cStatusBlob = Base64.getDecoder().decode(response.getEncryptedStatusBlob());
-
-            // Verify activation status blob
-            byte[] challengeData = null;
-            byte[] nonceData = null;
-            if (version == PowerAuthVersion.V3_0) {
-                statusBlob = CLIENT_ACTIVATION.getStatusFromEncryptedBlob(cStatusBlob, null, null, transportMasterKey);
-            } else {
-                challengeData = Base64.getDecoder().decode(request.getChallenge());
-                nonceData = Base64.getDecoder().decode(response.getNonce());
-                statusBlob = CLIENT_ACTIVATION.getStatusFromEncryptedBlob(cStatusBlob, challengeData, nonceData, transportMasterKey);
-                // Added in V3.1
-                assertEquals(20, statusBlob.getCtrLookAhead());
-                assertTrue(CLIENT_ACTIVATION.verifyHashForHashBasedCounter(statusBlob.getCtrDataHash(), CounterUtil.getCtrData(model, stepLoggerStatus), transportMasterKey, ProtocolVersion.fromValue(version.value())));
-            }
-            assertTrue(statusBlob.isValid());
-            assertEquals(0x2, statusBlob.getActivationStatus());
-            assertEquals(10, statusBlob.getMaxFailedAttempts());
-            assertEquals(0, statusBlob.getFailedAttempts());
-            assertEquals(3, statusBlob.getCurrentVersion());
-            assertEquals(3, statusBlob.getUpgradeVersion());
-
-            // Commit activation
-            CommitActivationResponse commitResponse = powerAuthClient.commitActivation(initResponse.getActivationId(), "test");
-            assertEquals(initResponse.getActivationId(), commitResponse.getActivationId());
-
-            // Get status
-            stepLoggerStatus = new ObjectStepLogger(System.out);
-            new GetStatusStep().execute(stepLoggerStatus, statusModel.toMap());
-            assertTrue(stepLoggerStatus.getResult().success());
-            assertEquals(200, stepLoggerStatus.getResponse().statusCode());
-            request = (ActivationStatusRequest) stepLoggerStatus.getRequest().requestObject();
-            responseObject = (ObjectResponse<ActivationStatusResponse>) stepLoggerStatus.getResponse().responseObject();
-            response = responseObject.getResponseObject();
-            assertEquals(initResponse.getActivationId(), response.getActivationId());
-
-            // Verify activation status blob
-            if (version != PowerAuthVersion.V3_0) {
-                challengeData = Base64.getDecoder().decode(request.getChallenge());
-                nonceData = Base64.getDecoder().decode(response.getNonce());
-            }
-            cStatusBlob = Base64.getDecoder().decode(response.getEncryptedStatusBlob());
-            statusBlob = CLIENT_ACTIVATION.getStatusFromEncryptedBlob(cStatusBlob, challengeData, nonceData, transportMasterKey);
-            assertTrue(statusBlob.isValid());
-            assertEquals(0x3, statusBlob.getActivationStatus());
-
-            // Block activation
-            BlockActivationResponse blockResponse = powerAuthClient.blockActivation(initResponse.getActivationId(), "test", "test");
-            assertEquals(initResponse.getActivationId(), blockResponse.getActivationId());
-            assertEquals("test", blockResponse.getBlockedReason());
-
-            // Get status
-            stepLoggerStatus = new ObjectStepLogger(System.out);
-            new GetStatusStep().execute(stepLoggerStatus, statusModel.toMap());
-            assertTrue(stepLoggerStatus.getResult().success());
-            assertEquals(200, stepLoggerStatus.getResponse().statusCode());
-            request = (ActivationStatusRequest) stepLoggerStatus.getRequest().requestObject();
-            responseObject = (ObjectResponse<ActivationStatusResponse>) stepLoggerStatus.getResponse().responseObject();
-            response = responseObject.getResponseObject();
-            assertEquals(initResponse.getActivationId(), response.getActivationId());
-
-            // Verify activation status blob
-            if (version != PowerAuthVersion.V3_0) {
-                challengeData = Base64.getDecoder().decode(request.getChallenge());
-                nonceData = Base64.getDecoder().decode(response.getNonce());
-            }
-            cStatusBlob = Base64.getDecoder().decode(response.getEncryptedStatusBlob());
-            statusBlob = CLIENT_ACTIVATION.getStatusFromEncryptedBlob(cStatusBlob, challengeData, nonceData, transportMasterKey);
-            assertTrue(statusBlob.isValid());
-            assertEquals(0x4, statusBlob.getActivationStatus());
-
-            // Remove activation
-            powerAuthClient.removeActivation(initResponse.getActivationId(), "test");
-
-            // Get status
-            stepLoggerStatus = new ObjectStepLogger(System.out);
-            new GetStatusStep().execute(stepLoggerStatus, statusModel.toMap());
-            assertTrue(stepLoggerStatus.getResult().success());
-            assertEquals(200, stepLoggerStatus.getResponse().statusCode());
-            request = (ActivationStatusRequest) stepLoggerStatus.getRequest().requestObject();
-            responseObject = (ObjectResponse<ActivationStatusResponse>) stepLoggerStatus.getResponse().responseObject();
-            response = responseObject.getResponseObject();
-            assertEquals(initResponse.getActivationId(), response.getActivationId());
-
-            // Verify activation status blob
-            if (version != PowerAuthVersion.V3_0) {
-                challengeData = Base64.getDecoder().decode(request.getChallenge());
-                nonceData = Base64.getDecoder().decode(response.getNonce());
-            }
-            cStatusBlob = Base64.getDecoder().decode(response.getEncryptedStatusBlob());
-            statusBlob = CLIENT_ACTIVATION.getStatusFromEncryptedBlob(cStatusBlob, challengeData, nonceData, transportMasterKey);
-            assertTrue(statusBlob.isValid());
-            assertEquals(0x5, statusBlob.getActivationStatus());
-        } else {
-            ActivationStatusBlobInfo statusBlob = extractStatusBlob(stepLoggerStatus);
-            assertTrue(statusBlob.isValid());
-            assertEquals(0x2, statusBlob.getActivationStatus());
-            assertEquals(10, statusBlob.getMaxFailedAttempts());
-            assertEquals(0, statusBlob.getFailedAttempts());
-            assertEquals(4, statusBlob.getCurrentVersion());
-            assertEquals(4, statusBlob.getUpgradeVersion());
-
-            // Commit activation
-            CommitActivationResponse commitResponse = powerAuthClient.commitActivation(initResponse.getActivationId(), "test");
-            assertEquals(initResponse.getActivationId(), commitResponse.getActivationId());
-
-            // Check status
-            stepLoggerStatus = new ObjectStepLogger(System.out);
-            new GetStatusStep().execute(stepLoggerStatus, statusModel.toMap());
-            assertTrue(stepLoggerStatus.getResult().success());
-            assertEquals(200, stepLoggerStatus.getResponse().statusCode());
-            statusBlob = extractStatusBlob(stepLoggerStatus);
-            assertTrue(statusBlob.isValid());
-            assertEquals(0x3, statusBlob.getActivationStatus());
-
-            // Block activation
-            BlockActivationResponse blockResponse = powerAuthClient.blockActivation(initResponse.getActivationId(), "test", "test");
-            assertEquals(initResponse.getActivationId(), blockResponse.getActivationId());
-            assertEquals("test", blockResponse.getBlockedReason());
-
-            // Check status
-            stepLoggerStatus = new ObjectStepLogger(System.out);
-            new GetStatusStep().execute(stepLoggerStatus, statusModel.toMap());
-            assertTrue(stepLoggerStatus.getResult().success());
-            assertEquals(200, stepLoggerStatus.getResponse().statusCode());
-            statusBlob = extractStatusBlob(stepLoggerStatus);
-            assertTrue(statusBlob.isValid());
-            assertEquals(0x4, statusBlob.getActivationStatus());
-
-            // Remove activation
-            powerAuthClient.removeActivation(initResponse.getActivationId(), "test");
-
-            // Check status
-            stepLoggerStatus = new ObjectStepLogger(System.out);
-            new GetStatusStep().execute(stepLoggerStatus, statusModel.toMap());
-            assertTrue(stepLoggerStatus.getResult().success());
-            assertEquals(200, stepLoggerStatus.getResponse().statusCode());
-            statusBlob = extractStatusBlob(stepLoggerStatus);
-            assertTrue(statusBlob.isValid());
-            assertEquals(0x5, statusBlob.getActivationStatus());
+        ActivationStatusBlobInfo statusBlob;
+        ActivationStatusRequest request = (ActivationStatusRequest) stepLoggerStatus.getRequest().requestObject();
+        if (version != PowerAuthVersion.V3_0) {
+            assertNotNull(request.getChallenge());
+        }
+        ObjectResponse<ActivationStatusResponse> responseObject = (ObjectResponse<ActivationStatusResponse>) stepLoggerStatus.getResponse().responseObject();
+        ActivationStatusResponse response = responseObject.getResponseObject();
+        assertEquals(initResponse.getActivationId(), response.getActivationId());
+        if (version != PowerAuthVersion.V3_0) {
+            assertNotNull(response.getNonce());
         }
 
+        // Get transport key
+        String transportMasterKeyBase64 = (String) model.getResultStatusObject().get("transportMasterKey");
+        SecretKey transportMasterKey = config.getKeyConvertor().convertBytesToSharedSecretKey(Base64.getDecoder().decode(transportMasterKeyBase64));
+        byte[] cStatusBlob = Base64.getDecoder().decode(response.getEncryptedStatusBlob());
+
+        // Verify activation status blob
+        byte[] challengeData = null;
+        byte[] nonceData = null;
+        if (version == PowerAuthVersion.V3_0) {
+            statusBlob = CLIENT_ACTIVATION.getStatusFromEncryptedBlob(cStatusBlob, null, null, transportMasterKey);
+        } else {
+            challengeData = Base64.getDecoder().decode(request.getChallenge());
+            nonceData = Base64.getDecoder().decode(response.getNonce());
+            statusBlob = CLIENT_ACTIVATION.getStatusFromEncryptedBlob(cStatusBlob, challengeData, nonceData, transportMasterKey);
+            // Added in V3.1
+            assertEquals(20, statusBlob.getCtrLookAhead());
+            assertTrue(CLIENT_ACTIVATION.verifyHashForHashBasedCounter(statusBlob.getCtrDataHash(), CounterUtil.getCtrData(model, stepLoggerStatus), transportMasterKey, ProtocolVersion.fromValue(version.value())));
+        }
+        assertTrue(statusBlob.isValid());
+        assertEquals(0x2, statusBlob.getActivationStatus());
+        assertEquals(10, statusBlob.getMaxFailedAttempts());
+        assertEquals(0, statusBlob.getFailedAttempts());
+        assertEquals(3, statusBlob.getCurrentVersion());
+        assertEquals(3, statusBlob.getUpgradeVersion());
+
+        // Commit activation
+        CommitActivationResponse commitResponse = powerAuthClient.commitActivation(initResponse.getActivationId(), "test");
+        assertEquals(initResponse.getActivationId(), commitResponse.getActivationId());
+
+        // Get status
+        stepLoggerStatus = new ObjectStepLogger(System.out);
+        new GetStatusStep().execute(stepLoggerStatus, statusModel.toMap());
+        assertTrue(stepLoggerStatus.getResult().success());
+        assertEquals(200, stepLoggerStatus.getResponse().statusCode());
+        request = (ActivationStatusRequest) stepLoggerStatus.getRequest().requestObject();
+        responseObject = (ObjectResponse<ActivationStatusResponse>) stepLoggerStatus.getResponse().responseObject();
+        response = responseObject.getResponseObject();
+        assertEquals(initResponse.getActivationId(), response.getActivationId());
+
+        // Verify activation status blob
+        if (version != PowerAuthVersion.V3_0) {
+            challengeData = Base64.getDecoder().decode(request.getChallenge());
+            nonceData = Base64.getDecoder().decode(response.getNonce());
+        }
+        cStatusBlob = Base64.getDecoder().decode(response.getEncryptedStatusBlob());
+        statusBlob = CLIENT_ACTIVATION.getStatusFromEncryptedBlob(cStatusBlob, challengeData, nonceData, transportMasterKey);
+        assertTrue(statusBlob.isValid());
+        assertEquals(0x3, statusBlob.getActivationStatus());
+
+        // Block activation
+        BlockActivationResponse blockResponse = powerAuthClient.blockActivation(initResponse.getActivationId(), "test", "test");
+        assertEquals(initResponse.getActivationId(), blockResponse.getActivationId());
+        assertEquals("test", blockResponse.getBlockedReason());
+
+        // Get status
+        stepLoggerStatus = new ObjectStepLogger(System.out);
+        new GetStatusStep().execute(stepLoggerStatus, statusModel.toMap());
+        assertTrue(stepLoggerStatus.getResult().success());
+        assertEquals(200, stepLoggerStatus.getResponse().statusCode());
+        request = (ActivationStatusRequest) stepLoggerStatus.getRequest().requestObject();
+        responseObject = (ObjectResponse<ActivationStatusResponse>) stepLoggerStatus.getResponse().responseObject();
+        response = responseObject.getResponseObject();
+        assertEquals(initResponse.getActivationId(), response.getActivationId());
+
+        // Verify activation status blob
+        if (version != PowerAuthVersion.V3_0) {
+            challengeData = Base64.getDecoder().decode(request.getChallenge());
+            nonceData = Base64.getDecoder().decode(response.getNonce());
+        }
+        cStatusBlob = Base64.getDecoder().decode(response.getEncryptedStatusBlob());
+        statusBlob = CLIENT_ACTIVATION.getStatusFromEncryptedBlob(cStatusBlob, challengeData, nonceData, transportMasterKey);
+        assertTrue(statusBlob.isValid());
+        assertEquals(0x4, statusBlob.getActivationStatus());
+
+        // Remove activation
+        powerAuthClient.removeActivation(initResponse.getActivationId(), "test");
+
+        // Get status
+        stepLoggerStatus = new ObjectStepLogger(System.out);
+        new GetStatusStep().execute(stepLoggerStatus, statusModel.toMap());
+        assertTrue(stepLoggerStatus.getResult().success());
+        assertEquals(200, stepLoggerStatus.getResponse().statusCode());
+        request = (ActivationStatusRequest) stepLoggerStatus.getRequest().requestObject();
+        responseObject = (ObjectResponse<ActivationStatusResponse>) stepLoggerStatus.getResponse().responseObject();
+        response = responseObject.getResponseObject();
+        assertEquals(initResponse.getActivationId(), response.getActivationId());
+
+        // Verify activation status blob
+        if (version != PowerAuthVersion.V3_0) {
+            challengeData = Base64.getDecoder().decode(request.getChallenge());
+            nonceData = Base64.getDecoder().decode(response.getNonce());
+        }
+        cStatusBlob = Base64.getDecoder().decode(response.getEncryptedStatusBlob());
+        statusBlob = CLIENT_ACTIVATION.getStatusFromEncryptedBlob(cStatusBlob, challengeData, nonceData, transportMasterKey);
+        assertTrue(statusBlob.isValid());
+        assertEquals(0x5, statusBlob.getActivationStatus());
     }
 
     private static ActivationStatusBlobInfo extractStatusBlob(ObjectStepLogger stepLogger) {
@@ -630,45 +579,39 @@ public class PowerAuthActivationShared {
         assertTrue(stepLoggerStatus.getResult().success());
         assertEquals(200, stepLoggerStatus.getResponse().statusCode());
 
-        if (version.getMajorVersion() == 3) {
-            final ActivationStatusRequest request = (ActivationStatusRequest) stepLoggerStatus.getRequest().requestObject();
-            if (version != PowerAuthVersion.V3_0) {
-                assertNotNull(request.getChallenge());
-            }
-            final ObjectResponse<ActivationStatusResponse> responseObject = (ObjectResponse<ActivationStatusResponse>) stepLoggerStatus.getResponse().responseObject();
-            ActivationStatusResponse response = responseObject.getResponseObject();
-            assertEquals(initResponse.getActivationId(), response.getActivationId());
-            if (version != PowerAuthVersion.V3_0) {
-                assertNotNull(response.getNonce());
-            }
-
-            // Get transport key
-            String transportMasterKeyBase64 = (String) model.getResultStatusObject().get("transportMasterKey");
-            SecretKey transportMasterKey = config.getKeyConvertor().convertBytesToSharedSecretKey(Base64.getDecoder().decode(transportMasterKeyBase64));
-
-            // Verify activation status blob
-            byte[] challengeData = null;
-            byte[] nonceData = null;
-            byte[] cStatusBlob = Base64.getDecoder().decode(response.getEncryptedStatusBlob());
-            ActivationStatusBlobInfo statusBlob;
-            if (version == PowerAuthVersion.V3_0) {
-                statusBlob = CLIENT_ACTIVATION.getStatusFromEncryptedBlob(cStatusBlob, null, null, transportMasterKey);
-            } else {
-                challengeData = Base64.getDecoder().decode(request.getChallenge());
-                nonceData = Base64.getDecoder().decode(response.getNonce());
-                statusBlob = CLIENT_ACTIVATION.getStatusFromEncryptedBlob(cStatusBlob, challengeData, nonceData, transportMasterKey);
-                // Added in V3.1
-                assertEquals(20, statusBlob.getCtrLookAhead());
-                assertTrue(CLIENT_ACTIVATION.verifyHashForHashBasedCounter(statusBlob.getCtrDataHash(), CounterUtil.getCtrData(model, stepLoggerStatus), transportMasterKey, ProtocolVersion.fromValue(version.value())));
-            }
-
-            assertTrue(statusBlob.isValid());
-            assertEquals(0x2, statusBlob.getActivationStatus());
-        } else {
-            ActivationStatusBlobInfo statusBlob = extractStatusBlob(stepLoggerStatus);
-            assertTrue(statusBlob.isValid());
-            assertEquals(0x2, statusBlob.getActivationStatus());
+        final ActivationStatusRequest request = (ActivationStatusRequest) stepLoggerStatus.getRequest().requestObject();
+        if (version != PowerAuthVersion.V3_0) {
+            assertNotNull(request.getChallenge());
         }
+        final ObjectResponse<ActivationStatusResponse> responseObject = (ObjectResponse<ActivationStatusResponse>) stepLoggerStatus.getResponse().responseObject();
+        ActivationStatusResponse response = responseObject.getResponseObject();
+        assertEquals(initResponse.getActivationId(), response.getActivationId());
+        if (version != PowerAuthVersion.V3_0) {
+            assertNotNull(response.getNonce());
+        }
+
+        // Get transport key
+        String transportMasterKeyBase64 = (String) model.getResultStatusObject().get("transportMasterKey");
+        SecretKey transportMasterKey = config.getKeyConvertor().convertBytesToSharedSecretKey(Base64.getDecoder().decode(transportMasterKeyBase64));
+
+        // Verify activation status blob
+        byte[] challengeData = null;
+        byte[] nonceData = null;
+        byte[] cStatusBlob = Base64.getDecoder().decode(response.getEncryptedStatusBlob());
+        ActivationStatusBlobInfo statusBlob;
+        if (version == PowerAuthVersion.V3_0) {
+            statusBlob = CLIENT_ACTIVATION.getStatusFromEncryptedBlob(cStatusBlob, null, null, transportMasterKey);
+        } else {
+            challengeData = Base64.getDecoder().decode(request.getChallenge());
+            nonceData = Base64.getDecoder().decode(response.getNonce());
+            statusBlob = CLIENT_ACTIVATION.getStatusFromEncryptedBlob(cStatusBlob, challengeData, nonceData, transportMasterKey);
+            // Added in V3.1
+            assertEquals(20, statusBlob.getCtrLookAhead());
+            assertTrue(CLIENT_ACTIVATION.verifyHashForHashBasedCounter(statusBlob.getCtrDataHash(), CounterUtil.getCtrData(model, stepLoggerStatus), transportMasterKey, ProtocolVersion.fromValue(version.value())));
+        }
+
+        assertTrue(statusBlob.isValid());
+        assertEquals(0x2, statusBlob.getActivationStatus());
 
         // Commit activation
         CommitActivationResponse commitResponse = powerAuthClient.commitActivation(initResponse.getActivationId(), "test");
@@ -688,15 +631,9 @@ public class PowerAuthActivationShared {
     }
 
     private static void checkEncryptedResponse(PowerAuthVersion version, Object response) {
-        if (version.getMajorVersion() == 3) {
-            final EciesEncryptedResponse eciesResponse = (EciesEncryptedResponse) response;
-            assertNotNull(eciesResponse.getEncryptedData());
-            assertNotNull(eciesResponse.getMac());
-        } else {
-            final AeadEncryptedResponse aeadResponse = (AeadEncryptedResponse) response;
-            assertNotNull(aeadResponse.getEncryptedData());
-            assertNotNull(aeadResponse.getTimestamp());
-        }
+        final EciesEncryptedResponse eciesResponse = (EciesEncryptedResponse) response;
+        assertNotNull(eciesResponse.getEncryptedData());
+        assertNotNull(eciesResponse.getMac());
     }
 
 }

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthActivationShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthActivationShared.java
@@ -32,7 +32,7 @@ import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedResponse;
 import com.wultra.security.powerauth.crypto.lib.enums.EcCurve;
 import com.wultra.security.powerauth.crypto.lib.enums.ProtocolVersion;
-import com.wultra.security.powerauth.test.shared.util.ResponseVerificationUtil;
+import com.wultra.security.powerauth.test.shared.v3.util.ResponseVerificationUtil;
 import com.wultra.core.rest.model.base.response.ErrorResponse;
 import com.wultra.core.rest.model.base.response.ObjectResponse;
 import com.wultra.security.powerauth.crypto.client.activation.PowerAuthClientActivation;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthApiShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthApiShared.java
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.wultra.security.powerauth.test.shared;
+package com.wultra.security.powerauth.test.shared.v3;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wultra.security.powerauth.client.model.response.v3.*;
@@ -35,7 +35,7 @@ import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncrypte
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedResponse;
 import com.wultra.security.powerauth.crypto.lib.enums.EcCurve;
 import com.wultra.security.powerauth.model.TemporaryKey;
-import com.wultra.security.powerauth.test.shared.util.TemporaryKeyFetchUtil;
+import com.wultra.security.powerauth.test.shared.v3.util.TemporaryKeyFetchUtil;
 import com.wultra.security.powerauth.crypto.client.keyfactory.PowerAuthClientKeyFactory;
 import com.wultra.security.powerauth.crypto.client.authentication.PowerAuthClientAuthentication;
 import com.wultra.security.powerauth.crypto.client.token.ClientTokenGenerator;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthCallbackShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthCallbackShared.java
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.wultra.security.powerauth.test.shared;
+package com.wultra.security.powerauth.test.shared.v3;
 
 import com.wultra.core.rest.client.base.RestClientException;
 import com.wultra.security.powerauth.client.v3.PowerAuthClient;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthCustomActivationOtpShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthCustomActivationOtpShared.java
@@ -1,6 +1,6 @@
 /*
  * PowerAuth test and related software components
- * Copyright (C) 2023 Wultra s.r.o.
+ * Copyright (C) 2025 Wultra s.r.o.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.wultra.security.powerauth.test.shared;
+package com.wultra.security.powerauth.test.shared.v3;
 
 import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.client.model.enumeration.ActivationStatus;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthCustomActivationShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthCustomActivationShared.java
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.wultra.security.powerauth.test.shared;
+package com.wultra.security.powerauth.test.shared.v3;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wultra.security.powerauth.client.v3.PowerAuthClient;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthCustomActivationShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthCustomActivationShared.java
@@ -25,7 +25,7 @@ import com.wultra.security.powerauth.client.model.error.PowerAuthClientException
 import com.wultra.security.powerauth.client.model.response.v3.GetActivationStatusResponse;
 import com.wultra.security.powerauth.client.model.response.v3.GetApplicationDetailResponse;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.util.ResponseVerificationUtil;
+import com.wultra.security.powerauth.test.shared.v3.util.ResponseVerificationUtil;
 import com.wultra.core.rest.model.base.response.ErrorResponse;
 import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;
 import com.wultra.security.powerauth.crypto.lib.generator.KeyGenerator;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthEncryptionShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthEncryptionShared.java
@@ -43,7 +43,7 @@ import com.wultra.security.powerauth.lib.cmd.steps.model.EncryptStepModel;
 import com.wultra.security.powerauth.lib.cmd.steps.model.VerifyAuthenticationStepModel;
 import com.wultra.security.powerauth.lib.cmd.util.CounterUtil;
 import com.wultra.security.powerauth.model.TemporaryKey;
-import com.wultra.security.powerauth.test.shared.util.TemporaryKeyFetchUtil;
+import com.wultra.security.powerauth.test.shared.v3.util.TemporaryKeyFetchUtil;
 import org.junit.jupiter.api.AssertionFailureBuilder;
 
 import java.io.BufferedWriter;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthEncryptionShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthEncryptionShared.java
@@ -1,0 +1,543 @@
+/*
+ * PowerAuth test and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.security.powerauth.test.shared.v3;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wultra.core.rest.model.base.response.ErrorResponse;
+import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
+import com.wultra.security.powerauth.client.model.request.v3.GetEciesDecryptorRequest;
+import com.wultra.security.powerauth.client.model.response.v3.GetEciesDecryptorResponse;
+import com.wultra.security.powerauth.client.v3.PowerAuthClient;
+import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
+import com.wultra.security.powerauth.crypto.lib.encryptor.ClientEncryptor;
+import com.wultra.security.powerauth.crypto.lib.encryptor.EncryptorFactory;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorParameters;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorScope;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ClientEciesSecrets;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedRequest;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedResponse;
+import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;
+import com.wultra.security.powerauth.crypto.lib.generator.HashBasedCounter;
+import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
+import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
+import com.wultra.security.powerauth.lib.cmd.logging.model.StepItem;
+import com.wultra.security.powerauth.lib.cmd.steps.EncryptStep;
+import com.wultra.security.powerauth.lib.cmd.steps.SignAndEncryptStep;
+import com.wultra.security.powerauth.lib.cmd.steps.model.EncryptStepModel;
+import com.wultra.security.powerauth.lib.cmd.steps.model.VerifyAuthenticationStepModel;
+import com.wultra.security.powerauth.lib.cmd.util.CounterUtil;
+import com.wultra.security.powerauth.model.TemporaryKey;
+import com.wultra.security.powerauth.test.shared.util.TemporaryKeyFetchUtil;
+import org.junit.jupiter.api.AssertionFailureBuilder;
+
+import java.io.BufferedWriter;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * PowerAuth encryption test shared logic.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class PowerAuthEncryptionShared {
+
+    private static final EncryptorFactory ENCRYPTOR_FACTORY = new EncryptorFactory();
+
+    public static void encryptInActivationScopeTest(PowerAuthTestConfiguration config, EncryptStepModel encryptModel, ObjectStepLogger stepLogger) throws Exception {
+        encryptModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/activation");
+        encryptModel.setScope("activation");
+
+        new EncryptStep().execute(stepLogger, encryptModel.toMap());
+        assertTrue(stepLogger.getResult().success());
+        assertEquals(200, stepLogger.getResponse().statusCode());
+
+        final EciesEncryptedResponse responseOK = (EciesEncryptedResponse) stepLogger.getResponse().responseObject();
+        assertNotNull(responseOK.getEncryptedData());
+        assertNotNull(responseOK.getMac());
+
+        final Object result = fetchDecryptedResponse(stepLogger);
+
+        assertEquals("{\"data\":\"Server successfully decrypted signed data: hello, scope: ACTIVATION_SCOPE\"}", result);
+    }
+
+    public static void encryptInApplicationScopeTest(PowerAuthTestConfiguration config, EncryptStepModel encryptModel, ObjectStepLogger stepLogger) throws Exception {
+        encryptModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/application");
+        encryptModel.setScope("application");
+
+        new EncryptStep().execute(stepLogger, encryptModel.toMap());
+        assertTrue(stepLogger.getResult().success());
+        assertEquals(200, stepLogger.getResponse().statusCode());
+
+        final EciesEncryptedResponse responseOK = (EciesEncryptedResponse) stepLogger.getResponse().responseObject();
+        assertNotNull(responseOK.getEncryptedData());
+        assertNotNull(responseOK.getMac());
+
+        final Object result = fetchDecryptedResponse(stepLogger);
+
+        assertEquals("{\"data\":\"Server successfully decrypted signed data: hello, scope: APPLICATION_SCOPE\"}", result);
+    }
+
+    public static void encryptInInvalidScope1Test(PowerAuthTestConfiguration config, EncryptStepModel encryptModel, ObjectStepLogger stepLogger) throws Exception {
+        encryptModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/activation");
+        encryptModel.setScope("application");
+
+        new EncryptStep().execute(stepLogger, encryptModel.toMap());
+        assertFalse(stepLogger.getResult().success());
+        assertEquals(400, stepLogger.getResponse().statusCode());
+    }
+
+    public static void encryptInInvalidScope2Test(PowerAuthTestConfiguration config, EncryptStepModel encryptModel, ObjectStepLogger stepLogger) throws Exception {
+        encryptModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/application");
+        encryptModel.setScope("activation");
+
+        new EncryptStep().execute(stepLogger, encryptModel.toMap());
+        assertFalse(stepLogger.getResult().success());
+        assertEquals(400, stepLogger.getResponse().statusCode());
+    }
+
+    public static void encryptEmptyDataTest(PowerAuthTestConfiguration config, EncryptStepModel encryptModel, ObjectStepLogger stepLogger) throws Exception {
+        File emptyDataFile = File.createTempFile("data_empty_signed", ".json");
+        emptyDataFile.deleteOnExit();
+        FileWriter fw = new FileWriter(emptyDataFile);
+        fw.close();
+
+        encryptModel.setData(Files.readAllBytes(Paths.get(emptyDataFile.getAbsolutePath())));
+        encryptModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/activation");
+        encryptModel.setScope("activation");
+
+        new EncryptStep().execute(stepLogger, encryptModel.toMap());
+        // It is allowed to encrypt empty data
+        assertTrue(stepLogger.getResult().success());
+        assertEquals(200, stepLogger.getResponse().statusCode());
+    }
+
+    public static void encryptBlockedActivationTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config, EncryptStepModel encryptModel, ObjectStepLogger stepLogger, PowerAuthVersion version) throws Exception {
+        encryptModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/activation");
+        encryptModel.setScope("activation");
+
+        // Block activation and verify that data exchange fails
+        powerAuthClient.blockActivation(config.getActivationId(version), "test", "test");
+
+        new EncryptStep().execute(stepLogger, encryptModel.toMap());
+        assertFalse(stepLogger.getResult().success());
+        assertEquals(400, stepLogger.getResponse().statusCode());
+
+        // Unblock activation and verify that data exchange succeeds
+        powerAuthClient.unblockActivation(config.getActivationId(version), "test");
+
+        ObjectStepLogger stepLoggerSuccess = new ObjectStepLogger(System.out);
+
+        new EncryptStep().execute(stepLoggerSuccess, encryptModel.toMap());
+        assertTrue(stepLoggerSuccess.getResult().success());
+        assertEquals(200, stepLoggerSuccess.getResponse().statusCode());
+
+        final EciesEncryptedResponse responseOK = (EciesEncryptedResponse) stepLoggerSuccess.getResponse().responseObject();
+        assertNotNull(responseOK.getEncryptedData());
+        assertNotNull(responseOK.getMac());
+
+        boolean responseSuccessfullyDecrypted = false;
+        for (StepItem item: stepLoggerSuccess.getItems()) {
+            if (item.name().equals("Decrypted Response")) {
+                assertEquals("{\"data\":\"Server successfully decrypted signed data: hello, scope: ACTIVATION_SCOPE\"}", item.object());
+                responseSuccessfullyDecrypted = true;
+                break;
+            }
+        }
+        assertTrue(responseSuccessfullyDecrypted);
+    }
+
+    public static void signAndEncryptTest(PowerAuthTestConfiguration config, VerifyAuthenticationStepModel signatureModel, ObjectStepLogger stepLogger, PowerAuthVersion version) throws Exception {
+        signatureModel.setResourceId("/exchange/signed");
+        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/signed");
+
+        new SignAndEncryptStep().execute(stepLogger, signatureModel.toMap());
+        assertTrue(stepLogger.getResult().success());
+        assertEquals(200, stepLogger.getResponse().statusCode());
+
+        final EciesEncryptedResponse responseOK = (EciesEncryptedResponse) stepLogger.getResponse().responseObject();
+        assertNotNull(responseOK.getEncryptedData());
+        assertNotNull(responseOK.getMac());
+
+        final Object result = fetchDecryptedResponse(stepLogger);
+
+        assertEquals("{\"data\":\"Server successfully decrypted data and verified signature, request data: hello, user ID: " + config.getUser(version) + "\"}", result);
+    }
+
+    public static void signAndEncryptWeakSignatureTypeTest(PowerAuthTestConfiguration config, VerifyAuthenticationStepModel signatureModel, ObjectStepLogger stepLogger) throws Exception {
+        signatureModel.setResourceId("/exchange/signed");
+        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/signed");
+
+        signatureModel.setAuthenticationCodeType(PowerAuthCodeType.POSSESSION);
+
+        new SignAndEncryptStep().execute(stepLogger, signatureModel.toMap());
+        assertFalse(stepLogger.getResult().success());
+        assertEquals(401, stepLogger.getResponse().statusCode());
+    }
+
+    public static void signAndEncryptInvalidPasswordTest(PowerAuthTestConfiguration config, VerifyAuthenticationStepModel signatureModel, ObjectStepLogger stepLogger) throws Exception {
+        signatureModel.setResourceId("/exchange/signed");
+        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/signed");
+        signatureModel.setPassword("0000");
+
+        new SignAndEncryptStep().execute(stepLogger, signatureModel.toMap());
+        assertFalse(stepLogger.getResult().success());
+        assertEquals(401, stepLogger.getResponse().statusCode());
+    }
+
+    public static void signAndEncryptEmptyDataTest(PowerAuthTestConfiguration config, VerifyAuthenticationStepModel signatureModel, EncryptStepModel encryptModel, ObjectStepLogger stepLogger) throws Exception {
+        signatureModel.setResourceId("/exchange/signed");
+        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/signed");
+        File emptyDataFile = File.createTempFile("data_empty_signed", ".json");
+        emptyDataFile.deleteOnExit();
+        FileWriter fw = new FileWriter(emptyDataFile);
+        fw.close();
+
+        encryptModel.setData(Files.readAllBytes(Paths.get(emptyDataFile.getAbsolutePath())));
+
+        new SignAndEncryptStep().execute(stepLogger, signatureModel.toMap());
+        // It is allowed to encrypt and sign empty data
+        assertTrue(stepLogger.getResult().success());
+        assertEquals(200, stepLogger.getResponse().statusCode());
+    }
+
+    public static void signAndEncryptLargeDataTest(PowerAuthTestConfiguration config, VerifyAuthenticationStepModel signatureModel, ObjectStepLogger stepLogger, PowerAuthVersion version) throws Exception {
+        signatureModel.setResourceId("/exchange/signed");
+        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/signed");
+
+        SecureRandom secureRandom = new SecureRandom();
+        File dataFileLarge = File.createTempFile("data_large_" + version, ".dat");
+        dataFileLarge.deleteOnExit();
+        FileWriter fw = new FileWriter(dataFileLarge);
+        fw.write("{\"data\": \"");
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        for (int i = 0; i < 5000; i++) {
+            baos.write(secureRandom.nextInt());
+        }
+        fw.write(Base64.getEncoder().encodeToString(baos.toByteArray()));
+        fw.write("\"}");
+        fw.close();
+
+        signatureModel.setData(Files.readAllBytes(Paths.get(dataFileLarge.getAbsolutePath())));
+
+        new SignAndEncryptStep().execute(stepLogger, signatureModel.toMap());
+        assertTrue(stepLogger.getResult().success());
+        assertEquals(200, stepLogger.getResponse().statusCode());
+    }
+
+    public static void signAndEncryptStringDataTest(PowerAuthTestConfiguration config, VerifyAuthenticationStepModel signatureModel, ObjectStepLogger stepLogger, PowerAuthVersion version) throws Exception {
+        signatureModel.setResourceId("/exchange/signed/string");
+        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/signed/string");
+
+        File dataFile = File.createTempFile("data_string" + version, ".dat");
+        dataFile.deleteOnExit();
+        BufferedWriter out = Files.newBufferedWriter(dataFile.toPath(), StandardCharsets.UTF_8);
+
+        String requestData = Base64.getEncoder().encodeToString(generateRandomString().getBytes(StandardCharsets.UTF_8));
+        // JSON Strings need to be enclosed in double quotes
+        out.write("\"" + requestData + "\"");
+        out.close();
+
+        signatureModel.setData(Files.readAllBytes(Paths.get(dataFile.getAbsolutePath())));
+
+        new SignAndEncryptStep().execute(stepLogger, signatureModel.toMap());
+        assertTrue(stepLogger.getResult().success());
+        assertEquals(200, stepLogger.getResponse().statusCode());
+
+        final Object result = fetchDecryptedResponse(stepLogger);
+
+        assertEquals("\"Server successfully decrypted data and verified signature, request data: " + requestData + ", user ID: " + config.getUser(version) + "\"", result);
+    }
+
+    public static void signAndEncryptRawDataTest(PowerAuthTestConfiguration config, VerifyAuthenticationStepModel signatureModel, ObjectStepLogger stepLogger, PowerAuthVersion version) throws Exception {
+        signatureModel.setResourceId("/exchange/signed/raw");
+        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/signed/raw");
+
+        File dataFile = File.createTempFile("data_raw_" + version, ".dat");
+        dataFile.deleteOnExit();
+        BufferedWriter out = Files.newBufferedWriter(dataFile.toPath(), StandardCharsets.UTF_8);
+
+        String requestData = generateRandomString();
+        out.write(requestData);
+        out.close();
+
+        signatureModel.setData(Files.readAllBytes(Paths.get(dataFile.getAbsolutePath())));
+
+        new SignAndEncryptStep().execute(stepLogger, signatureModel.toMap());
+        assertTrue(stepLogger.getResult().success());
+        assertEquals(200, stepLogger.getResponse().statusCode());
+
+        final Object result = fetchDecryptedResponse(stepLogger);
+
+        assertEquals(requestData, result);
+    }
+
+    public static void signAndEncryptGenerifiedDataTest(PowerAuthTestConfiguration config, VerifyAuthenticationStepModel signatureModel, ObjectStepLogger stepLogger) throws Exception {
+        signatureModel.setResourceId("/exchange/signed/generics");
+        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/signed/generics");
+        File dataFileWithGenerics = File.createTempFile("data-generics", ".json");
+        dataFileWithGenerics.deleteOnExit();
+        FileWriter fw = new FileWriter(dataFileWithGenerics);
+        fw.write("{\"requestObject\":{\"data\":\"test-data\"}}");
+        fw.close();
+        byte[] data = Files.readAllBytes(Paths.get(dataFileWithGenerics.getAbsolutePath()));
+        signatureModel.setData(data);
+
+        new SignAndEncryptStep().execute(stepLogger, signatureModel.toMap());
+        assertTrue(stepLogger.getResult().success());
+        assertEquals(200, stepLogger.getResponse().statusCode());
+
+        final Object result = fetchDecryptedResponse(stepLogger);
+
+        assertEquals("{\"status\":\"OK\",\"responseObject\":{\"data\":\"test-data\"}}", result);
+    }
+
+    private static Object fetchDecryptedResponse(final ObjectStepLogger stepLogger) {
+        return stepLogger.getItems().stream()
+                .filter(item -> "Decrypted Response".equals(item.name()))
+                .map(StepItem::object)
+                .findAny()
+                .orElseThrow(() -> AssertionFailureBuilder.assertionFailure().message("Response was not successfully decrypted").build());
+    }
+
+    public static void signAndEncryptInvalidResourceIdTest(PowerAuthTestConfiguration config, VerifyAuthenticationStepModel signatureModel, ObjectStepLogger stepLogger) throws Exception {
+        signatureModel.setResourceId("/exchange/invalid");
+        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/signed");
+
+        new SignAndEncryptStep().execute(stepLogger, signatureModel.toMap());
+        assertFalse(stepLogger.getResult().success());
+        assertEquals(401, stepLogger.getResponse().statusCode());
+    }
+
+    public static void signAndEncryptBlockedActivationTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config, VerifyAuthenticationStepModel signatureModel, ObjectStepLogger stepLogger, PowerAuthVersion version) throws Exception {
+        signatureModel.setResourceId("/exchange/signed");
+        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/signed");
+
+        // Block activation and verify that data exchange fails
+        powerAuthClient.blockActivation(config.getActivationId(version), "test", "test");
+
+        new SignAndEncryptStep().execute(stepLogger, signatureModel.toMap());
+        assertFalse(stepLogger.getResult().success());
+
+        // Unblock activation and verify that data exchange succeeds
+        powerAuthClient.unblockActivation(config.getActivationId(version), "test");
+
+        ObjectStepLogger stepLoggerSuccess = new ObjectStepLogger(System.out);
+        new SignAndEncryptStep().execute(stepLoggerSuccess, signatureModel.toMap());
+        assertTrue(stepLoggerSuccess.getResult().success());
+        assertEquals(200, stepLoggerSuccess.getResponse().statusCode());
+
+        EciesEncryptedResponse responseOK = (EciesEncryptedResponse) stepLoggerSuccess.getResponse().responseObject();
+        assertNotNull(responseOK.getEncryptedData());
+        assertNotNull(responseOK.getMac());
+
+        boolean responseSuccessfullyDecrypted = false;
+        for (StepItem item: stepLoggerSuccess.getItems()) {
+            if (item.name().equals("Decrypted Response")) {
+                assertEquals("{\"data\":\"Server successfully decrypted data and verified signature, request data: hello, user ID: " + config.getUser(version) + "\"}", item.object());
+                responseSuccessfullyDecrypted = true;
+                break;
+            }
+        }
+        assertTrue(responseSuccessfullyDecrypted);
+    }
+
+    public static void signAndEncryptUnsupportedApplicationTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config, VerifyAuthenticationStepModel signatureModel, PowerAuthVersion version) throws Exception {
+        signatureModel.setResourceId("/exchange/signed");
+        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/signed");
+
+        powerAuthClient.unsupportApplicationVersion(config.getApplicationId(), config.getApplicationVersionId());
+
+        ObjectStepLogger stepLogger1 = new ObjectStepLogger(System.out);
+        new SignAndEncryptStep().execute(stepLogger1, signatureModel.toMap());
+        assertFalse(stepLogger1.getResult().success());
+
+        ObjectMapper objectMapper = config.getObjectMapper();
+        final ErrorResponse errorResponse = objectMapper.readValue(stepLogger1.getResponse().responseObject().toString(), ErrorResponse.class);
+        assertEquals("ERROR", errorResponse.getStatus());
+
+        powerAuthClient.supportApplicationVersion(config.getApplicationId(), config.getApplicationVersionId());
+
+        ObjectStepLogger stepLogger2 = new ObjectStepLogger(System.out);
+        new SignAndEncryptStep().execute(stepLogger2, signatureModel.toMap());
+        assertTrue(stepLogger2.getResult().success());
+        assertEquals(200, stepLogger2.getResponse().statusCode());
+
+        final EciesEncryptedResponse responseOK = (EciesEncryptedResponse) stepLogger2.getResponse().responseObject();
+        assertNotNull(responseOK.getEncryptedData());
+        assertNotNull(responseOK.getMac());
+
+        boolean responseSuccessfullyDecrypted = false;
+        for (StepItem item: stepLogger2.getItems()) {
+            if (item.name().equals("Decrypted Response")) {
+                assertEquals("{\"data\":\"Server successfully decrypted data and verified signature, request data: hello, user ID: " + config.getUser(version) + "\"}", item.object());
+                responseSuccessfullyDecrypted = true;
+                break;
+            }
+        }
+        assertTrue(responseSuccessfullyDecrypted);
+    }
+
+    public static void signAndEncryptCounterIncrementTest(PowerAuthTestConfiguration config, VerifyAuthenticationStepModel signatureModel, ObjectStepLogger stepLogger, PowerAuthVersion version) throws Exception {
+        signatureModel.setResourceId("/exchange/signed");
+        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/signed");
+
+        byte[] ctrData = CounterUtil.getCtrData(signatureModel, stepLogger);
+        HashBasedCounter counter = new HashBasedCounter(version.value());
+        for (int i = 1; i <= 10; i++) {
+            ObjectStepLogger stepLoggerLoop = new ObjectStepLogger();
+            new SignAndEncryptStep().execute(stepLoggerLoop, signatureModel.toMap());
+            assertTrue(stepLoggerLoop.getResult().success());
+            assertEquals(200, stepLoggerLoop.getResponse().statusCode());
+
+            // Verify hash based counter
+            ctrData = counter.next(ctrData);
+            assertArrayEquals(ctrData, CounterUtil.getCtrData(signatureModel, stepLoggerLoop));
+        }
+    }
+
+    public static void signAndEncryptLookAheadTest(PowerAuthTestConfiguration config, VerifyAuthenticationStepModel signatureModel) throws Exception {
+        signatureModel.setResourceId("/exchange/signed");
+        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/signed");
+
+        // Move counter by 1-4, next signature should succeed thanks to counter lookahead and it is still in max failure limit
+        for (int i = 1; i < 4; i++) {
+            for (int j=0; j < i; j++) {
+                signatureModel.setPassword("1111");
+                ObjectStepLogger stepLogger = new ObjectStepLogger(System.out);
+                new SignAndEncryptStep().execute(stepLogger, signatureModel.toMap());
+                assertFalse(stepLogger.getResult().success());
+                assertEquals(401, stepLogger.getResponse().statusCode());
+            }
+
+            signatureModel.setPassword(config.getPassword());
+            ObjectStepLogger stepLogger = new ObjectStepLogger(System.out);
+            new SignAndEncryptStep().execute(stepLogger, signatureModel.toMap());
+            assertTrue(stepLogger.getResult().success());
+            assertEquals(200, stepLogger.getResponse().statusCode());
+        }
+    }
+
+    public static void signAndEncryptSingleFactorTest(PowerAuthTestConfiguration config, VerifyAuthenticationStepModel signatureModel, ObjectStepLogger stepLogger) throws Exception {
+        signatureModel.setResourceId("/exchange/signed");
+        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/signed");
+        signatureModel.setAuthenticationCodeType(PowerAuthCodeType.POSSESSION);
+
+        new SignAndEncryptStep().execute(stepLogger, signatureModel.toMap());
+        assertFalse(stepLogger.getResult().success());
+        assertEquals(401, stepLogger.getResponse().statusCode());
+
+        ObjectMapper objectMapper = config.getObjectMapper();
+        final ErrorResponse errorResponse = objectMapper.readValue(stepLogger.getResponse().responseObject().toString(), ErrorResponse.class);
+        assertEquals("ERROR", errorResponse.getStatus());
+    }
+
+    public static void signAndEncryptBiometryTest(PowerAuthTestConfiguration config, VerifyAuthenticationStepModel signatureModel, ObjectStepLogger stepLogger) throws Exception {
+        signatureModel.setResourceId("/exchange/signed");
+        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/signed");
+        signatureModel.setAuthenticationCodeType(PowerAuthCodeType.POSSESSION_BIOMETRY);
+
+        new SignAndEncryptStep().execute(stepLogger, signatureModel.toMap());
+        assertTrue(stepLogger.getResult().success());
+        assertEquals(200, stepLogger.getResponse().statusCode());
+    }
+
+    public static void signAndEncryptThreeFactorTest(PowerAuthTestConfiguration config, VerifyAuthenticationStepModel signatureModel, ObjectStepLogger stepLogger) throws Exception {
+        signatureModel.setResourceId("/exchange/signed");
+        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/signed");
+        signatureModel.setAuthenticationCodeType(PowerAuthCodeType.POSSESSION_KNOWLEDGE_BIOMETRY);
+
+        new SignAndEncryptStep().execute(stepLogger, signatureModel.toMap());
+        assertTrue(stepLogger.getResult().success());
+        assertEquals(200, stepLogger.getResponse().statusCode());
+    }
+
+    public static void replayAttackEciesDecryptorTest(final PowerAuthClient powerAuthClient, final PowerAuthTestConfiguration config, PowerAuthVersion version) throws Exception {
+        final TemporaryKey temporaryKey = TemporaryKeyFetchUtil.fetchTemporaryKey(version, EncryptorScope.APPLICATION_SCOPE, config);
+        String requestData = "test_data";
+        ClientEncryptor<EciesEncryptedRequest, EciesEncryptedResponse> clientEncryptor = ENCRYPTOR_FACTORY.getClientEncryptor(
+                EncryptorId.APPLICATION_SCOPE_GENERIC,
+                new EncryptorParameters(version.value(), config.getApplicationKey(), null, temporaryKey != null ? temporaryKey.getId() : null),
+                new ClientEciesSecrets(config.getMasterPublicKeyP256(), config.getApplicationSecret())
+        );
+        EciesEncryptedRequest encryptedRequest = clientEncryptor.encryptRequest(requestData.getBytes(StandardCharsets.UTF_8));
+        final GetEciesDecryptorRequest eciesDecryptorRequest = new GetEciesDecryptorRequest();
+        eciesDecryptorRequest.setProtocolVersion(version.value());
+        eciesDecryptorRequest.setActivationId(null);
+        eciesDecryptorRequest.setApplicationKey(config.getApplicationKey());
+        eciesDecryptorRequest.setEphemeralPublicKey(encryptedRequest.getEphemeralPublicKey());
+        eciesDecryptorRequest.setNonce(encryptedRequest.getNonce());
+        eciesDecryptorRequest.setTimestamp(encryptedRequest.getTimestamp());
+        eciesDecryptorRequest.setTemporaryKeyId(temporaryKey != null ? temporaryKey.getId() : null);
+        GetEciesDecryptorResponse decryptorResponse = powerAuthClient.getEciesDecryptor(eciesDecryptorRequest);
+        assertNotNull(decryptorResponse.getSecretKey());
+        assertNotNull(decryptorResponse.getSharedInfo2());
+
+        // Replay attack simulation - send the same request twice, expect error ERR0024
+        final PowerAuthClientException ex = assertThrows(PowerAuthClientException.class, () ->
+                powerAuthClient.getEciesDecryptor(eciesDecryptorRequest));
+        assertEquals("ERR0024", ex.getPowerAuthError().get().getCode());
+    }
+
+    public static void encryptedResponseTest(final PowerAuthTestConfiguration config, EncryptStepModel encryptModel, ObjectStepLogger stepLogger, PowerAuthVersion version) throws Exception {
+        encryptModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/activation");
+        encryptModel.setScope("activation");
+
+        new EncryptStep().execute(stepLogger, encryptModel.toMap());
+        assertTrue(stepLogger.getResult().success());
+        assertEquals(200, stepLogger.getResponse().statusCode());
+        EciesEncryptedResponse responseObject = (EciesEncryptedResponse) stepLogger.getResponse().responseObject();
+        assertNotNull(responseObject.getEncryptedData());
+        assertNotNull(responseObject.getMac());
+        switch (version) {
+            case V3_0, V3_1 -> {
+                assertNull(responseObject.getNonce());
+                assertNull(responseObject.getTimestamp());
+            }
+            case V3_2, V3_3 -> {
+                assertNotNull(responseObject.getNonce());
+                assertNotNull(responseObject.getTimestamp());
+            }
+            default -> fail("Unsupported version");
+        }
+    }
+
+    private static String generateRandomString() {
+        SecureRandom secureRandom = new SecureRandom();
+        StringBuilder alphabetBuilder = new StringBuilder();
+        for (int i = 0; i < 10000; i++) {
+            alphabetBuilder.append((char) i);
+        }
+        String alphabet = alphabetBuilder.toString();
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 100; i++) {
+            int randomChar = Math.abs(secureRandom.nextInt()) % alphabet.length();
+            sb.append(alphabet, randomChar, randomChar+1);
+        }
+        return sb.toString();
+    }
+
+}

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthEncryptionShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthEncryptionShared.java
@@ -120,13 +120,13 @@ public class PowerAuthEncryptionShared {
     }
 
     public static void encryptEmptyDataTest(PowerAuthTestConfiguration config, EncryptStepModel encryptModel, ObjectStepLogger stepLogger) throws Exception {
-        File emptyDataFile = File.createTempFile("data_empty_signed", ".json");
+        File emptyDataFile = File.createTempFile("data_empty", ".txt");
         emptyDataFile.deleteOnExit();
         FileWriter fw = new FileWriter(emptyDataFile);
         fw.close();
 
         encryptModel.setData(Files.readAllBytes(Paths.get(emptyDataFile.getAbsolutePath())));
-        encryptModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/activation");
+        encryptModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/raw");
         encryptModel.setScope("activation");
 
         new EncryptStep().execute(stepLogger, encryptModel.toMap());
@@ -211,7 +211,7 @@ public class PowerAuthEncryptionShared {
     public static void signAndEncryptEmptyDataTest(PowerAuthTestConfiguration config, VerifyAuthenticationStepModel signatureModel, EncryptStepModel encryptModel, ObjectStepLogger stepLogger) throws Exception {
         signatureModel.setResourceId("/exchange/signed");
         signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/signed");
-        File emptyDataFile = File.createTempFile("data_empty_signed", ".json");
+        File emptyDataFile = File.createTempFile("data_empty_signed", ".txt");
         emptyDataFile.deleteOnExit();
         FileWriter fw = new FileWriter(emptyDataFile);
         fw.close();

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthIdentityVerificationShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthIdentityVerificationShared.java
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.wultra.security.powerauth.test.shared;
+package com.wultra.security.powerauth.test.shared.v3;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthInfoShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthInfoShared.java
@@ -1,0 +1,103 @@
+/*
+ * PowerAuth test and related software components
+ * Copyright (C) 2023 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.security.powerauth.test.shared.v3;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.wultra.core.rest.client.base.DefaultRestClient;
+import com.wultra.core.rest.client.base.RestClient;
+import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
+import com.wultra.core.rest.model.base.request.ObjectRequest;
+import com.wultra.core.rest.model.base.response.ObjectResponse;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedResponse;
+import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
+import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
+import com.wultra.security.powerauth.lib.cmd.logging.model.StepItem;
+import com.wultra.security.powerauth.lib.cmd.steps.model.EncryptStepModel;
+import com.wultra.security.powerauth.lib.cmd.steps.EncryptStep;
+import com.wultra.security.powerauth.rest.api.model.request.UserInfoRequest;
+import com.wultra.security.powerauth.rest.api.model.response.ServerStatusResponse;
+import org.opentest4j.AssertionFailedError;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * PowerAuth server info test shared logic.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class PowerAuthInfoShared {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper().disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
+
+    // Tolerate 60 seconds time difference between client and server in tests
+    private static final long SERVER_CLIENT_TIME_DIFF_TOLERANCE_MILLIS = 60000;
+
+    public static void testUserInfo(final PowerAuthTestConfiguration config, final EncryptStepModel encryptModel, final PowerAuthVersion version) throws Exception {
+        encryptModel.setUriString(config.getEnrollmentServiceUrl() + "/pa/v3/user/info");
+        encryptModel.setScope("activation");
+        encryptModel.setData(objectMapper.writeValueAsBytes(new UserInfoRequest()));
+
+        final ObjectStepLogger stepLogger = new ObjectStepLogger(System.out);
+        new EncryptStep().execute(stepLogger, encryptModel.toMap());
+        assertTrue(stepLogger.getResult().success());
+        assertEquals(200, stepLogger.getResponse().statusCode());
+
+        final EciesEncryptedResponse response = (EciesEncryptedResponse) stepLogger.getResponse().responseObject();
+        assertNotNull(response.getEncryptedData());
+        assertNotNull(response.getMac());
+
+        final Map<String, Object> decryptedData = stepLogger.getItems().stream()
+                .filter(isStepItemDecryptedResponse())
+                .map(StepItem::object)
+                .map(Object::toString)
+                .map(it -> safeReadValue(it, new TypeReference<Map<String, Object>>() {}))
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElseThrow(() -> new AssertionFailedError("Decrypted data not found"));
+
+        assertNotNull(decryptedData.get("iat"));
+        assertNotNull(decryptedData.get("jti"));
+        assertEquals(config.getUser(version), decryptedData.get("sub"));
+    }
+
+    public static void testServerStatus(final PowerAuthTestConfiguration config) throws Exception {
+        final RestClient restClient = new DefaultRestClient(config.getEnrollmentServiceUrl());
+        final ObjectResponse<ServerStatusResponse> objectResponse = restClient.postObject("/pa/v3/status", new ObjectRequest<>(), ServerStatusResponse.class);
+        assertTrue(Math.abs(objectResponse.getResponseObject().serverTime() - System.currentTimeMillis()) < SERVER_CLIENT_TIME_DIFF_TOLERANCE_MILLIS);
+    }
+
+    private static Predicate<StepItem> isStepItemDecryptedResponse() {
+        return stepItem -> "Decrypted Response".equals(stepItem.name());
+    }
+
+    private static <T> T safeReadValue(final String value, final TypeReference<T> typeReference) {
+        try {
+            return objectMapper.readValue(value, typeReference);
+        } catch (JsonProcessingException e) {
+            fail("Unable to read json", e);
+            return null;
+        }
+    }
+}

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthOnboardingShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthOnboardingShared.java
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.wultra.security.powerauth.test.shared;
+package com.wultra.security.powerauth.test.shared.v3;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthSignatureShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthSignatureShared.java
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.wultra.security.powerauth.test.shared;
+package com.wultra.security.powerauth.test.shared.v3;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wultra.security.powerauth.client.model.response.v3.GetActivationStatusResponse;
@@ -39,7 +39,6 @@ import com.wultra.security.powerauth.crypto.lib.generator.HashBasedCounter;
 import com.wultra.security.powerauth.crypto.lib.generator.KeyGenerator;
 import com.wultra.security.powerauth.crypto.lib.util.AuthenticationCodeLegacyUtils;
 import com.wultra.security.powerauth.crypto.lib.util.SignatureUtils;
-import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
 import com.wultra.security.powerauth.http.PowerAuthHttpBody;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
@@ -204,11 +203,7 @@ public class PowerAuthSignatureShared {
 
     public static void signatureValidGetTest(final PowerAuthTestConfiguration config, final VerifyAuthenticationStepModel model, final ObjectStepLogger stepLogger) throws Exception {
         model.setHttpMethod("GET");
-        if (model.getVersion().getMajorVersion() == 3) {
-            model.setUriString(config.getPowerAuthIntegrationUrl() + "/pa/v3/signature/validate?who=John_Tramonta&when=now");
-        } else {
-            model.setUriString(config.getPowerAuthIntegrationUrl() + "/pa/v4/auth/validate?who=John_Tramonta&when=now");
-        }
+        model.setUriString(config.getPowerAuthIntegrationUrl() + "/pa/v3/signature/validate?who=John_Tramonta&when=now");
         new VerifyAuthenticationStep().execute(stepLogger, model.toMap());
         assertTrue(stepLogger.getResult().success());
         assertEquals(200, stepLogger.getResponse().statusCode());
@@ -286,11 +281,6 @@ public class PowerAuthSignatureShared {
         modelPrepare.setApplicationKey(config.getApplicationKey());
         modelPrepare.setApplicationSecret(config.getApplicationSecret());
         modelPrepare.setMasterPublicKeyP256(config.getMasterPublicKeyP256());
-        if (version.getMajorVersion() == 4) {
-            modelPrepare.setMasterPublicKeyP384(config.getMasterPublicKeyP384());
-            modelPrepare.setMasterPublicKeyMlDsa65(config.getMasterPublicKeyMlDsa65());
-            modelPrepare.setSharedSecretAlgorithm(SharedSecretAlgorithm.EC_P384_ML_L3);
-        }
         modelPrepare.setHeaders(new HashMap<>());
         modelPrepare.setPassword(config.getPassword());
         modelPrepare.setStatusFileName(tempStatusFile.getAbsolutePath());
@@ -366,11 +356,6 @@ public class PowerAuthSignatureShared {
         modelPrepare.setApplicationKey(config.getApplicationKey());
         modelPrepare.setApplicationSecret(config.getApplicationSecret());
         modelPrepare.setMasterPublicKeyP256(config.getMasterPublicKeyP256());
-        if (version.getMajorVersion() == 4) {
-            modelPrepare.setMasterPublicKeyP384(config.getMasterPublicKeyP384());
-            modelPrepare.setMasterPublicKeyMlDsa65(config.getMasterPublicKeyMlDsa65());
-            modelPrepare.setSharedSecretAlgorithm(SharedSecretAlgorithm.EC_P384_ML_L3);
-        }
         modelPrepare.setHeaders(new HashMap<>());
         modelPrepare.setPassword(config.getPassword());
         modelPrepare.setStatusFileName(tempStatusFile.getAbsolutePath());

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthTokenShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthTokenShared.java
@@ -1,0 +1,240 @@
+/*
+ * PowerAuth test and related software components
+ * Copyright (C) 2023 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.security.powerauth.test.shared.v3;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wultra.security.powerauth.client.v3.PowerAuthClient;
+import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
+import com.wultra.core.rest.model.base.response.ErrorResponse;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedResponse;
+import com.wultra.security.powerauth.crypto.lib.generator.HashBasedCounter;
+import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
+import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
+import com.wultra.security.powerauth.lib.cmd.logging.model.StepItem;
+import com.wultra.security.powerauth.lib.cmd.steps.VerifyTokenStep;
+import com.wultra.security.powerauth.lib.cmd.steps.model.CreateTokenStepModel;
+import com.wultra.security.powerauth.lib.cmd.steps.model.VerifyTokenStepModel;
+import com.wultra.security.powerauth.lib.cmd.steps.CreateTokenStep;
+import com.wultra.security.powerauth.lib.cmd.util.CounterUtil;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * PowerAuth token test shared logic.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class PowerAuthTokenShared {
+
+    public static void tokenCreateAndVerifyTest(final PowerAuthTestConfiguration config, final CreateTokenStepModel model, final File dataFile, final PowerAuthVersion version) throws Exception {
+        ObjectStepLogger stepLogger1 = new ObjectStepLogger();
+        new CreateTokenStep().execute(stepLogger1, model.toMap());
+        assertTrue(stepLogger1.getResult().success());
+        assertEquals(200, stepLogger1.getResponse().statusCode());
+
+        String tokenId = null;
+        String tokenSecret = null;
+        for (StepItem item: stepLogger1.getItems()) {
+            if (item.name().equals("Token successfully obtained")) {
+                final Map<String, Object> responseMap = (Map<String, Object>) item.object();
+                tokenId = (String) responseMap.get("tokenId");
+                tokenSecret = (String) responseMap.get("tokenSecret");
+                break;
+            }
+        }
+
+        assertNotNull(tokenId);
+        assertNotNull(tokenSecret);
+
+        VerifyTokenStepModel modelVerify = new VerifyTokenStepModel();
+        modelVerify.setTokenId(tokenId);
+        modelVerify.setTokenSecret(tokenSecret);
+        modelVerify.setHeaders(new HashMap<>());
+        modelVerify.setResultStatusObject(config.getResultStatusObject(version));
+        modelVerify.setUriString(getTokenUri(config));
+        modelVerify.setData(Files.readAllBytes(Paths.get(dataFile.getAbsolutePath())));
+        modelVerify.setHttpMethod("POST");
+        modelVerify.setVersion(version);
+
+        ObjectStepLogger stepLogger2 = new ObjectStepLogger();
+        new VerifyTokenStep().execute(stepLogger2, modelVerify.toMap());
+        assertTrue(stepLogger2.getResult().success());
+        assertEquals(200, stepLogger2.getResponse().statusCode());
+
+        final Map<String, Object> responseOK = (Map<String, Object>) stepLogger2.getResponse().responseObject();
+        assertEquals("OK", responseOK.get("status"));
+    }
+
+    public static void tokenCreateInvalidPasswordTest(final PowerAuthTestConfiguration config, final CreateTokenStepModel model, final ObjectStepLogger stepLogger) throws Exception {
+        model.setPassword("1235");
+
+        new CreateTokenStep().execute(stepLogger, model.toMap());
+        assertFalse(stepLogger.getResult().success());
+        assertEquals(401, stepLogger.getResponse().statusCode());
+
+        ObjectMapper objectMapper = config.getObjectMapper();
+        final ErrorResponse errorResponse = objectMapper.readValue(stepLogger.getResponse().responseObject().toString(), ErrorResponse.class);
+        assertEquals("ERROR", errorResponse.getStatus());
+        checkError(errorResponse);
+    }
+
+    public static void tokenVerifyInvalidTokenTest(final PowerAuthTestConfiguration config, final File dataFile, final PowerAuthVersion version) throws Exception {
+        VerifyTokenStepModel modelVerify = new VerifyTokenStepModel();
+        modelVerify.setTokenId("test");
+        modelVerify.setTokenSecret("test");
+        modelVerify.setHeaders(new HashMap<>());
+        modelVerify.setResultStatusObject(config.getResultStatusObject(version));
+        modelVerify.setUriString(getTokenUri(config));
+        modelVerify.setData(Files.readAllBytes(Paths.get(dataFile.getAbsolutePath())));
+        modelVerify.setHttpMethod("POST");
+        modelVerify.setVersion(version);
+
+        ObjectStepLogger stepLogger2 = new ObjectStepLogger();
+        new VerifyTokenStep().execute(stepLogger2, modelVerify.toMap());
+        assertFalse(stepLogger2.getResult().success());
+        assertEquals(401, stepLogger2.getResponse().statusCode());
+
+        ObjectMapper objectMapper = config.getObjectMapper();
+        final ErrorResponse errorResponse = objectMapper.readValue(stepLogger2.getResponse().responseObject().toString(), ErrorResponse.class);
+        assertEquals("ERROR", errorResponse.getStatus());
+        checkError(errorResponse);
+    }
+
+    public static void tokenVerifyRemovedTokenTest(final PowerAuthClient powerAuthClient, final PowerAuthTestConfiguration config, final CreateTokenStepModel model, final File dataFile, final PowerAuthVersion version) throws Exception {
+        ObjectStepLogger stepLogger1 = new ObjectStepLogger();
+        new CreateTokenStep().execute(stepLogger1, model.toMap());
+        assertTrue(stepLogger1.getResult().success());
+        assertEquals(200, stepLogger1.getResponse().statusCode());
+
+        String tokenId = null;
+        String tokenSecret = null;
+        for (StepItem item: stepLogger1.getItems()) {
+            if (item.name().equals("Token successfully obtained")) {
+                final Map<String, Object> responseMap = (Map<String, Object>) item.object();
+                tokenId = (String) responseMap.get("tokenId");
+                tokenSecret = (String) responseMap.get("tokenSecret");
+                break;
+            }
+        }
+
+        assertNotNull(tokenId);
+        assertNotNull(tokenSecret);
+
+        powerAuthClient.removeToken(tokenId, config.getActivationId(version));
+
+        VerifyTokenStepModel modelVerify = new VerifyTokenStepModel();
+        modelVerify.setTokenId(tokenId);
+        modelVerify.setTokenSecret(tokenSecret);
+        modelVerify.setHeaders(new HashMap<>());
+        modelVerify.setResultStatusObject(config.getResultStatusObject(version));
+        modelVerify.setUriString(getTokenUri(config));
+        modelVerify.setData(Files.readAllBytes(Paths.get(dataFile.getAbsolutePath())));
+        modelVerify.setHttpMethod("POST");
+        modelVerify.setVersion(version);
+
+        ObjectStepLogger stepLogger2 = new ObjectStepLogger();
+        new VerifyTokenStep().execute(stepLogger2, modelVerify.toMap());
+        assertFalse(stepLogger2.getResult().success());
+        assertEquals(401, stepLogger2.getResponse().statusCode());
+
+        ObjectMapper objectMapper = config.getObjectMapper();
+        final ErrorResponse errorResponse = objectMapper.readValue(stepLogger2.getResponse().responseObject().toString(), ErrorResponse.class);
+        assertEquals("ERROR", errorResponse.getStatus());
+        checkError(errorResponse);
+    }
+
+    public static void tokenCreateBlockedActivationTest(final PowerAuthClient powerAuthClient, final PowerAuthTestConfiguration config, final CreateTokenStepModel model, final PowerAuthVersion version) throws Exception {
+        powerAuthClient.blockActivation(config.getActivationId(version), "test", "test");
+
+        ObjectStepLogger stepLogger1 = new ObjectStepLogger(System.out);
+        new CreateTokenStep().execute(stepLogger1, model.toMap());
+        assertFalse(stepLogger1.getResult().success());
+        assertEquals(401, stepLogger1.getResponse().statusCode());
+
+        ObjectMapper objectMapper = config.getObjectMapper();
+        final ErrorResponse errorResponse = objectMapper.readValue(stepLogger1.getResponse().responseObject().toString(), ErrorResponse.class);
+        assertEquals("ERROR", errorResponse.getStatus());
+        checkError(errorResponse);
+
+        powerAuthClient.unblockActivation(config.getActivationId(version), "test");
+
+        ObjectStepLogger stepLogger2 = new ObjectStepLogger();
+        new CreateTokenStep().execute(stepLogger2, model.toMap());
+        assertTrue(stepLogger2.getResult().success());
+        assertEquals(200, stepLogger2.getResponse().statusCode());
+    }
+
+    public static void tokenUnsupportedApplicationTest(final PowerAuthClient powerAuthClient, final PowerAuthTestConfiguration config, final CreateTokenStepModel model) throws Exception {
+        powerAuthClient.unsupportApplicationVersion(config.getApplicationId(), config.getApplicationVersionId());
+
+        ObjectStepLogger stepLogger1 = new ObjectStepLogger(System.out);
+        new CreateTokenStep().execute(stepLogger1, model.toMap());
+        assertFalse(stepLogger1.getResult().success());
+        if (model.getVersion().useTemporaryKeys()) {
+            assertEquals(400, stepLogger1.getResponse().statusCode());
+        } else {
+            assertEquals(401, stepLogger1.getResponse().statusCode());
+        }
+
+        ObjectMapper objectMapper = config.getObjectMapper();
+        final ErrorResponse errorResponse = objectMapper.readValue(stepLogger1.getResponse().responseObject().toString(), ErrorResponse.class);
+        assertEquals("ERROR", errorResponse.getStatus());
+        checkError(errorResponse);
+
+        powerAuthClient.supportApplicationVersion(config.getApplicationId(), config.getApplicationVersionId());
+
+        ObjectStepLogger stepLogger2 = new ObjectStepLogger(System.out);
+        new CreateTokenStep().execute(stepLogger2, model.toMap());
+        assertTrue(stepLogger2.getResult().success());
+        assertEquals(200, stepLogger2.getResponse().statusCode());
+
+        checkResponse(stepLogger2);
+    }
+
+    public static void tokenCounterIncrementTest(final CreateTokenStepModel model, final ObjectStepLogger stepLogger, final PowerAuthVersion version) throws Exception {
+        byte[] ctrData = CounterUtil.getCtrData(model, stepLogger);
+        new CreateTokenStep().execute(stepLogger, model.toMap());
+        assertTrue(stepLogger.getResult().success());
+        assertEquals(200, stepLogger.getResponse().statusCode());
+
+        // Verify counter after createToken
+        byte[] ctrDataExpected = new HashBasedCounter(version.value()).next(ctrData);
+        assertArrayEquals(ctrDataExpected, CounterUtil.getCtrData(model, stepLogger));
+    }
+
+    private static void checkError(final ErrorResponse errorResponse) {
+        // Errors differ when Web Flow is used because of its Exception handler, for protocol version 3.3 temporary key error is present
+        assertTrue("POWERAUTH_AUTH_FAIL".equals(errorResponse.getResponseObject().getCode()) || "ERR_AUTHENTICATION".equals(errorResponse.getResponseObject().getCode()) || "ERR_TEMPORARY_KEY".equals(errorResponse.getResponseObject().getCode()));
+    }
+
+    private static String getTokenUri(final PowerAuthTestConfiguration config) {
+        return config.getPowerAuthIntegrationUrl() + "/api/auth/token/app/operation/list";
+    }
+
+    private static void checkResponse(ObjectStepLogger stepLogger) {
+        final EciesEncryptedResponse responseOK = (EciesEncryptedResponse) stepLogger.getResponse().responseObject();
+        assertNotNull(responseOK.getEncryptedData());
+        assertNotNull(responseOK.getMac());
+    }
+}

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthVaultUnlockShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthVaultUnlockShared.java
@@ -260,7 +260,7 @@ public class PowerAuthVaultUnlockShared {
     }
 
     private static void checkError(ErrorResponse errorResponse) {
-        // Errors differ when Web Flow is used because of its Exception handler, for protocol version 3.3 temporary key error is present
+        // For protocol version 3.3 temporary key error is present
         assertTrue("ERR_AUTHENTICATION".equals(errorResponse.getResponseObject().getCode()) || "ERR_TEMPORARY_KEY".equals(errorResponse.getResponseObject().getCode()));
         assertTrue("POWER_AUTH_CODE_INVALID".equals(errorResponse.getResponseObject().getMessage()) || "POWER_AUTH_TEMPORARY_KEY_FAILURE".equals(errorResponse.getResponseObject().getMessage()));
     }

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthVaultUnlockShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthVaultUnlockShared.java
@@ -15,11 +15,9 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.wultra.security.powerauth.test.shared;
+package com.wultra.security.powerauth.test.shared.v3;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.wultra.security.powerauth.client.model.enumeration.v3.SignatureType;
-import com.wultra.security.powerauth.client.model.enumeration.v4.AuthenticationCodeType;
 import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.client.model.response.v3.VerifyECDSASignatureResponse;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/util/ResponseVerificationUtil.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/util/ResponseVerificationUtil.java
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.wultra.security.powerauth.test.shared.util;
+package com.wultra.security.powerauth.test.shared.v3.util;
 
 import com.wultra.core.rest.model.base.response.ErrorResponse;
 import com.wultra.security.powerauth.lib.cmd.steps.model.BaseStepModel;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/util/TemporaryKeyFetchUtil.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/util/TemporaryKeyFetchUtil.java
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.wultra.security.powerauth.test.shared.util;
+package com.wultra.security.powerauth.test.shared.v3.util;
 
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/util/TemporaryKeyFetchUtil.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/util/TemporaryKeyFetchUtil.java
@@ -173,7 +173,7 @@ public class TemporaryKeyFetchUtil {
         final Base64URL encodedSignature = jwtParts[2];
         final String signingInput = encodedHeader + "." + encodedPayload;
         final byte[] signatureBytes = convertRawSignatureToDER(encodedSignature.decode());
-        return SIGNATURE_UTILS.validateECDSASignature(signingInput.getBytes(StandardCharsets.UTF_8), signatureBytes, publicKey);
+        return SIGNATURE_UTILS.validateECDSASignature(EcCurve.P256, signingInput.getBytes(StandardCharsets.UTF_8), signatureBytes, publicKey);
     }
 
     private static byte[] convertRawSignatureToDER(byte[] rawSignature) throws Exception {

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthActivationCommitPhaseShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthActivationCommitPhaseShared.java
@@ -48,7 +48,7 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 public class PowerAuthActivationCommitPhaseShared {
 
-    public static void validOtpOnKeysExchangeTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
+    public static void validOtpOnKeyExchangeTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
                                                   PrepareActivationStepModel model, String validOtpValue, PowerAuthVersion version) throws Exception {
 
         final JSONObject resultStatusObject = new JSONObject();
@@ -80,7 +80,7 @@ public class PowerAuthActivationCommitPhaseShared {
         powerAuthClient.removeActivation(initResponse.getActivationId(), "test");
     }
 
-    public static void invalidOtpOnKeysExchangeTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
+    public static void invalidOtpOnKeyExchangeTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
                                                     PrepareActivationStepModel model, String validOtpValue,
                                                     String invalidOtpValue, PowerAuthVersion version) throws Exception {
 

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthActivationCommitPhaseShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthActivationCommitPhaseShared.java
@@ -1,6 +1,6 @@
 /*
  * PowerAuth test and related software components
- * Copyright (C) 2023 Wultra s.r.o.
+ * Copyright (C) 2024 Wultra s.r.o.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
@@ -15,25 +15,26 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.wultra.security.powerauth.test.shared;
+package com.wultra.security.powerauth.test.shared.v4;
 
-import com.wultra.security.powerauth.client.v4.PowerAuthClient;
 import com.wultra.security.powerauth.client.model.enumeration.ActivationOtpValidation;
 import com.wultra.security.powerauth.client.model.enumeration.ActivationStatus;
+import com.wultra.security.powerauth.client.model.enumeration.CommitPhase;
 import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
 import com.wultra.security.powerauth.client.model.request.CommitActivationRequest;
 import com.wultra.security.powerauth.client.model.request.InitActivationRequest;
 import com.wultra.security.powerauth.client.model.response.CommitActivationResponse;
-import com.wultra.security.powerauth.client.model.response.v4.GetActivationStatusResponse;
 import com.wultra.security.powerauth.client.model.response.InitActivationResponse;
+import com.wultra.security.powerauth.client.model.response.v4.GetActivationStatusResponse;
+import com.wultra.security.powerauth.client.v4.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
 import com.wultra.security.powerauth.crypto.lib.model.ActivationStatusBlobInfo;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
-import com.wultra.security.powerauth.lib.cmd.steps.model.GetStatusStepModel;
-import com.wultra.security.powerauth.lib.cmd.steps.model.PrepareActivationStepModel;
 import com.wultra.security.powerauth.lib.cmd.steps.GetStatusStep;
 import com.wultra.security.powerauth.lib.cmd.steps.PrepareActivationStep;
+import com.wultra.security.powerauth.lib.cmd.steps.model.GetStatusStepModel;
+import com.wultra.security.powerauth.lib.cmd.steps.model.PrepareActivationStepModel;
 import org.json.simple.JSONObject;
 
 import java.util.Map;
@@ -41,11 +42,11 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * PowerAuth activation OTP test shared logic.
+ * PowerAuth activation commit phase shared logic.
  *
  * @author Roman Strobl, roman.strobl@wultra.com
  */
-public class PowerAuthActivationOtpShared {
+public class PowerAuthActivationCommitPhaseShared {
 
     public static void validOtpOnKeysExchangeTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
                                                   PrepareActivationStepModel model, String validOtpValue, PowerAuthVersion version) throws Exception {
@@ -57,8 +58,8 @@ public class PowerAuthActivationOtpShared {
         initRequest.setApplicationId(config.getApplicationId());
         initRequest.setUserId(config.getUser(version));
         initRequest.setMaxFailureCount(5L);
-        initRequest.setActivationOtpValidation(ActivationOtpValidation.ON_KEY_EXCHANGE);
         initRequest.setActivationOtp(validOtpValue);
+        initRequest.setCommitPhase(CommitPhase.ON_KEY_EXCHANGE);
         final InitActivationResponse initResponse = powerAuthClient.initActivation(initRequest);
 
         // Prepare activation
@@ -90,8 +91,8 @@ public class PowerAuthActivationOtpShared {
         initRequest.setApplicationId(config.getApplicationId());
         initRequest.setUserId(config.getUser(version));
         initRequest.setMaxFailureCount(5L);
-        initRequest.setActivationOtpValidation(ActivationOtpValidation.ON_KEY_EXCHANGE);
         initRequest.setActivationOtp(validOtpValue);
+        initRequest.setCommitPhase(CommitPhase.ON_KEY_EXCHANGE);
         InitActivationResponse initResponse = powerAuthClient.initActivation(initRequest);
 
         for (int iteration = 1; iteration <= 5; iteration++) {
@@ -123,8 +124,8 @@ public class PowerAuthActivationOtpShared {
         initRequest.setApplicationId(config.getApplicationId());
         initRequest.setUserId(config.getUser(version));
         initRequest.setMaxFailureCount(5L);
-        initRequest.setActivationOtpValidation(ActivationOtpValidation.ON_COMMIT);
         initRequest.setActivationOtp(validOtpValue);
+        initRequest.setCommitPhase(CommitPhase.ON_COMMIT);
         InitActivationResponse initResponse = powerAuthClient.initActivation(initRequest);
 
         // Prepare activation
@@ -176,8 +177,8 @@ public class PowerAuthActivationOtpShared {
         initRequest.setApplicationId(config.getApplicationId());
         initRequest.setUserId(config.getUser(version));
         initRequest.setMaxFailureCount(5L);
-        initRequest.setActivationOtpValidation(ActivationOtpValidation.ON_COMMIT);
         initRequest.setActivationOtp(validOtpValue);
+        initRequest.setCommitPhase(CommitPhase.ON_COMMIT);
         InitActivationResponse initResponse = powerAuthClient.initActivation(initRequest);
 
         // Prepare activation
@@ -332,134 +333,18 @@ public class PowerAuthActivationOtpShared {
         }
     }
 
-    public static void wrongActivationInitParamTest1(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config, PowerAuthVersion version) {
+    public static void wrongActivationInitParamTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config, PowerAuthVersion version) {
         assertThrows(PowerAuthClientException.class, () -> {
             // Init activation
             InitActivationRequest initRequest = new InitActivationRequest();
             initRequest.setApplicationId(config.getApplicationId());
             initRequest.setUserId(config.getUser(version));
             initRequest.setMaxFailureCount(5L);
-            // Set ON_KEY_EXCHANGE but no OTP
+            // Set both activation OTP validation and commit phase
             initRequest.setActivationOtpValidation(ActivationOtpValidation.ON_KEY_EXCHANGE);
+            initRequest.setCommitPhase(CommitPhase.ON_KEY_EXCHANGE);
             powerAuthClient.initActivation(initRequest);
         });
     }
 
-    public static void wrongActivationInitParamTest2(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config, PowerAuthVersion version) {
-        assertThrows(PowerAuthClientException.class, () -> {
-            // Init activation
-            InitActivationRequest initRequest = new InitActivationRequest();
-            initRequest.setApplicationId(config.getApplicationId());
-            initRequest.setUserId(config.getUser(version));
-            initRequest.setMaxFailureCount(5L);
-            // Set ON_COMMIT but no OTP
-            initRequest.setActivationOtpValidation(ActivationOtpValidation.ON_COMMIT);
-            powerAuthClient.initActivation(initRequest);
-        });
-    }
-
-    public static void wrongActivationInitParamTest3(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config, PowerAuthVersion version) {
-        assertThrows(PowerAuthClientException.class, () -> {
-            // Init activation
-            InitActivationRequest initRequest = new InitActivationRequest();
-            initRequest.setApplicationId(config.getApplicationId());
-            initRequest.setUserId(config.getUser(version));
-            initRequest.setMaxFailureCount(5L);
-            // Set ON_KEY_EXCHANGE but empty OTP
-            initRequest.setActivationOtpValidation(ActivationOtpValidation.ON_KEY_EXCHANGE);
-            initRequest.setActivationOtp("");
-            powerAuthClient.initActivation(initRequest);
-        });
-    }
-
-    public static void wrongActivationInitParamTest4(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config, PowerAuthVersion version) {
-        assertThrows(PowerAuthClientException.class, () -> {
-            // Init activation
-            InitActivationRequest initRequest = new InitActivationRequest();
-            initRequest.setApplicationId(config.getApplicationId());
-            initRequest.setUserId(config.getUser(version));
-            initRequest.setMaxFailureCount(5L);
-            // Set ON_COMMIT but empty OTP
-            initRequest.setActivationOtpValidation(ActivationOtpValidation.ON_COMMIT);
-            initRequest.setActivationOtp("");
-            powerAuthClient.initActivation(initRequest);
-        });
-    }
-
-    public static void missingOtpOnCommitTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
-                                              PrepareActivationStepModel model, String validOtpValue, PowerAuthVersion version) throws Exception {
-
-        final JSONObject resultStatusObject = new JSONObject();
-
-        // Init activation
-        InitActivationRequest initRequest = new InitActivationRequest();
-        initRequest.setApplicationId(config.getApplicationId());
-        initRequest.setUserId(config.getUser(version));
-        initRequest.setMaxFailureCount(5L);
-        initRequest.setActivationOtpValidation(ActivationOtpValidation.ON_COMMIT);
-        initRequest.setActivationOtp(validOtpValue);
-        InitActivationResponse initResponse = powerAuthClient.initActivation(initRequest);
-
-        // Prepare activation
-        model.setActivationCode(initResponse.getActivationCode());
-        model.setResultStatusObject(resultStatusObject);
-        ObjectStepLogger stepLoggerPrepare = new ObjectStepLogger(System.out);
-        new PrepareActivationStep().execute(stepLoggerPrepare, model.toMap());
-        assertTrue(stepLoggerPrepare.getResult().success());
-        assertEquals(200, stepLoggerPrepare.getResponse().statusCode());
-
-        // Verify activation status
-        GetActivationStatusResponse activationStatusResponse = powerAuthClient.getActivationStatus(initResponse.getActivationId());
-        assertEquals(ActivationStatus.PENDING_COMMIT, activationStatusResponse.getActivationStatus());
-
-        // Try commit with no OTP for more than max failed attempts. Use OTP in the last iteration, that should pass.
-        for (int iteration = 1; iteration <= 6; iteration++) {
-            boolean lastIteration = iteration == 6;
-            boolean isActivated;
-            try {
-                CommitActivationRequest commitRequest = new CommitActivationRequest();
-                commitRequest.setActivationId(initResponse.getActivationId());
-                if (lastIteration) {
-                    commitRequest.setActivationOtp(validOtpValue);
-                }
-                CommitActivationResponse commitResponse = powerAuthClient.commitActivation(commitRequest);
-                isActivated = commitResponse.isActivated();
-            } catch (PowerAuthClientException ex) {
-                isActivated = false;
-            }
-            assertEquals(lastIteration, isActivated);
-
-            // Verify activation status again
-            ActivationStatus expectedActivationStatus = lastIteration ? ActivationStatus.ACTIVE : ActivationStatus.PENDING_COMMIT;
-            activationStatusResponse = powerAuthClient.getActivationStatus(initResponse.getActivationId());
-            assertEquals(expectedActivationStatus, activationStatusResponse.getActivationStatus());
-        }
-
-        // Remove activation
-        powerAuthClient.removeActivation(initResponse.getActivationId(), "test");
-    }
-
-    public static void missingOtpOnKeysExchangeTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
-                                                    PrepareActivationStepModel model, String validOtpValue, PowerAuthVersion version) throws Exception {
-
-        final JSONObject resultStatusObject = new JSONObject();
-
-        // Init activation
-        InitActivationRequest initRequest = new InitActivationRequest();
-        initRequest.setApplicationId(config.getApplicationId());
-        initRequest.setUserId(config.getUser(version));
-        initRequest.setMaxFailureCount(5L);
-        initRequest.setActivationOtpValidation(ActivationOtpValidation.ON_KEY_EXCHANGE);
-        initRequest.setActivationOtp(validOtpValue);
-        InitActivationResponse initResponse = powerAuthClient.initActivation(initRequest);
-
-        // Prepare activation
-        model.setActivationCode(initResponse.getActivationCode());
-        model.setResultStatusObject(resultStatusObject);
-        model.setAdditionalActivationOtp(null);
-        ObjectStepLogger stepLoggerPrepare = new ObjectStepLogger(System.out);
-        new PrepareActivationStep().execute(stepLoggerPrepare, model.toMap());
-        assertFalse(stepLoggerPrepare.getResult().success());
-        assertEquals(400, stepLoggerPrepare.getResponse().statusCode());
-    }
 }

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthActivationFlagsShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthActivationFlagsShared.java
@@ -146,7 +146,6 @@ public class PowerAuthActivationFlagsShared {
         model.setActivationName("test v" + version);
         model.setApplicationKey(config.getApplicationKey());
         model.setApplicationSecret(config.getApplicationSecret());
-        model.setMasterPublicKeyP256(config.getMasterPublicKeyP256());
         model.setMasterPublicKeyP384(config.getMasterPublicKeyP384());
         model.setMasterPublicKeyMlDsa65(config.getMasterPublicKeyMlDsa65());
         model.setHeaders(new HashMap<>());

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthActivationFlagsShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthActivationFlagsShared.java
@@ -15,21 +15,25 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.wultra.security.powerauth.test.shared;
+package com.wultra.security.powerauth.test.shared.v4;
 
-import com.wultra.security.powerauth.client.model.response.v3.GetActivationStatusResponse;
-import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.client.model.request.InitActivationRequest;
 import com.wultra.security.powerauth.client.model.request.LookupActivationsRequest;
-import com.wultra.security.powerauth.client.model.response.*;
+import com.wultra.security.powerauth.client.model.response.CommitActivationResponse;
+import com.wultra.security.powerauth.client.model.response.InitActivationResponse;
+import com.wultra.security.powerauth.client.model.response.ListActivationFlagsResponse;
+import com.wultra.security.powerauth.client.model.response.LookupActivationsResponse;
+import com.wultra.security.powerauth.client.model.response.v4.GetActivationStatusResponse;
+import com.wultra.security.powerauth.client.v4.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
+import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
-import com.wultra.security.powerauth.lib.cmd.steps.model.CreateActivationStepModel;
-import com.wultra.security.powerauth.lib.cmd.steps.model.PrepareActivationStepModel;
 import com.wultra.security.powerauth.lib.cmd.steps.CreateActivationStep;
 import com.wultra.security.powerauth.lib.cmd.steps.PrepareActivationStep;
-import com.wultra.security.powerauth.rest.api.model.response.v3.ActivationLayer2Response;
+import com.wultra.security.powerauth.lib.cmd.steps.model.CreateActivationStepModel;
+import com.wultra.security.powerauth.lib.cmd.steps.model.PrepareActivationStepModel;
+import com.wultra.security.powerauth.rest.api.model.response.v4.ActivationLayer2Response;
 
 import java.io.File;
 import java.util.*;
@@ -143,11 +147,14 @@ public class PowerAuthActivationFlagsShared {
         model.setApplicationKey(config.getApplicationKey());
         model.setApplicationSecret(config.getApplicationSecret());
         model.setMasterPublicKeyP256(config.getMasterPublicKeyP256());
+        model.setMasterPublicKeyP384(config.getMasterPublicKeyP384());
+        model.setMasterPublicKeyMlDsa65(config.getMasterPublicKeyMlDsa65());
         model.setHeaders(new HashMap<>());
         model.setPassword(config.getPassword());
         model.setStatusFileName(tempStatusFile.getAbsolutePath());
         model.setResultStatusObject(config.getResultStatusObject(version));
         model.setUriString("http://localhost:" + port);
+        model.setSharedSecretAlgorithm(SharedSecretAlgorithm.EC_P384_ML_L3);
         model.setVersion(version);
         model.setDeviceInfo("backend-tests");
 

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthActivationOtpShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthActivationOtpShared.java
@@ -47,7 +47,7 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 public class PowerAuthActivationOtpShared {
 
-    public static void validOtpOnKeysExchangeTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
+    public static void validOtpOnKeyExchangeTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
                                                   PrepareActivationStepModel model, String validOtpValue, PowerAuthVersion version) throws Exception {
 
         final JSONObject resultStatusObject = new JSONObject();
@@ -79,7 +79,7 @@ public class PowerAuthActivationOtpShared {
         powerAuthClient.removeActivation(initResponse.getActivationId(), "test");
     }
 
-    public static void invalidOtpOnKeysExchangeTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
+    public static void invalidOtpOnKeyExchangeTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
                                                     PrepareActivationStepModel model, String validOtpValue,
                                                     String invalidOtpValue, PowerAuthVersion version) throws Exception {
 
@@ -439,7 +439,7 @@ public class PowerAuthActivationOtpShared {
         powerAuthClient.removeActivation(initResponse.getActivationId(), "test");
     }
 
-    public static void missingOtpOnKeysExchangeTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
+    public static void missingOtpOnKeyExchangeTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
                                                     PrepareActivationStepModel model, String validOtpValue, PowerAuthVersion version) throws Exception {
 
         final JSONObject resultStatusObject = new JSONObject();

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthActivationOtpShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthActivationOtpShared.java
@@ -1,0 +1,465 @@
+/*
+ * PowerAuth test and related software components
+ * Copyright (C) 2023 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.security.powerauth.test.shared.v4;
+
+import com.wultra.security.powerauth.client.model.enumeration.ActivationOtpValidation;
+import com.wultra.security.powerauth.client.model.enumeration.ActivationStatus;
+import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
+import com.wultra.security.powerauth.client.model.request.CommitActivationRequest;
+import com.wultra.security.powerauth.client.model.request.InitActivationRequest;
+import com.wultra.security.powerauth.client.model.response.CommitActivationResponse;
+import com.wultra.security.powerauth.client.model.response.InitActivationResponse;
+import com.wultra.security.powerauth.client.model.response.v4.GetActivationStatusResponse;
+import com.wultra.security.powerauth.client.v4.PowerAuthClient;
+import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
+import com.wultra.security.powerauth.crypto.lib.model.ActivationStatusBlobInfo;
+import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
+import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
+import com.wultra.security.powerauth.lib.cmd.steps.GetStatusStep;
+import com.wultra.security.powerauth.lib.cmd.steps.PrepareActivationStep;
+import com.wultra.security.powerauth.lib.cmd.steps.model.GetStatusStepModel;
+import com.wultra.security.powerauth.lib.cmd.steps.model.PrepareActivationStepModel;
+import org.json.simple.JSONObject;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * PowerAuth activation OTP test shared logic.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class PowerAuthActivationOtpShared {
+
+    public static void validOtpOnKeysExchangeTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
+                                                  PrepareActivationStepModel model, String validOtpValue, PowerAuthVersion version) throws Exception {
+
+        final JSONObject resultStatusObject = new JSONObject();
+
+        // Init activation
+        final InitActivationRequest initRequest = new InitActivationRequest();
+        initRequest.setApplicationId(config.getApplicationId());
+        initRequest.setUserId(config.getUser(version));
+        initRequest.setMaxFailureCount(5L);
+        initRequest.setActivationOtpValidation(ActivationOtpValidation.ON_KEY_EXCHANGE);
+        initRequest.setActivationOtp(validOtpValue);
+        final InitActivationResponse initResponse = powerAuthClient.initActivation(initRequest);
+
+        // Prepare activation
+        model.setActivationCode(initResponse.getActivationCode());
+        model.setResultStatusObject(resultStatusObject);
+        model.setAdditionalActivationOtp(validOtpValue);
+        ObjectStepLogger stepLoggerPrepare = new ObjectStepLogger(System.out);
+        new PrepareActivationStep().execute(stepLoggerPrepare, model.toMap());
+        assertTrue(stepLoggerPrepare.getResult().success());
+        assertEquals(200, stepLoggerPrepare.getResponse().statusCode());
+
+        // Verify activation status
+        final GetActivationStatusResponse activationStatusResponse = powerAuthClient.getActivationStatus(initResponse.getActivationId());
+        assertNotNull(activationStatusResponse);
+        assertEquals(ActivationStatus.ACTIVE, activationStatusResponse.getActivationStatus());
+
+        // Remove activation
+        powerAuthClient.removeActivation(initResponse.getActivationId(), "test");
+    }
+
+    public static void invalidOtpOnKeysExchangeTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
+                                                    PrepareActivationStepModel model, String validOtpValue,
+                                                    String invalidOtpValue, PowerAuthVersion version) throws Exception {
+
+        final JSONObject resultStatusObject = new JSONObject();
+
+        // Init activation
+        InitActivationRequest initRequest = new InitActivationRequest();
+        initRequest.setApplicationId(config.getApplicationId());
+        initRequest.setUserId(config.getUser(version));
+        initRequest.setMaxFailureCount(5L);
+        initRequest.setActivationOtpValidation(ActivationOtpValidation.ON_KEY_EXCHANGE);
+        initRequest.setActivationOtp(validOtpValue);
+        InitActivationResponse initResponse = powerAuthClient.initActivation(initRequest);
+
+        for (int iteration = 1; iteration <= 5; iteration++) {
+            final boolean lastIteration = iteration == 5;
+            // Prepare activation
+            model.setActivationCode(initResponse.getActivationCode());
+            model.setResultStatusObject(resultStatusObject);
+            model.setAdditionalActivationOtp(invalidOtpValue);
+            ObjectStepLogger stepLoggerPrepare = new ObjectStepLogger(System.out);
+            new PrepareActivationStep().execute(stepLoggerPrepare, model.toMap());
+            assertFalse(stepLoggerPrepare.getResult().success());
+            assertEquals(400, stepLoggerPrepare.getResponse().statusCode());
+
+            // Verify activation status
+            ActivationStatus expectedActivationStatus = lastIteration ? ActivationStatus.REMOVED : ActivationStatus.CREATED;
+            GetActivationStatusResponse activationStatusResponse = powerAuthClient.getActivationStatus(initResponse.getActivationId());
+            assertNotNull(activationStatusResponse);
+            assertEquals(expectedActivationStatus, activationStatusResponse.getActivationStatus());
+        }
+    }
+
+    public static void validOtpOnCommitTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config, PrepareActivationStepModel model,
+                                            String validOtpValue, String invalidOtpValue, PowerAuthVersion version) throws Exception {
+
+        final JSONObject resultStatusObject = new JSONObject();
+
+        // Init activation
+        InitActivationRequest initRequest = new InitActivationRequest();
+        initRequest.setApplicationId(config.getApplicationId());
+        initRequest.setUserId(config.getUser(version));
+        initRequest.setMaxFailureCount(5L);
+        initRequest.setActivationOtpValidation(ActivationOtpValidation.ON_COMMIT);
+        initRequest.setActivationOtp(validOtpValue);
+        InitActivationResponse initResponse = powerAuthClient.initActivation(initRequest);
+
+        // Prepare activation
+        model.setActivationCode(initResponse.getActivationCode());
+        model.setResultStatusObject(resultStatusObject);
+        ObjectStepLogger stepLoggerPrepare = new ObjectStepLogger(System.out);
+        new PrepareActivationStep().execute(stepLoggerPrepare, model.toMap());
+        assertTrue(stepLoggerPrepare.getResult().success());
+        assertEquals(200, stepLoggerPrepare.getResponse().statusCode());
+
+        // Verify activation status
+        GetActivationStatusResponse activationStatusResponse = powerAuthClient.getActivationStatus(initResponse.getActivationId());
+        assertNotNull(activationStatusResponse);
+        assertEquals(ActivationStatus.PENDING_COMMIT, activationStatusResponse.getActivationStatus());
+
+        // Try commit activation with wrong OTP. Last attempt is valid.
+        for (int iteration = 1; iteration <= 5; iteration++) {
+            boolean lastIteration = iteration == 5;
+            final CommitActivationRequest commitRequest = new CommitActivationRequest();
+            commitRequest.setActivationId(initResponse.getActivationId());
+            commitRequest.setActivationOtp(lastIteration ? validOtpValue : invalidOtpValue);
+
+            boolean isActivated;
+            try {
+                final CommitActivationResponse commitResponse = powerAuthClient.commitActivation(commitRequest);
+                isActivated = commitResponse.isActivated();
+            } catch (PowerAuthClientException ex) {
+                isActivated = false;
+            }
+            assertEquals(lastIteration, isActivated);
+
+            // Verify activation status
+            activationStatusResponse = powerAuthClient.getActivationStatus(initResponse.getActivationId());
+            assertEquals(lastIteration ? ActivationStatus.ACTIVE : ActivationStatus.PENDING_COMMIT, activationStatusResponse.getActivationStatus());
+        }
+
+        // Remove activation
+        powerAuthClient.removeActivation(initResponse.getActivationId(), "test");
+    }
+
+    public static void invalidOtpOnCommitTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
+                                              PrepareActivationStepModel model, String validOtpValue,
+                                              String invalidOtpValue, PowerAuthVersion version) throws Exception {
+
+        final JSONObject resultStatusObject = new JSONObject();
+
+        // Init activation
+        InitActivationRequest initRequest = new InitActivationRequest();
+        initRequest.setApplicationId(config.getApplicationId());
+        initRequest.setUserId(config.getUser(version));
+        initRequest.setMaxFailureCount(5L);
+        initRequest.setActivationOtpValidation(ActivationOtpValidation.ON_COMMIT);
+        initRequest.setActivationOtp(validOtpValue);
+        InitActivationResponse initResponse = powerAuthClient.initActivation(initRequest);
+
+        // Prepare activation
+        model.setActivationCode(initResponse.getActivationCode());
+        model.setResultStatusObject(resultStatusObject);
+        ObjectStepLogger stepLoggerPrepare = new ObjectStepLogger(System.out);
+        new PrepareActivationStep().execute(stepLoggerPrepare, model.toMap());
+        assertTrue(stepLoggerPrepare.getResult().success());
+        assertEquals(200, stepLoggerPrepare.getResponse().statusCode());
+
+        // Verify activation status
+        GetActivationStatusResponse activationStatusResponse = powerAuthClient.getActivationStatus(initResponse.getActivationId());
+        assertNotNull(activationStatusResponse);
+        assertEquals(ActivationStatus.PENDING_COMMIT, activationStatusResponse.getActivationStatus());
+
+        // Try commit activation with wrong OTP. Last attempt is valid.
+        for (int iteration = 1; iteration <= 5; iteration++) {
+            boolean lastIteration = iteration == 5;
+            CommitActivationRequest commitRequest = new CommitActivationRequest();
+            commitRequest.setActivationId(initResponse.getActivationId());
+            commitRequest.setActivationOtp(invalidOtpValue);
+
+            boolean isActivated;
+            try {
+                CommitActivationResponse commitResponse = powerAuthClient.commitActivation(commitRequest);
+                isActivated = commitResponse.isActivated();
+            } catch (PowerAuthClientException ex) {
+                isActivated = false;
+            }
+            assertFalse(isActivated);
+
+            // Verify activation status
+            ActivationStatus expectedActivationStatus = lastIteration ? ActivationStatus.REMOVED : ActivationStatus.PENDING_COMMIT;
+            activationStatusResponse = powerAuthClient.getActivationStatus(initResponse.getActivationId());
+            assertEquals(expectedActivationStatus, activationStatusResponse.getActivationStatus());
+        }
+    }
+
+    public static void updateValidOtpOnCommitTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
+                                                  PrepareActivationStepModel model, GetStatusStepModel statusModel,
+                                                  String validOtpValue, String invalidOtpValue, PowerAuthVersion version) throws Exception {
+
+        final JSONObject resultStatusObject = new JSONObject();
+
+        // Init activation
+        InitActivationRequest initRequest = new InitActivationRequest();
+        initRequest.setApplicationId(config.getApplicationId());
+        initRequest.setUserId(config.getUser(version));
+        initRequest.setMaxFailureCount(5L);
+        InitActivationResponse initResponse = powerAuthClient.initActivation(initRequest);
+
+        // Prepare activation
+        model.setActivationCode(initResponse.getActivationCode());
+        model.setResultStatusObject(resultStatusObject);
+        ObjectStepLogger stepLoggerPrepare = new ObjectStepLogger(System.out);
+        new PrepareActivationStep().execute(stepLoggerPrepare, model.toMap());
+        assertTrue(stepLoggerPrepare.getResult().success());
+        assertEquals(200, stepLoggerPrepare.getResponse().statusCode());
+
+        // Verify activation status
+        GetActivationStatusResponse activationStatusResponse = powerAuthClient.getActivationStatus(initResponse.getActivationId());
+        assertEquals(ActivationStatus.PENDING_COMMIT, activationStatusResponse.getActivationStatus());
+
+        // Update OTP
+        powerAuthClient.updateActivationOtp(initResponse.getActivationId(), null, validOtpValue);
+
+        // Try commit activation with wrong OTP. Last attempt is valid.
+        for (int iteration = 1; iteration <= 5; iteration++) {
+            boolean lastIteration = iteration == 5;
+            boolean isActivated;
+            try {
+                CommitActivationRequest commitRequest = new CommitActivationRequest();
+                commitRequest.setActivationId(initResponse.getActivationId());
+                commitRequest.setActivationOtp(lastIteration ? validOtpValue : invalidOtpValue);
+                CommitActivationResponse commitResponse = powerAuthClient.commitActivation(commitRequest);
+                isActivated = commitResponse.isActivated();
+            } catch (PowerAuthClientException ex) {
+                isActivated = false;
+            }
+            assertEquals(lastIteration, isActivated);
+
+            // Verify activation status
+            ActivationStatus expectedActivationStatus = lastIteration ? ActivationStatus.ACTIVE : ActivationStatus.PENDING_COMMIT;
+            activationStatusResponse = powerAuthClient.getActivationStatus(initResponse.getActivationId());
+            assertEquals(expectedActivationStatus, activationStatusResponse.getActivationStatus());
+        }
+
+        // Try to get activation status via RESTful API
+        ObjectStepLogger stepLoggerStatus = new ObjectStepLogger(System.out);
+        statusModel.setResultStatusObject(resultStatusObject);
+        new GetStatusStep().execute(stepLoggerStatus, statusModel.toMap());
+        assertTrue(stepLoggerStatus.getResult().success());
+        assertEquals(200, stepLoggerStatus.getResponse().statusCode());
+
+        // Validate failed and max failed attempts.
+        final Map<String, Object> statusResponseMap = (Map<String, Object>) stepLoggerStatus.getFirstItem("activation-status-obtained").object();
+        ActivationStatusBlobInfo statusBlobInfo = (ActivationStatusBlobInfo) statusResponseMap.get("statusBlob");
+        assertEquals(5L, statusBlobInfo.getMaxFailedAttempts());
+        assertEquals(0L, statusBlobInfo.getFailedAttempts());
+
+        // Remove activation
+        powerAuthClient.removeActivation(initResponse.getActivationId(), "test");
+    }
+
+    public static void updateInvalidOtpOnCommitTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
+                                                    PrepareActivationStepModel model, String validOtpValue,
+                                                    String invalidOtpValue, PowerAuthVersion version) throws Exception {
+
+        final JSONObject resultStatusObject = new JSONObject();
+
+        // Init activation
+        InitActivationRequest initRequest = new InitActivationRequest();
+        initRequest.setApplicationId(config.getApplicationId());
+        initRequest.setUserId(config.getUser(version));
+        initRequest.setMaxFailureCount(5L);
+        InitActivationResponse initResponse = powerAuthClient.initActivation(initRequest);
+
+        // Prepare activation
+        model.setActivationCode(initResponse.getActivationCode());
+        model.setResultStatusObject(resultStatusObject);
+        ObjectStepLogger stepLoggerPrepare = new ObjectStepLogger(System.out);
+        new PrepareActivationStep().execute(stepLoggerPrepare, model.toMap());
+        assertTrue(stepLoggerPrepare.getResult().success());
+        assertEquals(200, stepLoggerPrepare.getResponse().statusCode());
+
+        // Verify activation status
+        GetActivationStatusResponse activationStatusResponse = powerAuthClient.getActivationStatus(initResponse.getActivationId());
+        assertEquals(ActivationStatus.PENDING_COMMIT, activationStatusResponse.getActivationStatus());
+
+        // Update OTP
+        powerAuthClient.updateActivationOtp(initResponse.getActivationId(), null, validOtpValue);
+
+        // Try commit activation with wrong OTP. Last attempt is valid.
+        for (int iteration = 1; iteration <= 5; iteration++) {
+            boolean lastIteration = iteration == 5;
+            boolean isActivated;
+            try {
+                CommitActivationRequest commitRequest = new CommitActivationRequest();
+                commitRequest.setActivationId(initResponse.getActivationId());
+                commitRequest.setActivationOtp(invalidOtpValue);
+                CommitActivationResponse commitResponse = powerAuthClient.commitActivation(commitRequest);
+                isActivated = commitResponse.isActivated();
+            } catch (PowerAuthClientException ex) {
+                isActivated = false;
+            }
+            assertFalse(isActivated);
+
+            // Verify activation status
+            ActivationStatus expectedActivationStatus = lastIteration ? ActivationStatus.REMOVED : ActivationStatus.PENDING_COMMIT;
+            activationStatusResponse = powerAuthClient.getActivationStatus(initResponse.getActivationId());
+            assertEquals(expectedActivationStatus, activationStatusResponse.getActivationStatus());
+        }
+    }
+
+    public static void wrongActivationInitParamTest1(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config, PowerAuthVersion version) {
+        assertThrows(PowerAuthClientException.class, () -> {
+            // Init activation
+            InitActivationRequest initRequest = new InitActivationRequest();
+            initRequest.setApplicationId(config.getApplicationId());
+            initRequest.setUserId(config.getUser(version));
+            initRequest.setMaxFailureCount(5L);
+            // Set ON_KEY_EXCHANGE but no OTP
+            initRequest.setActivationOtpValidation(ActivationOtpValidation.ON_KEY_EXCHANGE);
+            powerAuthClient.initActivation(initRequest);
+        });
+    }
+
+    public static void wrongActivationInitParamTest2(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config, PowerAuthVersion version) {
+        assertThrows(PowerAuthClientException.class, () -> {
+            // Init activation
+            InitActivationRequest initRequest = new InitActivationRequest();
+            initRequest.setApplicationId(config.getApplicationId());
+            initRequest.setUserId(config.getUser(version));
+            initRequest.setMaxFailureCount(5L);
+            // Set ON_COMMIT but no OTP
+            initRequest.setActivationOtpValidation(ActivationOtpValidation.ON_COMMIT);
+            powerAuthClient.initActivation(initRequest);
+        });
+    }
+
+    public static void wrongActivationInitParamTest3(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config, PowerAuthVersion version) {
+        assertThrows(PowerAuthClientException.class, () -> {
+            // Init activation
+            InitActivationRequest initRequest = new InitActivationRequest();
+            initRequest.setApplicationId(config.getApplicationId());
+            initRequest.setUserId(config.getUser(version));
+            initRequest.setMaxFailureCount(5L);
+            // Set ON_KEY_EXCHANGE but empty OTP
+            initRequest.setActivationOtpValidation(ActivationOtpValidation.ON_KEY_EXCHANGE);
+            initRequest.setActivationOtp("");
+            powerAuthClient.initActivation(initRequest);
+        });
+    }
+
+    public static void wrongActivationInitParamTest4(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config, PowerAuthVersion version) {
+        assertThrows(PowerAuthClientException.class, () -> {
+            // Init activation
+            InitActivationRequest initRequest = new InitActivationRequest();
+            initRequest.setApplicationId(config.getApplicationId());
+            initRequest.setUserId(config.getUser(version));
+            initRequest.setMaxFailureCount(5L);
+            // Set ON_COMMIT but empty OTP
+            initRequest.setActivationOtpValidation(ActivationOtpValidation.ON_COMMIT);
+            initRequest.setActivationOtp("");
+            powerAuthClient.initActivation(initRequest);
+        });
+    }
+
+    public static void missingOtpOnCommitTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
+                                              PrepareActivationStepModel model, String validOtpValue, PowerAuthVersion version) throws Exception {
+
+        final JSONObject resultStatusObject = new JSONObject();
+
+        // Init activation
+        InitActivationRequest initRequest = new InitActivationRequest();
+        initRequest.setApplicationId(config.getApplicationId());
+        initRequest.setUserId(config.getUser(version));
+        initRequest.setMaxFailureCount(5L);
+        initRequest.setActivationOtpValidation(ActivationOtpValidation.ON_COMMIT);
+        initRequest.setActivationOtp(validOtpValue);
+        InitActivationResponse initResponse = powerAuthClient.initActivation(initRequest);
+
+        // Prepare activation
+        model.setActivationCode(initResponse.getActivationCode());
+        model.setResultStatusObject(resultStatusObject);
+        ObjectStepLogger stepLoggerPrepare = new ObjectStepLogger(System.out);
+        new PrepareActivationStep().execute(stepLoggerPrepare, model.toMap());
+        assertTrue(stepLoggerPrepare.getResult().success());
+        assertEquals(200, stepLoggerPrepare.getResponse().statusCode());
+
+        // Verify activation status
+        GetActivationStatusResponse activationStatusResponse = powerAuthClient.getActivationStatus(initResponse.getActivationId());
+        assertEquals(ActivationStatus.PENDING_COMMIT, activationStatusResponse.getActivationStatus());
+
+        // Try commit with no OTP for more than max failed attempts. Use OTP in the last iteration, that should pass.
+        for (int iteration = 1; iteration <= 6; iteration++) {
+            boolean lastIteration = iteration == 6;
+            boolean isActivated;
+            try {
+                CommitActivationRequest commitRequest = new CommitActivationRequest();
+                commitRequest.setActivationId(initResponse.getActivationId());
+                if (lastIteration) {
+                    commitRequest.setActivationOtp(validOtpValue);
+                }
+                CommitActivationResponse commitResponse = powerAuthClient.commitActivation(commitRequest);
+                isActivated = commitResponse.isActivated();
+            } catch (PowerAuthClientException ex) {
+                isActivated = false;
+            }
+            assertEquals(lastIteration, isActivated);
+
+            // Verify activation status again
+            ActivationStatus expectedActivationStatus = lastIteration ? ActivationStatus.ACTIVE : ActivationStatus.PENDING_COMMIT;
+            activationStatusResponse = powerAuthClient.getActivationStatus(initResponse.getActivationId());
+            assertEquals(expectedActivationStatus, activationStatusResponse.getActivationStatus());
+        }
+
+        // Remove activation
+        powerAuthClient.removeActivation(initResponse.getActivationId(), "test");
+    }
+
+    public static void missingOtpOnKeysExchangeTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
+                                                    PrepareActivationStepModel model, String validOtpValue, PowerAuthVersion version) throws Exception {
+
+        final JSONObject resultStatusObject = new JSONObject();
+
+        // Init activation
+        InitActivationRequest initRequest = new InitActivationRequest();
+        initRequest.setApplicationId(config.getApplicationId());
+        initRequest.setUserId(config.getUser(version));
+        initRequest.setMaxFailureCount(5L);
+        initRequest.setActivationOtpValidation(ActivationOtpValidation.ON_KEY_EXCHANGE);
+        initRequest.setActivationOtp(validOtpValue);
+        InitActivationResponse initResponse = powerAuthClient.initActivation(initRequest);
+
+        // Prepare activation
+        model.setActivationCode(initResponse.getActivationCode());
+        model.setResultStatusObject(resultStatusObject);
+        model.setAdditionalActivationOtp(null);
+        ObjectStepLogger stepLoggerPrepare = new ObjectStepLogger(System.out);
+        new PrepareActivationStep().execute(stepLoggerPrepare, model.toMap());
+        assertFalse(stepLoggerPrepare.getResult().success());
+        assertEquals(400, stepLoggerPrepare.getResponse().statusCode());
+    }
+}

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthActivationShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthActivationShared.java
@@ -30,7 +30,6 @@ import com.wultra.security.powerauth.client.model.response.v4.GetActivationStatu
 import com.wultra.security.powerauth.client.model.response.v4.GetApplicationDetailResponse;
 import com.wultra.security.powerauth.client.v4.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.crypto.client.activation.PowerAuthClientActivation;
 import com.wultra.security.powerauth.crypto.lib.enums.EcCurve;
 import com.wultra.security.powerauth.crypto.lib.generator.KeyGenerator;
 import com.wultra.security.powerauth.crypto.lib.model.ActivationStatusBlobInfo;
@@ -42,7 +41,6 @@ import com.wultra.security.powerauth.lib.cmd.steps.GetStatusStep;
 import com.wultra.security.powerauth.lib.cmd.steps.PrepareActivationStep;
 import com.wultra.security.powerauth.lib.cmd.steps.model.GetStatusStepModel;
 import com.wultra.security.powerauth.lib.cmd.steps.model.PrepareActivationStepModel;
-import com.wultra.security.powerauth.test.shared.util.ResponseVerificationUtil;
 import org.json.simple.JSONObject;
 import org.junit.jupiter.api.AssertionFailureBuilder;
 
@@ -172,7 +170,8 @@ public class PowerAuthActivationShared {
         ObjectMapper objectMapper = config.getObjectMapper();
         final ErrorResponse errorResponse = objectMapper.readValue(stepLoggerPrepare.getResponse().responseObject().toString(), ErrorResponse.class);
         assertEquals("ERROR", errorResponse.getStatus());
-        ResponseVerificationUtil.verifyErrorResponse(model, errorResponse);
+        assertEquals("ERR_TEMPORARY_KEY", errorResponse.getResponseObject().getCode());
+        assertEquals("POWER_AUTH_TEMPORARY_KEY_FAILURE", errorResponse.getResponseObject().getMessage());
 
         // Support application version
         powerAuthClient.supportApplicationVersion(config.getApplicationId(), config.getApplicationVersionId());
@@ -371,7 +370,8 @@ public class PowerAuthActivationShared {
         ObjectMapper objectMapper = config.getObjectMapper();
         final ErrorResponse errorResponse = objectMapper.readValue(stepLoggerPrepare.getResponse().responseObject().toString(), ErrorResponse.class);
         assertEquals("ERROR", errorResponse.getStatus());
-        ResponseVerificationUtil.verifyErrorResponse(model, errorResponse);
+        assertEquals("ERR_TEMPORARY_KEY", errorResponse.getResponseObject().getCode());
+        assertEquals("POWER_AUTH_TEMPORARY_KEY_FAILURE", errorResponse.getResponseObject().getMessage());
     }
 
     public static void activationInvalidApplicationSecretTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
@@ -401,7 +401,8 @@ public class PowerAuthActivationShared {
         ObjectMapper objectMapper = config.getObjectMapper();
         final ErrorResponse errorResponse = objectMapper.readValue(stepLoggerPrepare.getResponse().responseObject().toString(), ErrorResponse.class);
         assertEquals("ERROR", errorResponse.getStatus());
-        ResponseVerificationUtil.verifyErrorResponse(model, errorResponse);
+        assertEquals("ERR_TEMPORARY_KEY", errorResponse.getResponseObject().getCode());
+        assertEquals("POWER_AUTH_TEMPORARY_KEY_FAILURE", errorResponse.getResponseObject().getMessage());
     }
 
     public static void lookupActivationsTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config, PowerAuthVersion version) throws Exception {

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthActivationShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthActivationShared.java
@@ -30,22 +30,21 @@ import com.wultra.security.powerauth.client.model.response.v4.GetActivationStatu
 import com.wultra.security.powerauth.client.model.response.v4.GetApplicationDetailResponse;
 import com.wultra.security.powerauth.client.v4.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.crypto.lib.enums.EcCurve;
-import com.wultra.security.powerauth.crypto.lib.generator.KeyGenerator;
+import com.wultra.security.powerauth.crypto.client.v4.activation.PowerAuthClientActivation;
 import com.wultra.security.powerauth.crypto.lib.model.ActivationStatusBlobInfo;
 import com.wultra.security.powerauth.crypto.lib.v4.encryptor.model.response.AeadEncryptedResponse;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
 import com.wultra.security.powerauth.lib.cmd.logging.model.StepItem;
+import com.wultra.security.powerauth.lib.cmd.steps.ConfirmActivationStep;
 import com.wultra.security.powerauth.lib.cmd.steps.GetStatusStep;
 import com.wultra.security.powerauth.lib.cmd.steps.PrepareActivationStep;
+import com.wultra.security.powerauth.lib.cmd.steps.model.ConfirmActivationStepModel;
 import com.wultra.security.powerauth.lib.cmd.steps.model.GetStatusStepModel;
 import com.wultra.security.powerauth.lib.cmd.steps.model.PrepareActivationStepModel;
 import org.json.simple.JSONObject;
 import org.junit.jupiter.api.AssertionFailureBuilder;
 
-import java.security.KeyPair;
-import java.security.PublicKey;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
@@ -78,7 +77,7 @@ public class PowerAuthActivationShared {
         assertTrue(stepLoggerPrepare.getResult().success());
         assertEquals(200, stepLoggerPrepare.getResponse().statusCode());
 
-        checkEncryptedResponse(version, stepLoggerPrepare.getResponse().responseObject());
+        checkEncryptedResponse(stepLoggerPrepare.getResponse().responseObject());
 
         // Verify decrypted activationId
         String activationIdPrepareResponse = null;
@@ -127,6 +126,67 @@ public class PowerAuthActivationShared {
         // Verify activation status
         GetActivationStatusResponse statusResponseRemoved = powerAuthClient.getActivationStatus(initResponse.getActivationId());
         assertEquals(ActivationStatus.REMOVED, statusResponseRemoved.getActivationStatus());
+    }
+
+    public static void activationConfirmTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
+                                             PrepareActivationStepModel model, PowerAuthVersion version, boolean enableBiometry) throws Exception {
+        // Init activation
+        final InitActivationRequest initRequest = new InitActivationRequest();
+        initRequest.setApplicationId(config.getApplicationId());
+        initRequest.setUserId(config.getUser(version));
+        final InitActivationResponse initResponse = powerAuthClient.initActivation(initRequest);
+
+        // Prepare activation
+        model.setActivationCode(initResponse.getActivationCode());
+        ObjectStepLogger stepLoggerPrepare = new ObjectStepLogger(System.out);
+        new PrepareActivationStep().execute(stepLoggerPrepare, model.toMap());
+        assertTrue(stepLoggerPrepare.getResult().success());
+        assertEquals(200, stepLoggerPrepare.getResponse().statusCode());
+
+        // Verify activation status including status bits
+        GetActivationStatusResponse statusResponseBeforeConfirm = powerAuthClient.getActivationStatus(initResponse.getActivationId());
+        assertEquals(ActivationStatus.PENDING_COMMIT, statusResponseBeforeConfirm.getActivationStatus());
+        byte[] statusBlob = Base64.getDecoder().decode(statusResponseBeforeConfirm.getStatusBlob());
+        ActivationStatusBlobInfo statusBlobInfo = new PowerAuthClientActivation().getStatusFromBlob(statusBlob);
+        assertTrue(statusBlobInfo.isValid());
+        // Status bits are set to 0001 (pending confirmation)
+        assertEquals(1, statusBlobInfo.getStatusFlags());
+
+        // Confirm activation
+        ConfirmActivationStepModel confirmModel = new ConfirmActivationStepModel();
+        confirmModel.setApplicationKey(config.getApplicationKey());
+        confirmModel.setApplicationSecret(config.getApplicationSecret());
+        confirmModel.setEnableBiometry(enableBiometry);
+        confirmModel.setPassword(config.getPassword());
+        confirmModel.setVersion(version);
+        confirmModel.setStatusFileName(model.getStatusFileName());
+        confirmModel.setResultStatusObject(model.getResultStatusObject());
+        confirmModel.setUriString(config.getPowerAuthIntegrationUrl());
+        ObjectStepLogger stepLoggerConfirm = new ObjectStepLogger(System.out);
+        new ConfirmActivationStep().execute(stepLoggerConfirm, confirmModel.toMap());
+        assertTrue(stepLoggerConfirm.getResult().success());
+
+        // Verify activation status including status bits
+        GetActivationStatusResponse statusResponseConfirmed = powerAuthClient.getActivationStatus(initResponse.getActivationId());
+        assertEquals(ActivationStatus.PENDING_COMMIT, statusResponseConfirmed.getActivationStatus());
+        byte[] statusBlobConfirmed = Base64.getDecoder().decode(statusResponseConfirmed.getStatusBlob());
+        ActivationStatusBlobInfo statusBlobInfoConfirmed = new PowerAuthClientActivation().getStatusFromBlob(statusBlobConfirmed);
+        assertTrue(statusBlobInfoConfirmed.isValid());
+        if (enableBiometry) {
+            // Status bits are 1000 (biometry enabled, confirmed)
+            assertEquals(8, statusBlobInfoConfirmed.getStatusFlags());
+        } else {
+            // Status bits are 0000 (biometry disabled, confirmed)
+            assertEquals(0, statusBlobInfoConfirmed.getStatusFlags());
+        }
+
+        // Commit activation
+        CommitActivationResponse commitResponse = powerAuthClient.commitActivation(initResponse.getActivationId(), "test");
+        assertEquals(initResponse.getActivationId(), commitResponse.getActivationId());
+
+        // Verify activation status
+        GetActivationStatusResponse statusResponseActive = powerAuthClient.getActivationStatus(initResponse.getActivationId());
+        assertEquals(ActivationStatus.ACTIVE, statusResponseActive.getActivationStatus());
     }
 
     public static void activationNonExistentTest(PowerAuthClient powerAuthClient) throws PowerAuthClientException {
@@ -214,40 +274,6 @@ public class PowerAuthActivationShared {
         assertEquals("POWER_AUTH_ACTIVATION_INVALID", errorResponse.getResponseObject().getMessage());
     }
 
-    public static void activationPrepareBadMasterPublicKeyTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
-                                                               PrepareActivationStepModel model, PowerAuthVersion version) throws Exception {
-        // Init activation
-        InitActivationRequest initRequest = new InitActivationRequest();
-        initRequest.setApplicationId(config.getApplicationId());
-        initRequest.setUserId(config.getUser(version));
-        InitActivationResponse initResponse = powerAuthClient.initActivation(initRequest);
-
-        // Verify activation status
-        GetActivationStatusResponse statusResponseCreated = powerAuthClient.getActivationStatus(initResponse.getActivationId());
-        assertEquals(ActivationStatus.CREATED, statusResponseCreated.getActivationStatus());
-
-        KeyPair keyPair = new KeyGenerator().generateKeyPair(EcCurve.P256);
-        PublicKey originalKey = model.getMasterPublicKeyP256();
-
-        // Prepare activation
-        model.setActivationCode(initResponse.getActivationCode());
-        model.setMasterPublicKeyP256(keyPair.getPublic());
-        ObjectStepLogger stepLoggerPrepare = new ObjectStepLogger(System.out);
-        new PrepareActivationStep().execute(stepLoggerPrepare, model.toMap());
-        assertFalse(stepLoggerPrepare.getResult().success());
-        assertEquals(400, stepLoggerPrepare.getResponse().statusCode());
-
-        // Verify error response
-        ObjectMapper objectMapper = config.getObjectMapper();
-        final ErrorResponse errorResponse = objectMapper.readValue(stepLoggerPrepare.getResponse().responseObject().toString(), ErrorResponse.class);
-        assertEquals("ERROR", errorResponse.getStatus());
-        assertEquals("ERR_ACTIVATION", errorResponse.getResponseObject().getCode());
-        assertEquals("POWER_AUTH_ACTIVATION_INVALID", errorResponse.getResponseObject().getMessage());
-
-        // Revert master public key change
-        model.setMasterPublicKeyP256(originalKey);
-    }
-
     public static void activationStatusTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
                                             PrepareActivationStepModel model, PowerAuthVersion version) throws Exception {
         final JSONObject resultStatusObject = new JSONObject();
@@ -267,7 +293,7 @@ public class PowerAuthActivationShared {
         assertTrue(stepLoggerPrepare.getResult().success());
         assertEquals(200, stepLoggerPrepare.getResponse().statusCode());
 
-        checkEncryptedResponse(version, stepLoggerPrepare.getResponse().responseObject());
+        checkEncryptedResponse(stepLoggerPrepare.getResponse().responseObject());
 
         // Verify activation status
         GetStatusStepModel statusModel = new GetStatusStepModel();
@@ -495,7 +521,7 @@ public class PowerAuthActivationShared {
         assertTrue(stepLoggerPrepare.getResult().success());
         assertEquals(200, stepLoggerPrepare.getResponse().statusCode());
 
-        checkEncryptedResponse(version, stepLoggerPrepare.getResponse().responseObject());
+        checkEncryptedResponse(stepLoggerPrepare.getResponse().responseObject());
 
         // Verify activation status
         GetStatusStepModel statusModel = new GetStatusStepModel();
@@ -531,7 +557,7 @@ public class PowerAuthActivationShared {
         assertEquals(ActivationStatus.ACTIVE, statusResponseActive.getActivationStatus());
     }
 
-    private static void checkEncryptedResponse(PowerAuthVersion version, Object response) {
+    private static void checkEncryptedResponse(Object response) {
         final AeadEncryptedResponse aeadResponse = (AeadEncryptedResponse) response;
         assertNotNull(aeadResponse.getEncryptedData());
         assertNotNull(aeadResponse.getTimestamp());

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthActivationShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthActivationShared.java
@@ -1,0 +1,539 @@
+/*
+ * PowerAuth test and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.security.powerauth.test.shared.v4;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wultra.core.rest.model.base.response.ErrorResponse;
+import com.wultra.security.powerauth.client.model.entity.Activation;
+import com.wultra.security.powerauth.client.model.entity.ApplicationVersion;
+import com.wultra.security.powerauth.client.model.enumeration.ActivationStatus;
+import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
+import com.wultra.security.powerauth.client.model.request.InitActivationRequest;
+import com.wultra.security.powerauth.client.model.request.LookupActivationsRequest;
+import com.wultra.security.powerauth.client.model.response.*;
+import com.wultra.security.powerauth.client.model.response.v4.GetActivationStatusResponse;
+import com.wultra.security.powerauth.client.model.response.v4.GetApplicationDetailResponse;
+import com.wultra.security.powerauth.client.v4.PowerAuthClient;
+import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
+import com.wultra.security.powerauth.crypto.client.activation.PowerAuthClientActivation;
+import com.wultra.security.powerauth.crypto.lib.enums.EcCurve;
+import com.wultra.security.powerauth.crypto.lib.generator.KeyGenerator;
+import com.wultra.security.powerauth.crypto.lib.model.ActivationStatusBlobInfo;
+import com.wultra.security.powerauth.crypto.lib.v4.encryptor.model.response.AeadEncryptedResponse;
+import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
+import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
+import com.wultra.security.powerauth.lib.cmd.logging.model.StepItem;
+import com.wultra.security.powerauth.lib.cmd.steps.GetStatusStep;
+import com.wultra.security.powerauth.lib.cmd.steps.PrepareActivationStep;
+import com.wultra.security.powerauth.lib.cmd.steps.model.GetStatusStepModel;
+import com.wultra.security.powerauth.lib.cmd.steps.model.PrepareActivationStepModel;
+import com.wultra.security.powerauth.test.shared.util.ResponseVerificationUtil;
+import org.json.simple.JSONObject;
+import org.junit.jupiter.api.AssertionFailureBuilder;
+
+import java.security.KeyPair;
+import java.security.PublicKey;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * PowerAuth activation test shared logic.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class PowerAuthActivationShared {
+
+    public static void activationPrepareTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
+                                             PrepareActivationStepModel model, PowerAuthVersion version) throws Exception {
+        // Init activation
+        final InitActivationRequest initRequest = new InitActivationRequest();
+        initRequest.setApplicationId(config.getApplicationId());
+        initRequest.setUserId(config.getUser(version));
+        final InitActivationResponse initResponse = powerAuthClient.initActivation(initRequest);
+
+        // Verify activation status
+        final GetActivationStatusResponse statusResponseCreated = powerAuthClient.getActivationStatus(initResponse.getActivationId());
+        assertEquals(ActivationStatus.CREATED, statusResponseCreated.getActivationStatus());
+
+        // Prepare activation
+        model.setActivationCode(initResponse.getActivationCode());
+        ObjectStepLogger stepLoggerPrepare = new ObjectStepLogger(System.out);
+        new PrepareActivationStep().execute(stepLoggerPrepare, model.toMap());
+        assertTrue(stepLoggerPrepare.getResult().success());
+        assertEquals(200, stepLoggerPrepare.getResponse().statusCode());
+
+        checkEncryptedResponse(version, stepLoggerPrepare.getResponse().responseObject());
+
+        // Verify decrypted activationId
+        String activationIdPrepareResponse = null;
+        for (StepItem item: stepLoggerPrepare.getItems()) {
+            if (item.name().equals("Activation Done")) {
+                final Map<String, Object> responseMap = (Map<String, Object>) item.object();
+                activationIdPrepareResponse = (String) responseMap.get("activationId");
+                break;
+            }
+        }
+
+        assertEquals(initResponse.getActivationId(), activationIdPrepareResponse);
+
+        // Verify activation status
+        GetActivationStatusResponse statusResponseOtpUsed = powerAuthClient.getActivationStatus(initResponse.getActivationId());
+        assertEquals(ActivationStatus.PENDING_COMMIT, statusResponseOtpUsed.getActivationStatus());
+
+        // Commit activation
+        CommitActivationResponse commitResponse = powerAuthClient.commitActivation(initResponse.getActivationId(), "test");
+        assertEquals(initResponse.getActivationId(), commitResponse.getActivationId());
+
+        // Verify activation status
+        GetActivationStatusResponse statusResponseActive = powerAuthClient.getActivationStatus(initResponse.getActivationId());
+        assertEquals(ActivationStatus.ACTIVE, statusResponseActive.getActivationStatus());
+
+        // Block activation
+        final BlockActivationResponse blockResponse = powerAuthClient.blockActivation(initResponse.getActivationId(), "test", "test");
+        assertEquals(initResponse.getActivationId(), blockResponse.getActivationId());
+        assertEquals("test", blockResponse.getBlockedReason());
+
+        // Verify activation status
+        GetActivationStatusResponse statusResponseBlocked = powerAuthClient.getActivationStatus(initResponse.getActivationId());
+        assertEquals(ActivationStatus.BLOCKED, statusResponseBlocked.getActivationStatus());
+
+        // Unblock activation
+        final UnblockActivationResponse unblockResponse = powerAuthClient.unblockActivation(initResponse.getActivationId(), "test");
+        assertEquals(initResponse.getActivationId(), unblockResponse.getActivationId());
+
+        // Verify activation status
+        GetActivationStatusResponse statusResponseActive2 = powerAuthClient.getActivationStatus(initResponse.getActivationId());
+        assertEquals(ActivationStatus.ACTIVE, statusResponseActive2.getActivationStatus());
+
+        // Remove activation
+        powerAuthClient.removeActivation(initResponse.getActivationId(), "test");
+
+        // Verify activation status
+        GetActivationStatusResponse statusResponseRemoved = powerAuthClient.getActivationStatus(initResponse.getActivationId());
+        assertEquals(ActivationStatus.REMOVED, statusResponseRemoved.getActivationStatus());
+    }
+
+    public static void activationNonExistentTest(PowerAuthClient powerAuthClient) throws PowerAuthClientException {
+        // Verify activation status
+        GetActivationStatusResponse statusResponse = powerAuthClient.getActivationStatus("AAAAA-BBBBB-CCCCC-DDDDD");
+        assertEquals(ActivationStatus.REMOVED, statusResponse.getActivationStatus());
+    }
+
+    public static void activationPrepareUnsupportedApplicationTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
+                                                                   PrepareActivationStepModel model, PowerAuthVersion version) throws Exception {
+        // Unsupport application version
+        powerAuthClient.unsupportApplicationVersion(config.getApplicationId(), config.getApplicationVersionId());
+
+        // Verify that application version is unsupported
+        final GetApplicationDetailResponse detailResponse = powerAuthClient.getApplicationDetail(config.getApplicationId());
+        for (ApplicationVersion appVersion: detailResponse.getVersions()) {
+            if (appVersion.getApplicationVersionId().equals(config.getApplicationVersion())) {
+                assertFalse(appVersion.isSupported());
+            }
+        }
+
+        // Init activation should not fail, because application version is not known (applicationKey is not sent in InitActivationRequest)
+        InitActivationRequest initRequest = new InitActivationRequest();
+        initRequest.setApplicationId(config.getApplicationId());
+        initRequest.setUserId(config.getUser(version));
+        InitActivationResponse initResponse = powerAuthClient.initActivation(initRequest);
+
+        // Verify activation status
+        GetActivationStatusResponse statusResponseCreated = powerAuthClient.getActivationStatus(initResponse.getActivationId());
+        assertEquals(ActivationStatus.CREATED, statusResponseCreated.getActivationStatus());
+
+        // PrepareActivation should fail
+        model.setActivationCode(initResponse.getActivationCode());
+        ObjectStepLogger stepLoggerPrepare = new ObjectStepLogger(System.out);
+        new PrepareActivationStep().execute(stepLoggerPrepare, model.toMap());
+        assertFalse(stepLoggerPrepare.getResult().success());
+        // Verify BAD_REQUEST status code
+        assertEquals(400, stepLoggerPrepare.getResponse().statusCode());
+
+        // Verify error response
+        ObjectMapper objectMapper = config.getObjectMapper();
+        final ErrorResponse errorResponse = objectMapper.readValue(stepLoggerPrepare.getResponse().responseObject().toString(), ErrorResponse.class);
+        assertEquals("ERROR", errorResponse.getStatus());
+        ResponseVerificationUtil.verifyErrorResponse(model, errorResponse);
+
+        // Support application version
+        powerAuthClient.supportApplicationVersion(config.getApplicationId(), config.getApplicationVersionId());
+
+        // Verify that application version is supported
+        GetApplicationDetailResponse detailResponse2 = powerAuthClient.getApplicationDetail(config.getApplicationId());
+        for (ApplicationVersion appVersion: detailResponse2.getVersions()) {
+            if (appVersion.getApplicationVersionId().equals(config.getApplicationVersion())) {
+                assertTrue(appVersion.isSupported());
+            }
+        }
+    }
+
+    public static void activationPrepareExpirationTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
+                                                       PrepareActivationStepModel model, PowerAuthVersion version) throws Exception {
+        // Init activation should not fail, because application version is not known (applicationKey is not sent in InitActivationRequest)
+        InitActivationRequest initRequest = new InitActivationRequest();
+        initRequest.setApplicationId(config.getApplicationId());
+        initRequest.setUserId(config.getUser(version));
+        // Expire activation with 1 hour in the past
+        final Date expirationTime = Date.from(Instant.now().minus(Duration.ofHours(1)));
+        initRequest.setTimestampActivationExpire(expirationTime);
+        final Exception error = assertThrows(PowerAuthClientException.class, () -> powerAuthClient.initActivation(initRequest));
+        assertEquals("requestObject.timestampActivationExpire - The activation expiration timestamp must be in the future when initiating activation", error.getMessage());
+    }
+
+    public static void activationPrepareWithoutInitTest(PowerAuthTestConfiguration config, PrepareActivationStepModel model) throws Exception {
+        // Prepare non-existent activation
+        model.setActivationCode("AAAAA-BBBBB-CCCCC-EEEEE");
+        ObjectStepLogger stepLoggerPrepare = new ObjectStepLogger(System.out);
+        new PrepareActivationStep().execute(stepLoggerPrepare, model.toMap());
+        assertFalse(stepLoggerPrepare.getResult().success());
+        assertEquals(400, stepLoggerPrepare.getResponse().statusCode());
+
+        // Verify error response
+        ObjectMapper objectMapper = config.getObjectMapper();
+        final ErrorResponse errorResponse = objectMapper.readValue(stepLoggerPrepare.getResponse().responseObject().toString(), ErrorResponse.class);
+        assertEquals("ERROR", errorResponse.getStatus());
+        assertEquals("ERR_ACTIVATION", errorResponse.getResponseObject().getCode());
+        assertEquals("POWER_AUTH_ACTIVATION_INVALID", errorResponse.getResponseObject().getMessage());
+    }
+
+    public static void activationPrepareBadMasterPublicKeyTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
+                                                               PrepareActivationStepModel model, PowerAuthVersion version) throws Exception {
+        // Init activation
+        InitActivationRequest initRequest = new InitActivationRequest();
+        initRequest.setApplicationId(config.getApplicationId());
+        initRequest.setUserId(config.getUser(version));
+        InitActivationResponse initResponse = powerAuthClient.initActivation(initRequest);
+
+        // Verify activation status
+        GetActivationStatusResponse statusResponseCreated = powerAuthClient.getActivationStatus(initResponse.getActivationId());
+        assertEquals(ActivationStatus.CREATED, statusResponseCreated.getActivationStatus());
+
+        KeyPair keyPair = new KeyGenerator().generateKeyPair(EcCurve.P256);
+        PublicKey originalKey = model.getMasterPublicKeyP256();
+
+        // Prepare activation
+        model.setActivationCode(initResponse.getActivationCode());
+        model.setMasterPublicKeyP256(keyPair.getPublic());
+        ObjectStepLogger stepLoggerPrepare = new ObjectStepLogger(System.out);
+        new PrepareActivationStep().execute(stepLoggerPrepare, model.toMap());
+        assertFalse(stepLoggerPrepare.getResult().success());
+        assertEquals(400, stepLoggerPrepare.getResponse().statusCode());
+
+        // Verify error response
+        ObjectMapper objectMapper = config.getObjectMapper();
+        final ErrorResponse errorResponse = objectMapper.readValue(stepLoggerPrepare.getResponse().responseObject().toString(), ErrorResponse.class);
+        assertEquals("ERROR", errorResponse.getStatus());
+        assertEquals("ERR_ACTIVATION", errorResponse.getResponseObject().getCode());
+        assertEquals("POWER_AUTH_ACTIVATION_INVALID", errorResponse.getResponseObject().getMessage());
+
+        // Revert master public key change
+        model.setMasterPublicKeyP256(originalKey);
+    }
+
+    public static void activationStatusTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
+                                            PrepareActivationStepModel model, PowerAuthVersion version) throws Exception {
+        final JSONObject resultStatusObject = new JSONObject();
+
+        // Init activation
+        InitActivationRequest initRequest = new InitActivationRequest();
+        initRequest.setApplicationId(config.getApplicationId());
+        initRequest.setUserId(config.getUser(version));
+        initRequest.setMaxFailureCount(10L);
+        InitActivationResponse initResponse = powerAuthClient.initActivation(initRequest);
+
+        // Prepare activation
+        model.setActivationCode(initResponse.getActivationCode());
+        model.setResultStatusObject(resultStatusObject);
+        ObjectStepLogger stepLoggerPrepare = new ObjectStepLogger(System.out);
+        new PrepareActivationStep().execute(stepLoggerPrepare, model.toMap());
+        assertTrue(stepLoggerPrepare.getResult().success());
+        assertEquals(200, stepLoggerPrepare.getResponse().statusCode());
+
+        checkEncryptedResponse(version, stepLoggerPrepare.getResponse().responseObject());
+
+        // Verify activation status
+        GetStatusStepModel statusModel = new GetStatusStepModel();
+        statusModel.setResultStatusObject(resultStatusObject);
+        statusModel.setHeaders(new HashMap<>());
+        statusModel.setUriString(config.getPowerAuthIntegrationUrl());
+        statusModel.setApplicationKey(config.getApplicationKey());
+        statusModel.setApplicationSecret(config.getApplicationSecret());
+        statusModel.setVersion(version);
+
+        ObjectStepLogger stepLoggerStatus = new ObjectStepLogger(System.out);
+        new GetStatusStep().execute(stepLoggerStatus, statusModel.toMap());
+        assertTrue(stepLoggerStatus.getResult().success());
+        assertEquals(200, stepLoggerStatus.getResponse().statusCode());
+
+        ActivationStatusBlobInfo statusBlob = extractStatusBlob(stepLoggerStatus);
+        assertTrue(statusBlob.isValid());
+        assertEquals(0x2, statusBlob.getActivationStatus());
+        assertEquals(10, statusBlob.getMaxFailedAttempts());
+        assertEquals(0, statusBlob.getFailedAttempts());
+        assertEquals(4, statusBlob.getCurrentVersion());
+        assertEquals(4, statusBlob.getUpgradeVersion());
+
+        // Commit activation
+        CommitActivationResponse commitResponse = powerAuthClient.commitActivation(initResponse.getActivationId(), "test");
+        assertEquals(initResponse.getActivationId(), commitResponse.getActivationId());
+
+        // Check status
+        stepLoggerStatus = new ObjectStepLogger(System.out);
+        new GetStatusStep().execute(stepLoggerStatus, statusModel.toMap());
+        assertTrue(stepLoggerStatus.getResult().success());
+        assertEquals(200, stepLoggerStatus.getResponse().statusCode());
+        statusBlob = extractStatusBlob(stepLoggerStatus);
+        assertTrue(statusBlob.isValid());
+        assertEquals(0x3, statusBlob.getActivationStatus());
+
+        // Block activation
+        BlockActivationResponse blockResponse = powerAuthClient.blockActivation(initResponse.getActivationId(), "test", "test");
+        assertEquals(initResponse.getActivationId(), blockResponse.getActivationId());
+        assertEquals("test", blockResponse.getBlockedReason());
+
+        // Check status
+        stepLoggerStatus = new ObjectStepLogger(System.out);
+        new GetStatusStep().execute(stepLoggerStatus, statusModel.toMap());
+        assertTrue(stepLoggerStatus.getResult().success());
+        assertEquals(200, stepLoggerStatus.getResponse().statusCode());
+        statusBlob = extractStatusBlob(stepLoggerStatus);
+        assertTrue(statusBlob.isValid());
+        assertEquals(0x4, statusBlob.getActivationStatus());
+
+        // Remove activation
+        powerAuthClient.removeActivation(initResponse.getActivationId(), "test");
+
+        // Check status
+        stepLoggerStatus = new ObjectStepLogger(System.out);
+        new GetStatusStep().execute(stepLoggerStatus, statusModel.toMap());
+        assertTrue(stepLoggerStatus.getResult().success());
+        assertEquals(200, stepLoggerStatus.getResponse().statusCode());
+        statusBlob = extractStatusBlob(stepLoggerStatus);
+        assertTrue(statusBlob.isValid());
+        assertEquals(0x5, statusBlob.getActivationStatus());
+    }
+
+    private static ActivationStatusBlobInfo extractStatusBlob(ObjectStepLogger stepLogger) {
+        Object responseObject = stepLogger.getItems().stream()
+                .filter(item -> "Activation Status".equals(item.name()))
+                .map(StepItem::object)
+                .findAny()
+                .orElseThrow(() -> AssertionFailureBuilder.assertionFailure().message("Activation Status response is invalid").build());
+
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> responseObjectMap = (Map<String, Object>) responseObject;
+        return (ActivationStatusBlobInfo) responseObjectMap.get("statusBlob");
+    }
+
+    public static void activationInvalidApplicationKeyTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
+                                                           PrepareActivationStepModel model, PowerAuthVersion version) throws Exception {
+        // Init activation should not fail, because application version is not known (applicationKey is not sent in InitActivationRequest)
+        InitActivationRequest initRequest = new InitActivationRequest();
+        initRequest.setApplicationId(config.getApplicationId());
+        initRequest.setUserId(config.getUser(version));
+        InitActivationResponse initResponse = powerAuthClient.initActivation(initRequest);
+
+        // Verify activation status
+        GetActivationStatusResponse statusResponseCreated = powerAuthClient.getActivationStatus(initResponse.getActivationId());
+        assertEquals(ActivationStatus.CREATED, statusResponseCreated.getActivationStatus());
+
+        // PrepareActivation should fail
+        model.setActivationCode(initResponse.getActivationCode());
+        model.setApplicationKey("invalid");
+
+        // Verify that PrepareActivation fails
+        ObjectStepLogger stepLoggerPrepare = new ObjectStepLogger(System.out);
+        new PrepareActivationStep().execute(stepLoggerPrepare, model.toMap());
+        assertFalse(stepLoggerPrepare.getResult().success());
+        // Verify BAD_REQUEST status code
+        assertEquals(400, stepLoggerPrepare.getResponse().statusCode());
+
+        // Verify error response
+        ObjectMapper objectMapper = config.getObjectMapper();
+        final ErrorResponse errorResponse = objectMapper.readValue(stepLoggerPrepare.getResponse().responseObject().toString(), ErrorResponse.class);
+        assertEquals("ERROR", errorResponse.getStatus());
+        ResponseVerificationUtil.verifyErrorResponse(model, errorResponse);
+    }
+
+    public static void activationInvalidApplicationSecretTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
+                                                              PrepareActivationStepModel model, PowerAuthVersion version) throws Exception {
+        // Init activation should not fail, because application version is not known (applicationKey is not sent in InitActivationRequest)
+        InitActivationRequest initRequest = new InitActivationRequest();
+        initRequest.setApplicationId(config.getApplicationId());
+        initRequest.setUserId(config.getUser(version));
+        InitActivationResponse initResponse = powerAuthClient.initActivation(initRequest);
+
+        // Verify activation status
+        GetActivationStatusResponse statusResponseCreated = powerAuthClient.getActivationStatus(initResponse.getActivationId());
+        assertEquals(ActivationStatus.CREATED, statusResponseCreated.getActivationStatus());
+
+        // PrepareActivation should fail
+        model.setActivationCode(initResponse.getActivationCode());
+        model.setApplicationSecret("invalid");
+
+        // Verify that PrepareActivation fails
+        ObjectStepLogger stepLoggerPrepare = new ObjectStepLogger(System.out);
+        new PrepareActivationStep().execute(stepLoggerPrepare, model.toMap());
+        assertFalse(stepLoggerPrepare.getResult().success());
+        // Verify BAD_REQUEST status code
+        assertEquals(400, stepLoggerPrepare.getResponse().statusCode());
+
+        // Verify error response
+        ObjectMapper objectMapper = config.getObjectMapper();
+        final ErrorResponse errorResponse = objectMapper.readValue(stepLoggerPrepare.getResponse().responseObject().toString(), ErrorResponse.class);
+        assertEquals("ERROR", errorResponse.getStatus());
+        ResponseVerificationUtil.verifyErrorResponse(model, errorResponse);
+    }
+
+    public static void lookupActivationsTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config, PowerAuthVersion version) throws Exception {
+        InitActivationResponse response = powerAuthClient.initActivation(config.getUser(version), config.getApplicationId());
+        GetActivationStatusResponse statusResponse = powerAuthClient.getActivationStatus(response.getActivationId());
+        final Date timestampCreated = statusResponse.getTimestampCreated();
+        assertEquals(ActivationStatus.CREATED, statusResponse.getActivationStatus());
+        final List<Activation> activations = powerAuthClient.lookupActivations(Collections.singletonList(config.getUser(version)), Collections.singletonList(config.getApplicationId()),
+                null, timestampCreated, ActivationStatus.CREATED, null);
+        assertTrue(activations.size() >= 1);
+    }
+
+    public static void lookupActivationsNonExistentUserTest(PowerAuthClient powerAuthClient) throws Exception {
+        LookupActivationsRequest lookupActivationsRequest = new LookupActivationsRequest();
+        lookupActivationsRequest.getUserIds().add("nonexistent");
+        LookupActivationsResponse response = powerAuthClient.lookupActivations(lookupActivationsRequest);
+        assertEquals(0, response.getActivations().size());
+    }
+
+    public static void lookupActivationsApplicationTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config, PowerAuthVersion version) throws Exception {
+        LookupActivationsRequest lookupActivationsRequest = new LookupActivationsRequest();
+        lookupActivationsRequest.getUserIds().add(config.getUser(version));
+        lookupActivationsRequest.getApplicationIds().add(config.getApplicationId());
+        LookupActivationsResponse response = powerAuthClient.lookupActivations(lookupActivationsRequest);
+        assertTrue(response.getActivations().size() >= 1);
+    }
+
+    public static void lookupActivationsNonExistentApplicationTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config, PowerAuthVersion version) throws Exception {
+        final LookupActivationsRequest lookupActivationsRequest = new LookupActivationsRequest();
+        lookupActivationsRequest.getUserIds().add(config.getUser(version));
+        lookupActivationsRequest.getApplicationIds().add("10000000");
+        LookupActivationsResponse response = powerAuthClient.lookupActivations(lookupActivationsRequest);
+        assertEquals(0, response.getActivations().size());
+    }
+
+    public static void lookupActivationsStatusTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config, PowerAuthVersion version) throws Exception {
+        LookupActivationsRequest lookupActivationsRequest = new LookupActivationsRequest();
+        lookupActivationsRequest.getUserIds().add(config.getUser(version));
+        lookupActivationsRequest.setActivationStatus(ActivationStatus.ACTIVE);
+        LookupActivationsResponse response = powerAuthClient.lookupActivations(lookupActivationsRequest);
+        assertTrue(response.getActivations().size() >= 1);
+    }
+
+    public static void lookupActivationsInvalidStatusTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config, PowerAuthVersion version) throws Exception {
+        //
+        // This test may fail in case that our battery of tests leaves some activation in the blocked state.
+        // Try to re-run the test alone, or fix the new test case that collides with this one.
+        //
+        LookupActivationsRequest lookupActivationsRequest = new LookupActivationsRequest();
+        lookupActivationsRequest.getUserIds().add(config.getUser(version));
+        lookupActivationsRequest.setActivationStatus(ActivationStatus.BLOCKED);
+        LookupActivationsResponse response = powerAuthClient.lookupActivations(lookupActivationsRequest);
+        assertEquals(0, response.getActivations().size());
+    }
+
+    public static void lookupActivationsDateValidTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config, PowerAuthVersion version) throws Exception {
+        LookupActivationsRequest lookupActivationsRequest = new LookupActivationsRequest();
+        lookupActivationsRequest.getUserIds().add(config.getUser(version));
+        final Date timestampLastUsedAfter = Date.from(Instant.now().minus(Duration.ofMinutes(1)));
+        lookupActivationsRequest.setTimestampLastUsedAfter(timestampLastUsedAfter);
+        LookupActivationsResponse response = powerAuthClient.lookupActivations(lookupActivationsRequest);
+        assertTrue(response.getActivations().size() >= 1);
+    }
+
+    public static void lookupActivationsDateInvalidTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config, PowerAuthVersion version) throws Exception {
+        LookupActivationsRequest lookupActivationsRequest = new LookupActivationsRequest();
+        lookupActivationsRequest.getUserIds().add(config.getUser(version));
+        final Date timestampLastUsedAfter = Date.from(Instant.now().plus(Duration.ofMinutes(1)));
+        lookupActivationsRequest.setTimestampLastUsedAfter(timestampLastUsedAfter);
+        LookupActivationsResponse response = powerAuthClient.lookupActivations(lookupActivationsRequest);
+        assertEquals(0, response.getActivations().size());
+    }
+
+    public static void updateActivationStatusTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
+                                                  PrepareActivationStepModel model, PowerAuthVersion version) throws Exception {
+        final JSONObject resultStatusObject = new JSONObject();
+
+        // Init activation
+        InitActivationRequest initRequest = new InitActivationRequest();
+        initRequest.setApplicationId(config.getApplicationId());
+        initRequest.setUserId(config.getUser(version));
+        initRequest.setMaxFailureCount(10L);
+        InitActivationResponse initResponse = powerAuthClient.initActivation(initRequest);
+
+        // Prepare activation
+        model.setActivationCode(initResponse.getActivationCode());
+        model.setResultStatusObject(resultStatusObject);
+        ObjectStepLogger stepLoggerPrepare = new ObjectStepLogger(System.out);
+        new PrepareActivationStep().execute(stepLoggerPrepare, model.toMap());
+        assertTrue(stepLoggerPrepare.getResult().success());
+        assertEquals(200, stepLoggerPrepare.getResponse().statusCode());
+
+        checkEncryptedResponse(version, stepLoggerPrepare.getResponse().responseObject());
+
+        // Verify activation status
+        GetStatusStepModel statusModel = new GetStatusStepModel();
+        statusModel.setResultStatusObject(resultStatusObject);
+        statusModel.setHeaders(new HashMap<>());
+        statusModel.setUriString(config.getPowerAuthIntegrationUrl());
+        statusModel.setApplicationKey(config.getApplicationKey());
+        statusModel.setApplicationSecret(config.getApplicationSecret());
+        statusModel.setVersion(version);
+        ObjectStepLogger stepLoggerStatus = new ObjectStepLogger(System.out);
+        new GetStatusStep().execute(stepLoggerStatus, statusModel.toMap());
+        assertTrue(stepLoggerStatus.getResult().success());
+        assertEquals(200, stepLoggerStatus.getResponse().statusCode());
+
+        ActivationStatusBlobInfo statusBlob = extractStatusBlob(stepLoggerStatus);
+        assertTrue(statusBlob.isValid());
+        assertEquals(0x2, statusBlob.getActivationStatus());
+
+        // Commit activation
+        CommitActivationResponse commitResponse = powerAuthClient.commitActivation(initResponse.getActivationId(), "test");
+        assertEquals(initResponse.getActivationId(), commitResponse.getActivationId());
+
+        // Block activation using UpdateStatusForActivations method
+        powerAuthClient.updateStatusForActivations(Collections.singletonList(initResponse.getActivationId()), ActivationStatus.BLOCKED);
+
+        GetActivationStatusResponse statusResponseBlocked = powerAuthClient.getActivationStatus(initResponse.getActivationId());
+        assertEquals(ActivationStatus.BLOCKED, statusResponseBlocked.getActivationStatus());
+
+        // Remove activation using UpdateStatusForActivations method
+        powerAuthClient.updateStatusForActivations(Collections.singletonList(initResponse.getActivationId()), ActivationStatus.ACTIVE);
+
+        GetActivationStatusResponse statusResponseActive = powerAuthClient.getActivationStatus(initResponse.getActivationId());
+        assertEquals(ActivationStatus.ACTIVE, statusResponseActive.getActivationStatus());
+    }
+
+    private static void checkEncryptedResponse(PowerAuthVersion version, Object response) {
+        final AeadEncryptedResponse aeadResponse = (AeadEncryptedResponse) response;
+        assertNotNull(aeadResponse.getEncryptedData());
+        assertNotNull(aeadResponse.getTimestamp());
+    }
+
+}

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthApiShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthApiShared.java
@@ -1,0 +1,118 @@
+/*
+ * PowerAuth test and related software components
+ * Copyright (C) 2023 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.security.powerauth.test.shared.v4;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wultra.security.powerauth.client.model.entity.SignatureAuditItem;
+import com.wultra.security.powerauth.client.model.enumeration.ActivationStatus;
+import com.wultra.security.powerauth.client.model.enumeration.v4.AuthenticationCodeType;
+import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
+import com.wultra.security.powerauth.client.model.response.v4.VerifyAuthenticationResponse;
+import com.wultra.security.powerauth.client.v4.PowerAuthClient;
+import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
+import com.wultra.security.powerauth.crypto.client.v4.authentication.PowerAuthClientAuthentication;
+import com.wultra.security.powerauth.crypto.client.v4.keyfactory.PowerAuthClientKeyFactory;
+import com.wultra.security.powerauth.crypto.client.v4.token.ClientTokenGenerator;
+import com.wultra.security.powerauth.crypto.lib.config.AuthenticationCodeConfiguration;
+import com.wultra.security.powerauth.crypto.lib.encryptor.EncryptorFactory;
+import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;
+import com.wultra.security.powerauth.crypto.lib.generator.KeyGenerator;
+import com.wultra.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
+import com.wultra.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
+import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
+import com.wultra.security.powerauth.http.PowerAuthHttpBody;
+import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
+import com.wultra.security.powerauth.lib.cmd.steps.model.BaseStepModel;
+import com.wultra.security.powerauth.lib.cmd.util.CounterUtil;
+import com.wultra.security.powerauth.lib.cmd.util.EncryptedStorageUtil;
+import com.wultra.security.powerauth.lib.cmd.util.JsonUtil;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.util.Base64;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * PowerAuth server API test shared logic.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class PowerAuthApiShared {
+
+    private static final KeyConvertor KEY_CONVERTOR = new KeyConvertor();
+    private static final EncryptorFactory ENCRYPTOR_FACTORY = new EncryptorFactory();
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final KeyGenerator KEY_GENERATOR = new KeyGenerator();
+    private static final PowerAuthClientAuthentication CLIENT_AUTHENTICATION = new PowerAuthClientAuthentication();
+    private static final PowerAuthClientKeyFactory KEY_FACTORY = new PowerAuthClientKeyFactory();
+    private static final ClientTokenGenerator CLIENT_TOKEN_GENERATOR = new ClientTokenGenerator();
+
+    private static final int TIME_SYNCHRONIZATION_WINDOW_SECONDS = 60;
+
+    public static void verifyAuthenticationTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config, PowerAuthVersion version) throws GenericCryptoException, CryptoProviderException, InvalidKeyException, PowerAuthClientException {
+        Calendar before = new GregorianCalendar();
+        before.add(Calendar.SECOND, -TIME_SYNCHRONIZATION_WINDOW_SECONDS);
+        byte[] nonceBytes = KEY_GENERATOR.generateRandomBytes(16);
+        String data = "test_data";
+        String normalizedData = PowerAuthHttpBody.getAuthenticationBaseString("POST", "/pa/auth/validate", nonceBytes, data.getBytes(StandardCharsets.UTF_8));
+        String normalizedDataWithSecret = normalizedData + "&" + config.getApplicationSecret();
+        byte[] ctrData = Base64.getDecoder().decode(JsonUtil.stringValue(config.getResultStatusObject(version), "ctrData"));
+        byte[] possessionKeyBytes = Base64.getDecoder().decode(JsonUtil.stringValue(config.getResultStatusObject(version), "possessionFactorKey"));
+        byte[] knowledgeKeySalt = Base64.getDecoder().decode(JsonUtil.stringValue(config.getResultStatusObject(version), "knowledgeFactorKeySalt"));
+        byte[] knowledgeKeyEncryptedBytes = Base64.getDecoder().decode(JsonUtil.stringValue(config.getResultStatusObject(version), "knowledgeFactorKeyEncrypted"));
+        SecretKey knowledgeKey = EncryptedStorageUtil.getKnowledgeFactorKey(config.getPassword().toCharArray(), knowledgeKeyEncryptedBytes, knowledgeKeySalt, KEY_GENERATOR);
+        SecretKey possessionKey = KEY_CONVERTOR.convertBytesToSharedSecretKey(possessionKeyBytes);
+        String authCodeValue = CLIENT_AUTHENTICATION.computeAuthCode(normalizedDataWithSecret.getBytes(StandardCharsets.UTF_8), KEY_FACTORY.keysForAuthenticationCodeType(PowerAuthCodeType.POSSESSION_KNOWLEDGE,
+                possessionKey, knowledgeKey, null), ctrData, AuthenticationCodeConfiguration.base64());
+        VerifyAuthenticationResponse signatureResponse = powerAuthClient.verifyAuthentication(config.getActivationId(version), config.getApplicationKey(), normalizedData, authCodeValue, AuthenticationCodeType.POSSESSION_KNOWLEDGE, version.value(), null);
+        assertTrue(signatureResponse.isAuthenticationValid());
+        BaseStepModel model = new BaseStepModel();
+        model.setResultStatusObject(config.getResultStatusObject(version));
+        CounterUtil.incrementCounter(model);
+        Calendar after = new GregorianCalendar();
+        after.add(Calendar.SECOND, TIME_SYNCHRONIZATION_WINDOW_SECONDS);
+        List<SignatureAuditItem> auditItems = powerAuthClient.getSignatureAuditLog(config.getUser(version), config.getApplicationId(), before.getTime(), after.getTime());
+        boolean signatureFound = auditItems.stream()
+                .filter(item -> authCodeValue.equals(item.getSignature()))
+                .peek(item -> verifyAuditItem(item, version, config, normalizedDataWithSecret))
+                .findFirst()
+                .isPresent();
+        assertTrue(signatureFound);
+    }
+
+    private static void verifyAuditItem(SignatureAuditItem item, PowerAuthVersion version, PowerAuthTestConfiguration config, String normalizedDataWithSecret) {
+        assertEquals(config.getActivationId(version), item.getActivationId());
+        assertEquals(
+                normalizedDataWithSecret,
+                new String(Base64.getDecoder().decode(item.getDataBase64()))
+        );
+        assertEquals(AuthenticationCodeType.POSSESSION_KNOWLEDGE.toString(), item.getSignatureType().toString());
+        assertEquals(version.value(), item.getSignatureVersion());
+        assertEquals(ActivationStatus.ACTIVE, item.getActivationStatus());
+        assertEquals(config.getApplicationId(), item.getApplicationId());
+        assertEquals(config.getUser(version), item.getUserId());
+        assertEquals(4, item.getVersion());
+    }
+
+}

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthAuthenticationShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthAuthenticationShared.java
@@ -433,9 +433,9 @@ public class PowerAuthAuthenticationShared {
 
     public static void authSwappedKeyTest(final PowerAuthTestConfiguration config, final VerifyAuthenticationStepModel model, final ObjectStepLogger stepLogger) throws Exception {
         // Save biometry key
-        String biometryKeyOrig = (String) model.getResultStatusObject().get("authBiometryKey");
+        String biometryKeyOrig = (String) model.getResultStatusObject().get("biometryFactorKey");
         // Set possession key as biometry key
-        model.getResultStatusObject().put("authBiometryKey", model.getResultStatusObject().get("authPossessionKey"));
+        model.getResultStatusObject().put("biometryFactorKey", model.getResultStatusObject().get("possessionFactorKey"));
         // Verify three factor auth
         model.setAuthenticationCodeType(PowerAuthCodeType.POSSESSION_KNOWLEDGE_BIOMETRY);
 
@@ -449,7 +449,7 @@ public class PowerAuthAuthenticationShared {
         checkError(errorResponse);
 
         // Revert biometry key change
-        model.getResultStatusObject().put("authBiometryKey", biometryKeyOrig);
+        model.getResultStatusObject().put("biometryFactorKey", biometryKeyOrig);
     }
 
     public static void authInvalidResourceIdTest(final PowerAuthTestConfiguration config, final VerifyAuthenticationStepModel model, final ObjectStepLogger stepLogger) throws Exception {

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthAuthenticationShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthAuthenticationShared.java
@@ -1,0 +1,481 @@
+/*
+ * PowerAuth test and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.security.powerauth.test.shared.v4;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wultra.core.rest.model.base.response.ErrorResponse;
+import com.wultra.core.rest.model.base.response.Response;
+import com.wultra.security.powerauth.client.model.enumeration.ActivationStatus;
+import com.wultra.security.powerauth.client.model.request.InitActivationRequest;
+import com.wultra.security.powerauth.client.model.response.CommitActivationResponse;
+import com.wultra.security.powerauth.client.model.response.InitActivationResponse;
+import com.wultra.security.powerauth.client.model.response.v4.GetActivationStatusResponse;
+import com.wultra.security.powerauth.client.v4.PowerAuthClient;
+import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
+import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;
+import com.wultra.security.powerauth.crypto.lib.generator.HashBasedCounter;
+import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
+import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
+import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
+import com.wultra.security.powerauth.lib.cmd.steps.PrepareActivationStep;
+import com.wultra.security.powerauth.lib.cmd.steps.VerifyAuthenticationStep;
+import com.wultra.security.powerauth.lib.cmd.steps.model.PrepareActivationStepModel;
+import com.wultra.security.powerauth.lib.cmd.steps.model.VerifyAuthenticationStepModel;
+import com.wultra.security.powerauth.lib.cmd.util.CounterUtil;
+import org.apache.commons.text.CharacterPredicates;
+import org.apache.commons.text.RandomStringGenerator;
+import org.json.simple.JSONObject;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * PowerAuth authentication test shared logic.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class PowerAuthAuthenticationShared {
+
+    public static void authValidTest(final VerifyAuthenticationStepModel model, final ObjectStepLogger stepLogger) throws Exception {
+        new VerifyAuthenticationStep().execute(stepLogger, model.toMap());
+        assertTrue(stepLogger.getResult().success());
+        assertEquals(200, stepLogger.getResponse().statusCode());
+
+        final Response responseOK = (Response) stepLogger.getResponse().responseObject();
+        assertEquals("OK", responseOK.getStatus());
+    }
+
+    public static void authInvalidPasswordTest(final PowerAuthTestConfiguration config, final VerifyAuthenticationStepModel model, final ObjectStepLogger stepLogger) throws Exception {
+        model.setPassword("1111");
+        new VerifyAuthenticationStep().execute(stepLogger, model.toMap());
+        assertFalse(stepLogger.getResult().success());
+        assertEquals(401, stepLogger.getResponse().statusCode());
+
+        ObjectMapper objectMapper = config.getObjectMapper();
+        final ErrorResponse errorResponse = objectMapper.readValue(stepLogger.getResponse().responseObject().toString(), ErrorResponse.class);
+        assertEquals("ERROR", errorResponse.getStatus());
+        checkError(errorResponse);
+    }
+
+    public static void authIncorrectPasswordFormatTest(final PowerAuthTestConfiguration config, final VerifyAuthenticationStepModel model, final ObjectStepLogger stepLogger) throws Exception {
+        model.setPassword("*");
+        new VerifyAuthenticationStep().execute(stepLogger, model.toMap());
+        assertFalse(stepLogger.getResult().success());
+        assertEquals(401, stepLogger.getResponse().statusCode());
+
+        ObjectMapper objectMapper = config.getObjectMapper();
+        final ErrorResponse errorResponse = objectMapper.readValue(stepLogger.getResponse().responseObject().toString(), ErrorResponse.class);
+        assertEquals("ERROR", errorResponse.getStatus());
+        checkError(errorResponse);
+    }
+
+    public static void authCounterLookAheadTest(final PowerAuthTestConfiguration config, final VerifyAuthenticationStepModel model) throws Exception {
+        // Move counter by 1-4, next auth should succeed thanks to counter lookahead and it is still in max failure limit
+        for (int i = 1; i < 4; i++) {
+            for (int j=0; j < i; j++) {
+                model.setPassword("1111");
+                ObjectStepLogger stepLogger = new ObjectStepLogger();
+                new VerifyAuthenticationStep().execute(stepLogger, model.toMap());
+                assertFalse(stepLogger.getResult().success());
+                assertEquals(401, stepLogger.getResponse().statusCode());
+            }
+
+            ObjectStepLogger stepLogger = new ObjectStepLogger();
+            model.setPassword(config.getPassword());
+            new VerifyAuthenticationStep().execute(stepLogger, model.toMap());
+            assertTrue(stepLogger.getResult().success());
+            assertEquals(200, stepLogger.getResponse().statusCode());
+
+            final Response responseOK = (Response) stepLogger.getResponse().responseObject();
+            assertEquals("OK", responseOK.getStatus());
+        }
+
+    }
+
+    public static void authBlockedActivationTest(final PowerAuthClient powerAuthClient, final PowerAuthTestConfiguration config, final VerifyAuthenticationStepModel model, final PowerAuthVersion version) throws Exception {
+        powerAuthClient.blockActivation(config.getActivationId(version), "test", "test");
+
+        ObjectStepLogger stepLogger1 = new ObjectStepLogger(System.out);
+        new VerifyAuthenticationStep().execute(stepLogger1, model.toMap());
+        assertFalse(stepLogger1.getResult().success());
+        assertEquals(401, stepLogger1.getResponse().statusCode());
+
+        ObjectMapper objectMapper = config.getObjectMapper();
+        final ErrorResponse errorResponse = objectMapper.readValue(stepLogger1.getResponse().responseObject().toString(), ErrorResponse.class);
+        assertEquals("ERROR", errorResponse.getStatus());
+        checkError(errorResponse);
+
+        powerAuthClient.unblockActivation(config.getActivationId(version), "test");
+
+        ObjectStepLogger stepLogger2 = new ObjectStepLogger();
+        new VerifyAuthenticationStep().execute(stepLogger2, model.toMap());
+        assertTrue(stepLogger2.getResult().success());
+        assertEquals(200, stepLogger2.getResponse().statusCode());
+    }
+
+    public static void authSingleFactorTest(final VerifyAuthenticationStepModel model, final ObjectStepLogger stepLogger) throws Exception {
+        model.setAuthenticationCodeType(PowerAuthCodeType.POSSESSION);
+
+        new VerifyAuthenticationStep().execute(stepLogger, model.toMap());
+        assertTrue(stepLogger.getResult().success());
+        assertEquals(200, stepLogger.getResponse().statusCode());
+    }
+
+    public static void authBiometryTest(final VerifyAuthenticationStepModel model, final ObjectStepLogger stepLogger) throws Exception {
+        model.setAuthenticationCodeType(PowerAuthCodeType.POSSESSION_BIOMETRY);
+
+        new VerifyAuthenticationStep().execute(stepLogger, model.toMap());
+        assertTrue(stepLogger.getResult().success());
+        assertEquals(200, stepLogger.getResponse().statusCode());
+    }
+
+    public static void authThreeFactorTest(final VerifyAuthenticationStepModel model, final ObjectStepLogger stepLogger) throws Exception {
+        model.setAuthenticationCodeType(PowerAuthCodeType.POSSESSION_KNOWLEDGE_BIOMETRY);
+
+        new VerifyAuthenticationStep().execute(stepLogger, model.toMap());
+        assertTrue(stepLogger.getResult().success());
+        assertEquals(200, stepLogger.getResponse().statusCode());
+    }
+
+    public static void authEmptyDataTest(final VerifyAuthenticationStepModel model, final ObjectStepLogger stepLogger, final PowerAuthVersion version) throws Exception {
+        File dataFile = File.createTempFile("data_empty" + version, ".json");
+        dataFile.deleteOnExit();
+        FileWriter fw = new FileWriter(dataFile);
+        fw.close();
+        model.setData(Files.readAllBytes(Paths.get(dataFile.getAbsolutePath())));
+
+        new VerifyAuthenticationStep().execute(stepLogger, model.toMap());
+        assertTrue(stepLogger.getResult().success());
+        assertEquals(200, stepLogger.getResponse().statusCode());
+
+        final Response responseOK = (Response) stepLogger.getResponse().responseObject();
+        assertEquals("OK", responseOK.getStatus());
+    }
+
+    public static void authValidGetTest(final PowerAuthTestConfiguration config, final VerifyAuthenticationStepModel model, final ObjectStepLogger stepLogger) throws Exception {
+        model.setHttpMethod("GET");
+        model.setUriString(config.getPowerAuthIntegrationUrl() + "/pa/v4/auth/validate?who=John_Tramonta&when=now");
+        new VerifyAuthenticationStep().execute(stepLogger, model.toMap());
+        assertTrue(stepLogger.getResult().success());
+        assertEquals(200, stepLogger.getResponse().statusCode());
+
+        final Response responseOK = (Response) stepLogger.getResponse().responseObject();
+        assertEquals("OK", responseOK.getStatus());
+    }
+
+    public static void authValidGetNoParamTest(final PowerAuthTestConfiguration config, final VerifyAuthenticationStepModel model, final ObjectStepLogger stepLogger) throws Exception {
+        model.setHttpMethod("GET");
+        new VerifyAuthenticationStep().execute(stepLogger, model.toMap());
+        assertTrue(stepLogger.getResult().success());
+        assertEquals(200, stepLogger.getResponse().statusCode());
+
+        final Response responseOK = (Response) stepLogger.getResponse().responseObject();
+        assertEquals("OK", responseOK.getStatus());
+    }
+
+    public static void authGetInvalidPasswordTest(final PowerAuthTestConfiguration config, final VerifyAuthenticationStepModel model, final ObjectStepLogger stepLogger) throws Exception {
+        model.setHttpMethod("GET");
+        model.setPassword("0000");
+        model.setUriString(config.getPowerAuthIntegrationUrl() + "/pa/v4/auth/validate?who=John_Tramonta&when=now");
+        new VerifyAuthenticationStep().execute(stepLogger, model.toMap());
+        assertFalse(stepLogger.getResult().success());
+        assertEquals(401, stepLogger.getResponse().statusCode());
+
+        ObjectMapper objectMapper = config.getObjectMapper();
+        final ErrorResponse errorResponse = objectMapper.readValue(stepLogger.getResponse().responseObject().toString(), ErrorResponse.class);
+        assertEquals("ERROR", errorResponse.getStatus());
+        checkError(errorResponse);
+    }
+
+    public static void authUnsupportedApplicationTest(final PowerAuthClient powerAuthClient, final PowerAuthTestConfiguration config, final VerifyAuthenticationStepModel model) throws Exception {
+        powerAuthClient.unsupportApplicationVersion(config.getApplicationId(), config.getApplicationVersionId());
+
+        ObjectStepLogger stepLogger1 = new ObjectStepLogger(System.out);
+        new VerifyAuthenticationStep().execute(stepLogger1, model.toMap());
+        assertFalse(stepLogger1.getResult().success());
+        assertEquals(401, stepLogger1.getResponse().statusCode());
+
+        ObjectMapper objectMapper = config.getObjectMapper();
+        final ErrorResponse errorResponse = objectMapper.readValue(stepLogger1.getResponse().responseObject().toString(), ErrorResponse.class);
+        assertEquals("ERROR", errorResponse.getStatus());
+        checkError(errorResponse);
+
+        powerAuthClient.supportApplicationVersion(config.getApplicationId(), config.getApplicationVersionId());
+
+        ObjectStepLogger stepLogger2 = new ObjectStepLogger(System.out);
+        new VerifyAuthenticationStep().execute(stepLogger2, model.toMap());
+        assertTrue(stepLogger2.getResult().success());
+        assertEquals(200, stepLogger2.getResponse().statusCode());
+
+        final Response responseOK = (Response) stepLogger2.getResponse().responseObject();
+        assertEquals("OK", responseOK.getStatus());
+    }
+
+    public static void authMaxFailedAttemptsTest(final PowerAuthClient powerAuthClient, final PowerAuthTestConfiguration config, final VerifyAuthenticationStepModel model, final PowerAuthVersion version) throws Exception {
+        // Create temp status file
+        File tempStatusFile = File.createTempFile("pa_status", ".json");
+        tempStatusFile.deleteOnExit();
+
+        final JSONObject resultStatusObject = new JSONObject();
+
+        // Init activation
+        final InitActivationRequest initRequest = new InitActivationRequest();
+        initRequest.setApplicationId(config.getApplicationId());
+        initRequest.setUserId(config.getUser(version));
+        initRequest.setMaxFailureCount(3L);
+        final InitActivationResponse initResponse = powerAuthClient.initActivation(initRequest);
+
+        // Prepare activation
+        PrepareActivationStepModel modelPrepare = new PrepareActivationStepModel();
+        modelPrepare.setActivationCode(initResponse.getActivationCode());
+        modelPrepare.setActivationName("test v" + version);
+        modelPrepare.setApplicationKey(config.getApplicationKey());
+        modelPrepare.setApplicationSecret(config.getApplicationSecret());
+        modelPrepare.setMasterPublicKeyP256(config.getMasterPublicKeyP256());
+        if (version.getMajorVersion() == 4) {
+            modelPrepare.setMasterPublicKeyP384(config.getMasterPublicKeyP384());
+            modelPrepare.setMasterPublicKeyMlDsa65(config.getMasterPublicKeyMlDsa65());
+            modelPrepare.setSharedSecretAlgorithm(SharedSecretAlgorithm.EC_P384_ML_L3);
+        }
+        modelPrepare.setHeaders(new HashMap<>());
+        modelPrepare.setPassword(config.getPassword());
+        modelPrepare.setStatusFileName(tempStatusFile.getAbsolutePath());
+        modelPrepare.setResultStatusObject(resultStatusObject);
+        modelPrepare.setUriString(config.getPowerAuthIntegrationUrl());
+        modelPrepare.setVersion(version);
+        modelPrepare.setDeviceInfo("backend-tests");
+
+        ObjectStepLogger stepLoggerPrepare = new ObjectStepLogger(System.out);
+        new PrepareActivationStep().execute(stepLoggerPrepare, modelPrepare.toMap());
+        assertTrue(stepLoggerPrepare.getResult().success());
+        assertEquals(200, stepLoggerPrepare.getResponse().statusCode());
+
+        // Commit activation
+        CommitActivationResponse commitResponse = powerAuthClient.commitActivation(initResponse.getActivationId(), "test");
+        assertEquals(initResponse.getActivationId(), commitResponse.getActivationId());
+
+        model.setStatusFileName(tempStatusFile.getAbsolutePath());
+        model.setResultStatusObject(resultStatusObject);
+        model.setPassword("1111");
+
+        // Fail two auths
+        for (int i = 0; i < 2; i++) {
+            ObjectStepLogger stepLoggerauth = new ObjectStepLogger();
+            new VerifyAuthenticationStep().execute(stepLoggerauth, model.toMap());
+            assertFalse(stepLoggerauth.getResult().success());
+            assertEquals(401, stepLoggerauth.getResponse().statusCode());
+        }
+
+        // Last auth before max failed attempts should be successful
+        model.setPassword(config.getPassword());
+        ObjectStepLogger stepLogger2 = new ObjectStepLogger();
+        new VerifyAuthenticationStep().execute(stepLogger2, model.toMap());
+        assertTrue(stepLogger2.getResult().success());
+        assertEquals(200, stepLogger2.getResponse().statusCode());
+
+        // Fail three auths
+        model.setPassword("1111");
+        for (int i = 0; i < 3; i++) {
+            ObjectStepLogger stepLoggerauth = new ObjectStepLogger();
+            new VerifyAuthenticationStep().execute(stepLoggerauth, model.toMap());
+            assertFalse(stepLoggerauth.getResult().success());
+            assertEquals(401, stepLoggerauth.getResponse().statusCode());
+        }
+
+        // Activation should be blocked
+        final GetActivationStatusResponse statusResponseBlocked = powerAuthClient.getActivationStatus(initResponse.getActivationId());
+        assertEquals(ActivationStatus.BLOCKED, statusResponseBlocked.getActivationStatus());
+
+        // Remove activation
+        powerAuthClient.removeActivation(initResponse.getActivationId(), "test");
+    }
+
+    public static void authLookAheadTest(final PowerAuthClient powerAuthClient, final PowerAuthTestConfiguration config, final VerifyAuthenticationStepModel model, final PowerAuthVersion version) throws Exception {
+        // Create temp status file
+        File tempStatusFile = File.createTempFile("pa_status_lookahead", ".json");
+        tempStatusFile.deleteOnExit();
+
+        final JSONObject resultStatusObject = new JSONObject();
+
+        // Init activation
+        InitActivationRequest initRequest = new InitActivationRequest();
+        initRequest.setApplicationId(config.getApplicationId());
+        initRequest.setUserId(config.getUser(version));
+        // High limit to test lookahead
+        initRequest.setMaxFailureCount(100L);
+        InitActivationResponse initResponse = powerAuthClient.initActivation(initRequest);
+
+        // Prepare activation
+        PrepareActivationStepModel modelPrepare = new PrepareActivationStepModel();
+        modelPrepare.setActivationCode(initResponse.getActivationCode());
+        modelPrepare.setActivationName("test v" + version);
+        modelPrepare.setApplicationKey(config.getApplicationKey());
+        modelPrepare.setApplicationSecret(config.getApplicationSecret());
+        modelPrepare.setMasterPublicKeyP256(config.getMasterPublicKeyP256());
+        if (version.getMajorVersion() == 4) {
+            modelPrepare.setMasterPublicKeyP384(config.getMasterPublicKeyP384());
+            modelPrepare.setMasterPublicKeyMlDsa65(config.getMasterPublicKeyMlDsa65());
+            modelPrepare.setSharedSecretAlgorithm(SharedSecretAlgorithm.EC_P384_ML_L3);
+        }
+        modelPrepare.setHeaders(new HashMap<>());
+        modelPrepare.setPassword(config.getPassword());
+        modelPrepare.setStatusFileName(tempStatusFile.getAbsolutePath());
+        modelPrepare.setResultStatusObject(resultStatusObject);
+        modelPrepare.setUriString(config.getPowerAuthIntegrationUrl());
+        modelPrepare.setVersion(version);
+        modelPrepare.setDeviceInfo("backend-tests");
+
+        ObjectStepLogger stepLoggerPrepare = new ObjectStepLogger(System.out);
+        new PrepareActivationStep().execute(stepLoggerPrepare, modelPrepare.toMap());
+        assertTrue(stepLoggerPrepare.getResult().success());
+        assertEquals(200, stepLoggerPrepare.getResponse().statusCode());
+
+        // Commit activation
+        final CommitActivationResponse commitResponse = powerAuthClient.commitActivation(initResponse.getActivationId(), "test");
+        assertEquals(initResponse.getActivationId(), commitResponse.getActivationId());
+
+        model.setStatusFileName(tempStatusFile.getAbsolutePath());
+        model.setResultStatusObject(resultStatusObject);
+        model.setPassword("1111");
+
+        // Fail 19 auths
+        for (int i = 0; i < 19; i++) {
+            ObjectStepLogger stepLoggerauth = new ObjectStepLogger();
+            new VerifyAuthenticationStep().execute(stepLoggerauth, model.toMap());
+            assertFalse(stepLoggerauth.getResult().success());
+            assertEquals(401, stepLoggerauth.getResponse().statusCode());
+        }
+
+        // Last auth before lookahead failure should be successful and should fix counter
+        model.setPassword(config.getPassword());
+        ObjectStepLogger stepLogger2 = new ObjectStepLogger();
+        new VerifyAuthenticationStep().execute(stepLogger2, model.toMap());
+        assertTrue(stepLogger2.getResult().success());
+        assertEquals(200, stepLogger2.getResponse().statusCode());
+
+        // Fail 20 auths
+        model.setPassword("1111");
+        for (int i = 0; i < 20; i++) {
+            ObjectStepLogger stepLoggerauth = new ObjectStepLogger();
+            new VerifyAuthenticationStep().execute(stepLoggerauth, model.toMap());
+            assertFalse(stepLoggerauth.getResult().success());
+            assertEquals(401, stepLoggerauth.getResponse().statusCode());
+        }
+
+        // auth after lookahead failure should be fail
+        model.setPassword(config.getPassword());
+        ObjectStepLogger stepLogger3 = new ObjectStepLogger();
+        new VerifyAuthenticationStep().execute(stepLogger3, model.toMap());
+        assertFalse(stepLogger3.getResult().success());
+        assertEquals(401, stepLogger3.getResponse().statusCode());
+
+        // Remove activation
+        powerAuthClient.removeActivation(initResponse.getActivationId(), "test");
+    }
+
+    public static void authCounterIncrementTest(final VerifyAuthenticationStepModel model, final ObjectStepLogger stepLogger, final PowerAuthVersion version) throws Exception {
+        byte[] ctrData = CounterUtil.getCtrData(model, stepLogger);
+        HashBasedCounter counter = new HashBasedCounter(version.value());
+        for (int i = 1; i <= 10; i++) {
+            ObjectStepLogger stepLoggerLoop = new ObjectStepLogger();
+            new VerifyAuthenticationStep().execute(stepLoggerLoop, model.toMap());
+            assertTrue(stepLoggerLoop.getResult().success());
+            assertEquals(200, stepLoggerLoop.getResponse().statusCode());
+
+            // Verify hash based counter
+            ctrData = counter.next(ctrData);
+            assertArrayEquals(ctrData, CounterUtil.getCtrData(model, stepLoggerLoop));
+        }
+    }
+
+    public static void authLargeDataTest(final VerifyAuthenticationStepModel model, final ObjectStepLogger stepLogger, final PowerAuthVersion version) throws Exception {
+        final File dataFileLarge = File.createTempFile("data_large" + version, ".dat");
+        dataFileLarge.deleteOnExit();
+        final FileWriter fw = new FileWriter(dataFileLarge);
+        final RandomStringGenerator randomStringGenerator =
+                new RandomStringGenerator.Builder()
+                        .withinRange('0', 'z')
+                        .filteredBy(CharacterPredicates.LETTERS, CharacterPredicates.DIGITS)
+                        .get();
+        final String randomString = randomStringGenerator.generate(10000);
+        fw.write(randomString);
+        fw.close();
+
+        model.setData(Files.readAllBytes(Paths.get(dataFileLarge.getAbsolutePath())));
+
+        new VerifyAuthenticationStep().execute(stepLogger, model.toMap());
+        assertTrue(stepLogger.getResult().success());
+        assertEquals(200, stepLogger.getResponse().statusCode());
+
+        final Response responseOK = (Response) stepLogger.getResponse().responseObject();
+        assertEquals("OK", responseOK.getStatus());
+    }
+
+    public static void authSwappedKeyTest(final PowerAuthTestConfiguration config, final VerifyAuthenticationStepModel model, final ObjectStepLogger stepLogger) throws Exception {
+        // Save biometry key
+        String biometryKeyOrig = (String) model.getResultStatusObject().get("authBiometryKey");
+        // Set possession key as biometry key
+        model.getResultStatusObject().put("authBiometryKey", model.getResultStatusObject().get("authPossessionKey"));
+        // Verify three factor auth
+        model.setAuthenticationCodeType(PowerAuthCodeType.POSSESSION_KNOWLEDGE_BIOMETRY);
+
+        new VerifyAuthenticationStep().execute(stepLogger, model.toMap());
+        assertFalse(stepLogger.getResult().success());
+        assertEquals(401, stepLogger.getResponse().statusCode());
+
+        ObjectMapper objectMapper = config.getObjectMapper();
+        final ErrorResponse errorResponse = objectMapper.readValue(stepLogger.getResponse().responseObject().toString(), ErrorResponse.class);
+        assertEquals("ERROR", errorResponse.getStatus());
+        checkError(errorResponse);
+
+        // Revert biometry key change
+        model.getResultStatusObject().put("authBiometryKey", biometryKeyOrig);
+    }
+
+    public static void authInvalidResourceIdTest(final PowerAuthTestConfiguration config, final VerifyAuthenticationStepModel model, final ObjectStepLogger stepLogger) throws Exception {
+        // Set invalid resource ID
+        model.setResourceId("/pa/auth/invalid");
+
+        // Verify two factor auth
+        model.setAuthenticationCodeType(PowerAuthCodeType.POSSESSION_KNOWLEDGE);
+
+        new VerifyAuthenticationStep().execute(stepLogger, model.toMap());
+        assertFalse(stepLogger.getResult().success());
+        assertEquals(401, stepLogger.getResponse().statusCode());
+
+        ObjectMapper objectMapper = config.getObjectMapper();
+        final ErrorResponse errorResponse = objectMapper.readValue(stepLogger.getResponse().responseObject().toString(), ErrorResponse.class);
+        assertEquals("ERROR", errorResponse.getStatus());
+        checkError(errorResponse);
+
+        // Revert resource ID
+        model.setResourceId("/pa/auth/validate");
+    }
+
+    private static void checkError(ErrorResponse errorResponse) {
+        // Errors differ when Web Flow is used because of its Exception handler
+        assertTrue("ERR_AUTHENTICATION".equals(errorResponse.getResponseObject().getCode()));
+        assertTrue("POWER_AUTH_CODE_INVALID".equals(errorResponse.getResponseObject().getMessage()));
+    }
+
+}

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthAuthenticationShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthAuthenticationShared.java
@@ -256,12 +256,9 @@ public class PowerAuthAuthenticationShared {
         modelPrepare.setActivationName("test v" + version);
         modelPrepare.setApplicationKey(config.getApplicationKey());
         modelPrepare.setApplicationSecret(config.getApplicationSecret());
-        modelPrepare.setMasterPublicKeyP256(config.getMasterPublicKeyP256());
-        if (version.getMajorVersion() == 4) {
-            modelPrepare.setMasterPublicKeyP384(config.getMasterPublicKeyP384());
-            modelPrepare.setMasterPublicKeyMlDsa65(config.getMasterPublicKeyMlDsa65());
-            modelPrepare.setSharedSecretAlgorithm(SharedSecretAlgorithm.EC_P384_ML_L3);
-        }
+        modelPrepare.setMasterPublicKeyP384(config.getMasterPublicKeyP384());
+        modelPrepare.setMasterPublicKeyMlDsa65(config.getMasterPublicKeyMlDsa65());
+        modelPrepare.setSharedSecretAlgorithm(SharedSecretAlgorithm.EC_P384_ML_L3);
         modelPrepare.setHeaders(new HashMap<>());
         modelPrepare.setPassword(config.getPassword());
         modelPrepare.setStatusFileName(tempStatusFile.getAbsolutePath());
@@ -336,12 +333,9 @@ public class PowerAuthAuthenticationShared {
         modelPrepare.setActivationName("test v" + version);
         modelPrepare.setApplicationKey(config.getApplicationKey());
         modelPrepare.setApplicationSecret(config.getApplicationSecret());
-        modelPrepare.setMasterPublicKeyP256(config.getMasterPublicKeyP256());
-        if (version.getMajorVersion() == 4) {
-            modelPrepare.setMasterPublicKeyP384(config.getMasterPublicKeyP384());
-            modelPrepare.setMasterPublicKeyMlDsa65(config.getMasterPublicKeyMlDsa65());
-            modelPrepare.setSharedSecretAlgorithm(SharedSecretAlgorithm.EC_P384_ML_L3);
-        }
+        modelPrepare.setMasterPublicKeyP384(config.getMasterPublicKeyP384());
+        modelPrepare.setMasterPublicKeyMlDsa65(config.getMasterPublicKeyMlDsa65());
+        modelPrepare.setSharedSecretAlgorithm(SharedSecretAlgorithm.EC_P384_ML_L3);
         modelPrepare.setHeaders(new HashMap<>());
         modelPrepare.setPassword(config.getPassword());
         modelPrepare.setStatusFileName(tempStatusFile.getAbsolutePath());

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthAuthenticationShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthAuthenticationShared.java
@@ -149,6 +149,11 @@ public class PowerAuthAuthenticationShared {
         assertEquals(200, stepLogger.getResponse().statusCode());
     }
 
+    public static void authBiometryNoResponseCheckTest(final VerifyAuthenticationStepModel model, final ObjectStepLogger stepLogger) throws Exception {
+        model.setAuthenticationCodeType(PowerAuthCodeType.POSSESSION_BIOMETRY);
+        new VerifyAuthenticationStep().execute(stepLogger, model.toMap());
+    }
+
     public static void authThreeFactorTest(final VerifyAuthenticationStepModel model, final ObjectStepLogger stepLogger) throws Exception {
         model.setAuthenticationCodeType(PowerAuthCodeType.POSSESSION_KNOWLEDGE_BIOMETRY);
 
@@ -183,7 +188,7 @@ public class PowerAuthAuthenticationShared {
         assertEquals("OK", responseOK.getStatus());
     }
 
-    public static void authValidGetNoParamTest(final PowerAuthTestConfiguration config, final VerifyAuthenticationStepModel model, final ObjectStepLogger stepLogger) throws Exception {
+    public static void authValidGetNoParamTest(final VerifyAuthenticationStepModel model, final ObjectStepLogger stepLogger) throws Exception {
         model.setHttpMethod("GET");
         new VerifyAuthenticationStep().execute(stepLogger, model.toMap());
         assertTrue(stepLogger.getResult().success());

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthCallbackShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthCallbackShared.java
@@ -1,0 +1,88 @@
+/*
+ * PowerAuth test and related software components
+ * Copyright (C) 2023 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.security.powerauth.test.shared.v4;
+
+import com.wultra.core.rest.client.base.RestClientException;
+import com.wultra.security.powerauth.client.model.entity.CallbackUrl;
+import com.wultra.security.powerauth.client.model.enumeration.CallbackUrlType;
+import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
+import com.wultra.security.powerauth.client.model.request.CreateCallbackUrlRequest;
+import com.wultra.security.powerauth.client.model.response.GetCallbackUrlListResponse;
+import com.wultra.security.powerauth.client.v4.PowerAuthClient;
+import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
+import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
+import com.wultra.security.powerauth.lib.cmd.util.RestClientFactory;
+import org.springframework.core.ParameterizedTypeReference;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Callback test shared logic.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class PowerAuthCallbackShared {
+
+    public static void callbackExecutionTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config, Integer port, PowerAuthVersion version) throws PowerAuthClientException, RestClientException {
+        // Skip test when the tested PA server is not running on localhost
+        assumeTrue(config.getPowerAuthRestUrl().contains("localhost:8080"));
+
+        final CreateCallbackUrlRequest pasCreateCallbackUrlRequest = new CreateCallbackUrlRequest();
+        pasCreateCallbackUrlRequest.setApplicationId(config.getApplicationId());
+        pasCreateCallbackUrlRequest.setName(UUID.randomUUID().toString());
+        pasCreateCallbackUrlRequest.setType(CallbackUrlType.ACTIVATION_STATUS_CHANGE);
+        pasCreateCallbackUrlRequest.setCallbackUrl("http://localhost:" + port + "/callback/post");
+        pasCreateCallbackUrlRequest.setAttributes(List.of("activationId", "userId", "activationName", "deviceInfo",
+                "platform", "activationFlags", "activationStatus", "blockedReason", "applicationId"));
+        powerAuthClient.createCallbackUrl(pasCreateCallbackUrlRequest);
+
+        final GetCallbackUrlListResponse callbacks = powerAuthClient.getCallbackUrlList(config.getApplicationId());
+        // Update activation status
+        powerAuthClient.blockActivation(config.getActivationId(version), "TEST_CALLBACK", config.getUser(version));
+        String callbackUrlVerify = "http://localhost:" + port + "/callback/verify";
+        // When a HTTP error occurs, the test fails
+        Map<String, Object> request = new HashMap<>();
+        request.put("activationId", config.getActivationId(version));
+        request.put("userId", config.getUser(version));
+        request.put("activationName", "test v" + version);
+        request.put("deviceInfo", "backend-tests");
+        request.put("platform", "unknown");
+        request.put("activationFlags", Collections.emptyList());
+        request.put("activationStatus", "BLOCKED");
+        request.put("blockedReason", "TEST_CALLBACK");
+        request.put("applicationId", config.getApplicationId());
+        RestClientFactory.getRestClient().post(callbackUrlVerify, request, new ParameterizedTypeReference<String>() {});
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        powerAuthClient.unblockActivation(config.getActivationId(version), config.getUser(version));
+        boolean callbackFound = false;
+        for (CallbackUrl callback: callbacks.getCallbackUrlList()) {
+            if (Objects.equals(pasCreateCallbackUrlRequest.getName(), callback.getName())) {
+                callbackFound = true;
+                powerAuthClient.removeCallbackUrl(callback.getId());
+            }
+        }
+        assertTrue(callbackFound);
+    }
+}

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthCustomActivationOtpShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthCustomActivationOtpShared.java
@@ -1,0 +1,201 @@
+/*
+ * PowerAuth test and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.security.powerauth.test.shared.v4;
+
+import com.wultra.security.powerauth.client.model.enumeration.ActivationStatus;
+import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
+import com.wultra.security.powerauth.client.model.request.CommitActivationRequest;
+import com.wultra.security.powerauth.client.model.response.CommitActivationResponse;
+import com.wultra.security.powerauth.client.model.response.v4.GetActivationStatusResponse;
+import com.wultra.security.powerauth.client.v4.PowerAuthClient;
+import com.wultra.security.powerauth.crypto.lib.model.ActivationStatusBlobInfo;
+import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
+import com.wultra.security.powerauth.lib.cmd.steps.CreateActivationStep;
+import com.wultra.security.powerauth.lib.cmd.steps.GetStatusStep;
+import com.wultra.security.powerauth.lib.cmd.steps.model.CreateActivationStepModel;
+import com.wultra.security.powerauth.lib.cmd.steps.model.GetStatusStepModel;
+import com.wultra.security.powerauth.provider.CustomActivationProviderForTests;
+import com.wultra.security.powerauth.rest.api.model.response.v4.ActivationLayer1Response;
+import com.wultra.security.powerauth.rest.api.model.response.v4.ActivationLayer2Response;
+import org.junit.jupiter.api.AssertionFailureBuilder;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Custom activation OTP test shared logic.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class PowerAuthCustomActivationOtpShared {
+
+    public static void customActivationOtpValidTest(PowerAuthClient powerAuthClient, CreateActivationStepModel createModel, GetStatusStepModel statusModel,
+                                             ObjectStepLogger stepLogger, String validOtpValue, String invalidOtpValue) throws Exception {
+
+        Map<String, String> identityAttributes = new HashMap<>();
+        identityAttributes.put("test_id", "TEST_2_STATIC_NOCOMMIT_NOPROCESS");
+
+        Map<String, Object> customAttributes = new HashMap<>();
+        customAttributes.put("key", "value");
+
+        createModel.setIdentityAttributes(identityAttributes);
+        createModel.setCustomAttributes(customAttributes);
+
+        new CreateActivationStep().execute(stepLogger, createModel.toMap());
+        assertTrue(stepLogger.getResult().success());
+        assertEquals(200, stepLogger.getResponse().statusCode());
+
+        final ActivationLayer2Response layer2Response = fetchLayer2Response(stepLogger);
+
+        final String activationId = layer2Response.getActivationId();
+        assertNotNull(activationId);
+        assertNotNull(layer2Response.getCtrData());
+        assertNotNull(layer2Response.getServerPublicKeys());
+        assertNotNull(layer2Response.getSharedSecretResponse());
+
+        // Verify activation status - activation was not automatically committed
+        final GetActivationStatusResponse statusResponseActive = powerAuthClient.getActivationStatus(activationId);
+        assertEquals(ActivationStatus.PENDING_COMMIT, statusResponseActive.getActivationStatus());
+        assertEquals("static_username", statusResponseActive.getUserId());
+
+        final ActivationLayer1Response layer1Response = fetchLayer1Response(stepLogger);
+
+        // Verify custom attributes, there should be no change
+        assertEquals("value", layer1Response.getCustomAttributes().get("key"));
+
+        // Now update activation OTP for the pending activation
+        powerAuthClient.updateActivationOtp(activationId, null, validOtpValue);
+
+        // Try commit activation with wrong OTP, but the very last attempt is valid.
+        final int maxIterations = CustomActivationProviderForTests.MAX_FAILED_ATTEMPTS;
+        for (int iteration = 1; iteration <= maxIterations; iteration++) {
+            boolean lastIteration = iteration == maxIterations;
+            boolean isActivated;
+            try {
+                final CommitActivationRequest commitRequest = new CommitActivationRequest();
+                commitRequest.setActivationId(activationId);
+                commitRequest.setActivationOtp(lastIteration ? validOtpValue : invalidOtpValue);
+                final CommitActivationResponse commitResponse = powerAuthClient.commitActivation(commitRequest);
+                isActivated = commitResponse.isActivated();
+            } catch (PowerAuthClientException ex) {
+                isActivated = false;
+            }
+            assertEquals(lastIteration, isActivated);
+
+            // Verify activation status
+            ActivationStatus expectedActivationStatus = lastIteration ? ActivationStatus.ACTIVE : ActivationStatus.PENDING_COMMIT;
+            GetActivationStatusResponse activationStatusResponse = powerAuthClient.getActivationStatus(activationId);
+            assertEquals(expectedActivationStatus, activationStatusResponse.getActivationStatus());
+        }
+
+        // Try to get activation status via RESTful API
+        ObjectStepLogger stepLoggerStatus = new ObjectStepLogger(System.out);
+        new GetStatusStep().execute(stepLoggerStatus, statusModel.toMap());
+        assertTrue(stepLoggerStatus.getResult().success());
+        assertEquals(200, stepLoggerStatus.getResponse().statusCode());
+
+        // Validate failed attempts counter.
+        final Map<String, Object> statusResponseMap = (Map<String, Object>) stepLoggerStatus.getFirstItem("activation-status-obtained").object();
+        ActivationStatusBlobInfo statusBlobInfo = (ActivationStatusBlobInfo) statusResponseMap.get("statusBlob");
+        assertEquals(0L, statusBlobInfo.getFailedAttempts());
+
+        // Remove activation
+        powerAuthClient.removeActivation(activationId, "test");
+    }
+
+    public static void customActivationOtpInvalidTest(PowerAuthClient powerAuthClient, CreateActivationStepModel createModel,
+                                        ObjectStepLogger stepLogger, String validOtpValue, String invalidOtpValue) throws Exception {
+
+        Map<String, String> identityAttributes = new HashMap<>();
+        identityAttributes.put("test_id", "TEST_2_STATIC_NOCOMMIT_NOPROCESS");
+
+        Map<String, Object> customAttributes = new HashMap<>();
+        customAttributes.put("key", "value");
+
+        createModel.setIdentityAttributes(identityAttributes);
+        createModel.setCustomAttributes(customAttributes);
+
+        new CreateActivationStep().execute(stepLogger, createModel.toMap());
+        assertTrue(stepLogger.getResult().success());
+        assertEquals(200, stepLogger.getResponse().statusCode());
+
+        final ActivationLayer2Response layer2Response = fetchLayer2Response(stepLogger);
+
+        final String activationId = layer2Response.getActivationId();
+        assertNotNull(activationId);
+        assertNotNull(layer2Response.getCtrData());
+        assertNotNull(layer2Response.getServerPublicKeys());
+        assertNotNull(layer2Response.getSharedSecretResponse());
+
+        // Verify activation status - activation was not automatically committed
+        final GetActivationStatusResponse statusResponseActive = powerAuthClient.getActivationStatus(activationId);
+        assertEquals(ActivationStatus.PENDING_COMMIT, statusResponseActive.getActivationStatus());
+        assertEquals("static_username", statusResponseActive.getUserId());
+
+        final ActivationLayer1Response layer1Response = fetchLayer1Response(stepLogger);
+
+        // Verify custom attributes, there should be no change
+        assertEquals("value", layer1Response.getCustomAttributes().get("key"));
+
+        // Now update activation OTP for the pending activation
+        powerAuthClient.updateActivationOtp(activationId, null, validOtpValue);
+
+        // Try commit activation with wrong OTP
+        final int maxIterations = CustomActivationProviderForTests.MAX_FAILED_ATTEMPTS;
+        for (int iteration = 1; iteration <= maxIterations; iteration++) {
+            boolean lastIteration = iteration == maxIterations;
+            boolean isActivated;
+            try {
+                CommitActivationRequest commitRequest = new CommitActivationRequest();
+                commitRequest.setActivationId(activationId);
+                commitRequest.setActivationOtp(invalidOtpValue);
+                CommitActivationResponse commitResponse = powerAuthClient.commitActivation(commitRequest);
+                isActivated = commitResponse.isActivated();
+            } catch (PowerAuthClientException ex) {
+                isActivated = false;
+            }
+            assertFalse(isActivated);
+
+            // Verify activation status
+            ActivationStatus expectedActivationStatus = lastIteration ? ActivationStatus.REMOVED : ActivationStatus.PENDING_COMMIT;
+            GetActivationStatusResponse activationStatusResponse = powerAuthClient.getActivationStatus(activationId);
+            assertEquals(expectedActivationStatus, activationStatusResponse.getActivationStatus());
+        }
+
+        // Remove activation
+        powerAuthClient.removeActivation(activationId, "test");
+    }
+
+    private static ActivationLayer1Response fetchLayer1Response(final ObjectStepLogger stepLogger) {
+        return stepLogger.getItems().stream()
+                .filter(item -> "Decrypted Layer 1 Response".equals(item.name()))
+                .map(item -> (ActivationLayer1Response) item.object())
+                .findAny()
+                .orElseThrow(() -> AssertionFailureBuilder.assertionFailure().message("Response was not successfully decrypted").build());
+    }
+
+    private static ActivationLayer2Response fetchLayer2Response(final ObjectStepLogger stepLogger) {
+        return stepLogger.getItems().stream()
+                .filter(item -> "Decrypted Layer 2 Response".equals(item.name()))
+                .map(item -> (ActivationLayer2Response) item.object())
+                .findAny()
+                .orElseThrow(() -> AssertionFailureBuilder.assertionFailure().message("Response was not successfully decrypted").build());
+    }
+}

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthCustomActivationShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthCustomActivationShared.java
@@ -36,7 +36,6 @@ import com.wultra.security.powerauth.lib.cmd.steps.model.CreateActivationStepMod
 import com.wultra.security.powerauth.lib.cmd.steps.model.VerifyAuthenticationStepModel;
 import com.wultra.security.powerauth.rest.api.model.response.v4.ActivationLayer1Response;
 import com.wultra.security.powerauth.rest.api.model.response.v4.ActivationLayer2Response;
-import com.wultra.security.powerauth.test.shared.util.ResponseVerificationUtil;
 import org.junit.jupiter.api.AssertionFailureBuilder;
 
 import java.io.File;
@@ -282,7 +281,8 @@ public class PowerAuthCustomActivationShared {
         ObjectMapper objectMapper = config.getObjectMapper();
         final ErrorResponse errorResponse = objectMapper.readValue(stepLogger.getResponse().responseObject().toString(), ErrorResponse.class);
         assertEquals("ERROR", errorResponse.getStatus());
-        ResponseVerificationUtil.verifyErrorResponse(model, errorResponse);
+        assertEquals("ERR_TEMPORARY_KEY", errorResponse.getResponseObject().getCode());
+        assertEquals("POWER_AUTH_TEMPORARY_KEY_FAILURE", errorResponse.getResponseObject().getMessage());
 
         // Support application version
         powerAuthClient.supportApplicationVersion(config.getApplicationId(), config.getApplicationVersionId());
@@ -312,7 +312,8 @@ public class PowerAuthCustomActivationShared {
         ObjectMapper objectMapper = config.getObjectMapper();
         final ErrorResponse errorResponse = objectMapper.readValue(stepLogger.getResponse().responseObject().toString(), ErrorResponse.class);
         assertEquals("ERROR", errorResponse.getStatus());
-        ResponseVerificationUtil.verifyErrorResponse(model, errorResponse);
+        assertEquals("ERR_TEMPORARY_KEY", errorResponse.getResponseObject().getCode());
+        assertEquals("POWER_AUTH_TEMPORARY_KEY_FAILURE", errorResponse.getResponseObject().getMessage());
 
         model.setApplicationKey(config.getApplicationKey());
     }
@@ -333,7 +334,8 @@ public class PowerAuthCustomActivationShared {
         ObjectMapper objectMapper = config.getObjectMapper();
         final ErrorResponse errorResponse = objectMapper.readValue(stepLogger.getResponse().responseObject().toString(), ErrorResponse.class);
         assertEquals("ERROR", errorResponse.getStatus());
-        ResponseVerificationUtil.verifyErrorResponse(model, errorResponse);
+        assertEquals("ERR_TEMPORARY_KEY", errorResponse.getResponseObject().getCode());
+        assertEquals("POWER_AUTH_TEMPORARY_KEY_FAILURE", errorResponse.getResponseObject().getMessage());
 
         model.setApplicationSecret(config.getApplicationSecret());
     }

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthCustomActivationShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthCustomActivationShared.java
@@ -1,0 +1,454 @@
+/*
+ * PowerAuth test and related software components
+ * Copyright (C) 2023 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.security.powerauth.test.shared.v4;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wultra.core.rest.model.base.response.ErrorResponse;
+import com.wultra.security.powerauth.client.model.entity.ApplicationVersion;
+import com.wultra.security.powerauth.client.model.enumeration.ActivationStatus;
+import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
+import com.wultra.security.powerauth.client.model.response.v4.GetActivationStatusResponse;
+import com.wultra.security.powerauth.client.model.response.v4.GetApplicationDetailResponse;
+import com.wultra.security.powerauth.client.v4.PowerAuthClient;
+import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
+import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;
+import com.wultra.security.powerauth.crypto.lib.generator.KeyGenerator;
+import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
+import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
+import com.wultra.security.powerauth.lib.cmd.steps.CreateActivationStep;
+import com.wultra.security.powerauth.lib.cmd.steps.VerifyAuthenticationStep;
+import com.wultra.security.powerauth.lib.cmd.steps.model.CreateActivationStepModel;
+import com.wultra.security.powerauth.lib.cmd.steps.model.VerifyAuthenticationStepModel;
+import com.wultra.security.powerauth.rest.api.model.response.v4.ActivationLayer1Response;
+import com.wultra.security.powerauth.rest.api.model.response.v4.ActivationLayer2Response;
+import com.wultra.security.powerauth.test.shared.util.ResponseVerificationUtil;
+import org.junit.jupiter.api.AssertionFailureBuilder;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.KeyPair;
+import java.security.PublicKey;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Custom activation test shared logic.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class PowerAuthCustomActivationShared {
+
+    public static void customActivationValidTest(PowerAuthClient powerAuthClient, CreateActivationStepModel model, ObjectStepLogger stepLogger) throws Exception {
+        Map<String, String> identityAttributes = new HashMap<>();
+        identityAttributes.put("test_id", "TEST_1_SIMPLE_LOOKUP_COMMIT_PROCESS");
+        identityAttributes.put("username", "TestUser1");
+
+        Map<String, Object> customAttributes = new HashMap<>();
+        customAttributes.put("key", "value");
+
+        model.setIdentityAttributes(identityAttributes);
+        model.setCustomAttributes(customAttributes);
+
+        new CreateActivationStep().execute(stepLogger, model.toMap());
+        assertTrue(stepLogger.getResult().success());
+        assertEquals(200, stepLogger.getResponse().statusCode());
+
+        final ActivationLayer2Response layer2Response = fetchLayer2Response(stepLogger);
+        final String activationId = layer2Response.getActivationId();
+
+        assertNotNull(activationId);
+        assertNotNull(layer2Response.getCtrData());
+        assertNotNull(layer2Response.getServerPublicKeys());
+        assertNotNull(layer2Response.getSharedSecretResponse());
+
+        // Verify activation status - activation was automatically committed
+        final GetActivationStatusResponse statusResponseActive = powerAuthClient.getActivationStatus(activationId);
+        assertEquals(ActivationStatus.ACTIVE, statusResponseActive.getActivationStatus());
+        assertEquals("TestUser1", statusResponseActive.getUserId());
+
+        final ActivationLayer1Response layer1Response = fetchLayer1Response(stepLogger);
+        // Verify custom attributes after processing
+        assertEquals("value_new", layer1Response.getCustomAttributes().get("key_new"));
+
+        powerAuthClient.removeActivation(activationId, "test");
+    }
+
+    public static void customActivationValid2Test(PowerAuthClient powerAuthClient, CreateActivationStepModel model, ObjectStepLogger stepLogger) throws Exception {
+        Map<String, String> identityAttributes = new HashMap<>();
+        identityAttributes.put("test_id", "TEST_2_STATIC_NOCOMMIT_NOPROCESS");
+
+        Map<String, Object> customAttributes = new HashMap<>();
+        customAttributes.put("key", "value");
+
+        model.setIdentityAttributes(identityAttributes);
+        model.setCustomAttributes(customAttributes);
+
+        new CreateActivationStep().execute(stepLogger, model.toMap());
+        assertTrue(stepLogger.getResult().success());
+        assertEquals(200, stepLogger.getResponse().statusCode());
+
+        final ActivationLayer2Response layer2Response = fetchLayer2Response(stepLogger);
+        final String activationId = layer2Response.getActivationId();
+        assertNotNull(activationId);
+        assertNotNull(layer2Response.getCtrData());
+        assertNotNull(layer2Response.getServerPublicKeys());
+        assertNotNull(layer2Response.getSharedSecretResponse());
+
+        // Verify activation status - activation was not automatically committed
+        final GetActivationStatusResponse statusResponseActive = powerAuthClient.getActivationStatus(activationId);
+        assertEquals(ActivationStatus.PENDING_COMMIT, statusResponseActive.getActivationStatus());
+        assertEquals("static_username", statusResponseActive.getUserId());
+
+        final ActivationLayer1Response layer1Response = fetchLayer1Response(stepLogger);
+        // Verify custom attributes, there should be no change
+        assertEquals("value", layer1Response.getCustomAttributes().get("key"));
+
+        powerAuthClient.removeActivation(activationId, "test");
+    }
+
+    public static void customActivationValid3Test(PowerAuthClient powerAuthClient, CreateActivationStepModel model, ObjectStepLogger stepLogger) throws Exception {
+        Map<String, String> identityAttributes = new HashMap<>();
+        identityAttributes.put("test_id", "TEST_3_USER_ID_MAP_COMMIT_NOPROCESS");
+
+        Map<String, Object> customAttributes = new HashMap<>();
+        identityAttributes.put("username", "TestUser1");
+        customAttributes.put("key", "value");
+
+        model.setIdentityAttributes(identityAttributes);
+        model.setCustomAttributes(customAttributes);
+
+        new CreateActivationStep().execute(stepLogger, model.toMap());
+        assertTrue(stepLogger.getResult().success());
+        assertEquals(200, stepLogger.getResponse().statusCode());
+
+        final ActivationLayer2Response layer2Response = fetchLayer2Response(stepLogger);
+        final String activationId = layer2Response.getActivationId();
+        assertNotNull(activationId);
+        assertNotNull(layer2Response.getCtrData());
+        assertNotNull(layer2Response.getServerPublicKeys());
+        assertNotNull(layer2Response.getSharedSecretResponse());
+
+        // Verify activation status - activation was automatically committed
+        final GetActivationStatusResponse statusResponseActive = powerAuthClient.getActivationStatus(activationId);
+        assertEquals(ActivationStatus.ACTIVE, statusResponseActive.getActivationStatus());
+        assertEquals("12345678", statusResponseActive.getUserId());
+
+        final ActivationLayer1Response layer1Response = fetchLayer1Response(stepLogger);
+        // Verify custom attributes, there should be no change
+        assertEquals("value", layer1Response.getCustomAttributes().get("key"));
+
+        powerAuthClient.removeActivation(activationId, "test");
+    }
+
+    public static void customActivationMissingUsernameTest(PowerAuthTestConfiguration config, CreateActivationStepModel model, ObjectStepLogger stepLogger) throws Exception {
+        Map<String, String> identityAttributes = new HashMap<>();
+        identityAttributes.put("test_id", "TEST_4_MISSING_USERNAME");
+
+        Map<String, Object> customAttributes = new HashMap<>();
+        customAttributes.put("key", "value");
+
+        model.setIdentityAttributes(identityAttributes);
+        model.setCustomAttributes(customAttributes);
+
+        new CreateActivationStep().execute(stepLogger, model.toMap());
+        assertFalse(stepLogger.getResult().success());
+        assertEquals(400, stepLogger.getResponse().statusCode());
+
+        // Verify error response
+        ObjectMapper objectMapper = config.getObjectMapper();
+        final ErrorResponse errorResponse = objectMapper.readValue(stepLogger.getResponse().responseObject().toString(), ErrorResponse.class);
+        assertEquals("ERROR", errorResponse.getStatus());
+        assertEquals("ERR_ACTIVATION", errorResponse.getResponseObject().getCode());
+        assertEquals("POWER_AUTH_ACTIVATION_INVALID", errorResponse.getResponseObject().getMessage());
+    }
+
+    public static void customActivationEmptyUsernameTest(PowerAuthTestConfiguration config, CreateActivationStepModel model, ObjectStepLogger stepLogger) throws Exception {
+        Map<String, String> identityAttributes = new HashMap<>();
+        identityAttributes.put("test_id", "TEST_5_EMPTY_USERNAME");
+        identityAttributes.put("username", "");
+
+        Map<String, Object> customAttributes = new HashMap<>();
+        customAttributes.put("key", "value");
+
+        model.setIdentityAttributes(identityAttributes);
+        model.setCustomAttributes(customAttributes);
+
+        new CreateActivationStep().execute(stepLogger, model.toMap());
+        assertFalse(stepLogger.getResult().success());
+        assertEquals(400, stepLogger.getResponse().statusCode());
+
+        // Verify error response
+        ObjectMapper objectMapper = config.getObjectMapper();
+        final ErrorResponse errorResponse = objectMapper.readValue(stepLogger.getResponse().responseObject().toString(), ErrorResponse.class);
+        assertEquals("ERROR", errorResponse.getStatus());
+        assertEquals("ERR_ACTIVATION", errorResponse.getResponseObject().getCode());
+        assertEquals("POWER_AUTH_ACTIVATION_INVALID", errorResponse.getResponseObject().getMessage());
+    }
+
+    public static void customActivationUsernameTooLongTest(PowerAuthTestConfiguration config, CreateActivationStepModel model, ObjectStepLogger stepLogger) throws Exception {
+        Map<String, String> identityAttributes = new HashMap<>();
+        identityAttributes.put("test_id", "TEST_6_USERNAME_TOO_LONG");
+        identityAttributes.put("username", "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890");
+
+        Map<String, Object> customAttributes = new HashMap<>();
+        customAttributes.put("key", "value");
+
+        model.setIdentityAttributes(identityAttributes);
+        model.setCustomAttributes(customAttributes);
+
+        new CreateActivationStep().execute(stepLogger, model.toMap());
+        assertFalse(stepLogger.getResult().success());
+        assertEquals(400, stepLogger.getResponse().statusCode());
+
+        // Verify error response
+        ObjectMapper objectMapper = config.getObjectMapper();
+        final ErrorResponse errorResponse = objectMapper.readValue(stepLogger.getResponse().responseObject().toString(), ErrorResponse.class);
+        assertEquals("ERROR", errorResponse.getStatus());
+        assertEquals("ERR_ACTIVATION", errorResponse.getResponseObject().getCode());
+        assertEquals("POWER_AUTH_ACTIVATION_INVALID", errorResponse.getResponseObject().getMessage());
+    }
+
+    public static void customActivationBadMasterPublicKeyTest(PowerAuthTestConfiguration config, CreateActivationStepModel model, ObjectStepLogger stepLogger) throws Exception {
+        Map<String, String> identityAttributes = new HashMap<>();
+        identityAttributes.put("test_id", "TEST_7_BAD_MASTER_PUBLIC_KEY");
+        model.setIdentityAttributes(identityAttributes);
+
+        KeyPair keyPair = new KeyGenerator().generateKeyPair();
+        PublicKey originalKey = model.getMasterPublicKeyP256();
+
+        // Set bad master public key
+        model.setMasterPublicKeyP384(keyPair.getPublic());
+
+        // Create activation
+        new CreateActivationStep().execute(stepLogger, model.toMap());
+        assertFalse(stepLogger.getResult().success());
+        if (model.getVersion().useTemporaryKeys()) {
+            // JWT signature error, cannot obtain server response
+            assertNull(stepLogger.getResponse());
+        } else {
+            assertEquals(400, stepLogger.getResponse().statusCode());
+            // Verify error response
+            ObjectMapper objectMapper = config.getObjectMapper();
+            final ErrorResponse errorResponse = objectMapper.readValue(stepLogger.getResponse().responseObject().toString(), ErrorResponse.class);
+            assertEquals("ERROR", errorResponse.getStatus());
+            assertEquals("ERR_ACTIVATION", errorResponse.getResponseObject().getCode());
+            assertEquals("POWER_AUTH_ACTIVATION_INVALID", errorResponse.getResponseObject().getMessage());
+        }
+
+        // Revert master public key change
+        model.setMasterPublicKeyP384(originalKey);
+    }
+
+    public static void customActivationUnsupportedApplicationTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config, CreateActivationStepModel model, ObjectStepLogger stepLogger) throws Exception {
+        Map<String, String> identityAttributes = new HashMap<>();
+        identityAttributes.put("test_id", "TEST_8_UNSUPPORTED_APP_VERSION");
+        model.setIdentityAttributes(identityAttributes);
+
+        // Unsupport application version
+        powerAuthClient.unsupportApplicationVersion(config.getApplicationId(), config.getApplicationVersionId());
+
+        // Verify that application version is unsupported
+        final GetApplicationDetailResponse detailResponse = powerAuthClient.getApplicationDetail(config.getApplicationId());
+        for (ApplicationVersion version: detailResponse.getVersions()) {
+            if (version.getApplicationVersionId().equals(config.getApplicationVersion())) {
+                assertFalse(version.isSupported());
+            }
+        }
+
+        // Create activation
+        new CreateActivationStep().execute(stepLogger, model.toMap());
+        assertFalse(stepLogger.getResult().success());
+        assertEquals(400, stepLogger.getResponse().statusCode());
+
+        // Verify error response
+        ObjectMapper objectMapper = config.getObjectMapper();
+        final ErrorResponse errorResponse = objectMapper.readValue(stepLogger.getResponse().responseObject().toString(), ErrorResponse.class);
+        assertEquals("ERROR", errorResponse.getStatus());
+        ResponseVerificationUtil.verifyErrorResponse(model, errorResponse);
+
+        // Support application version
+        powerAuthClient.supportApplicationVersion(config.getApplicationId(), config.getApplicationVersionId());
+
+        // Verify that application version is supported
+        GetApplicationDetailResponse detailResponse2 = powerAuthClient.getApplicationDetail(config.getApplicationId());
+        for (ApplicationVersion version: detailResponse2.getVersions()) {
+            if (version.getApplicationVersionId().equals(config.getApplicationVersion())) {
+                assertTrue(version.isSupported());
+            }
+        }
+    }
+
+    public static void customActivationInvalidApplicationKeyTest(PowerAuthTestConfiguration config, CreateActivationStepModel model, ObjectStepLogger stepLogger) throws Exception {
+        Map<String, String> identityAttributes = new HashMap<>();
+        identityAttributes.put("test_id", "TEST_8_INVALID_APP_KEY");
+        model.setIdentityAttributes(identityAttributes);
+
+        model.setApplicationKey("invalid");
+
+        // Verify that CreateActivation fails
+        new CreateActivationStep().execute(stepLogger, model.toMap());
+        assertFalse(stepLogger.getResult().success());
+        assertEquals(400, stepLogger.getResponse().statusCode());
+
+        // Verify error response
+        ObjectMapper objectMapper = config.getObjectMapper();
+        final ErrorResponse errorResponse = objectMapper.readValue(stepLogger.getResponse().responseObject().toString(), ErrorResponse.class);
+        assertEquals("ERROR", errorResponse.getStatus());
+        ResponseVerificationUtil.verifyErrorResponse(model, errorResponse);
+
+        model.setApplicationKey(config.getApplicationKey());
+    }
+
+    public static void customActivationInvalidApplicationSecretTest(PowerAuthTestConfiguration config, CreateActivationStepModel model, ObjectStepLogger stepLogger) throws Exception {
+        Map<String, String> identityAttributes = new HashMap<>();
+        identityAttributes.put("test_id", "TEST_8_INVALID_APP_SECRET");
+        model.setIdentityAttributes(identityAttributes);
+
+        model.setApplicationSecret("invalid");
+
+        // Verify that CreateActivation fails
+        new CreateActivationStep().execute(stepLogger, model.toMap());
+        assertFalse(stepLogger.getResult().success());
+        assertEquals(400, stepLogger.getResponse().statusCode());
+
+        // Verify error response
+        ObjectMapper objectMapper = config.getObjectMapper();
+        final ErrorResponse errorResponse = objectMapper.readValue(stepLogger.getResponse().responseObject().toString(), ErrorResponse.class);
+        assertEquals("ERROR", errorResponse.getStatus());
+        ResponseVerificationUtil.verifyErrorResponse(model, errorResponse);
+
+        model.setApplicationSecret(config.getApplicationSecret());
+    }
+
+    public static void customActivationDoubleCommitTest(PowerAuthClient powerAuthClient, CreateActivationStepModel model, ObjectStepLogger stepLogger) throws Exception {
+        Map<String, String> identityAttributes = new HashMap<>();
+        identityAttributes.put("test_id", "TEST_9_DOUBLE_COMMIT");
+        identityAttributes.put("username", "TestUser1");
+        model.setIdentityAttributes(identityAttributes);
+
+        new CreateActivationStep().execute(stepLogger, model.toMap());
+        assertTrue(stepLogger.getResult().success());
+        assertEquals(200, stepLogger.getResponse().statusCode());
+
+        final ActivationLayer2Response layer2Response = fetchLayer2Response(stepLogger);
+        final String activationId = layer2Response.getActivationId();
+        assertNotNull(activationId);
+        assertNotNull(layer2Response.getCtrData());
+        assertNotNull(layer2Response.getServerPublicKeys());
+        assertNotNull(layer2Response.getSharedSecretResponse());
+
+        // Verify activation status - activation was automatically committed
+        final GetActivationStatusResponse statusResponseActive = powerAuthClient.getActivationStatus(activationId);
+        assertEquals(ActivationStatus.ACTIVE, statusResponseActive.getActivationStatus());
+
+        fetchLayer1Response(stepLogger);
+
+        // Commit activation
+        try {
+            powerAuthClient.commitActivation(activationId, "test");
+            fail("Double commit should not be allowed");
+        } catch (PowerAuthClientException ex) {
+            powerAuthClient.removeActivation(activationId, "test");
+        }
+    }
+
+    public static void customActivationSignatureMaxFailedTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config,
+                                                              CreateActivationStepModel model, ObjectStepLogger stepLogger,
+                                                              File dataFile, File tempStatusFile, Integer port, PowerAuthVersion version) throws Exception {
+        Map<String, String> identityAttributes = new HashMap<>();
+        identityAttributes.put("test_id", "TEST_10_SIGNATURES_MAX_FAILED");
+        identityAttributes.put("username", "TestUser1");
+
+        model.setIdentityAttributes(identityAttributes);
+
+        new CreateActivationStep().execute(stepLogger, model.toMap());
+        assertTrue(stepLogger.getResult().success());
+        assertEquals(200, stepLogger.getResponse().statusCode());
+
+        final ActivationLayer2Response layer2Response = fetchLayer2Response(stepLogger);
+        final String activationId = layer2Response.getActivationId();
+        assertNotNull(activationId);
+
+        fetchLayer1Response(stepLogger);
+
+        VerifyAuthenticationStepModel signatureModel = new VerifyAuthenticationStepModel();
+        signatureModel.setApplicationKey(config.getApplicationKey());
+        signatureModel.setApplicationSecret(config.getApplicationSecret());
+        signatureModel.setData(Files.readAllBytes(Paths.get(dataFile.getAbsolutePath())));
+        signatureModel.setHeaders(new HashMap<>());
+        signatureModel.setHttpMethod("POST");
+        signatureModel.setPassword(config.getPassword());
+        signatureModel.setResourceId("/pa/auth/validate");
+        signatureModel.setResultStatusObject(config.getResultStatusObject(version));
+        signatureModel.setAuthenticationCodeType(PowerAuthCodeType.POSSESSION_KNOWLEDGE);
+        signatureModel.setStatusFileName(tempStatusFile.getAbsolutePath());
+        signatureModel.setUriString("http://localhost:" + port + "/pa/v4/auth/validate");
+        signatureModel.setVersion(version);
+
+        signatureModel.setPassword("1111");
+
+        // Fail 2 signatures (configured value for maximum failed count is 3)
+        for (int i = 0; i < 2; i++) {
+            ObjectStepLogger stepLoggerSignature = new ObjectStepLogger();
+            new VerifyAuthenticationStep().execute(stepLoggerSignature, signatureModel.toMap());
+            assertFalse(stepLoggerSignature.getResult().success());
+            assertEquals(401, stepLoggerSignature.getResponse().statusCode());
+        }
+
+        // Last signature before max failed attempts should be successful
+        signatureModel.setPassword(config.getPassword());
+        ObjectStepLogger stepLogger2 = new ObjectStepLogger();
+        new VerifyAuthenticationStep().execute(stepLogger2, signatureModel.toMap());
+        assertTrue(stepLogger2.getResult().success());
+        assertEquals(200, stepLogger2.getResponse().statusCode());
+
+        // Fail 3 signatures (configured value for maximum failed count is 3)
+        signatureModel.setPassword("1111");
+        for (int i = 0; i < 3; i++) {
+            ObjectStepLogger stepLoggerSignature = new ObjectStepLogger();
+            new VerifyAuthenticationStep().execute(stepLoggerSignature, signatureModel.toMap());
+            assertFalse(stepLoggerSignature.getResult().success());
+            assertEquals(401, stepLoggerSignature.getResponse().statusCode());
+        }
+
+        // Activation should be blocked
+        GetActivationStatusResponse statusResponseBlocked = powerAuthClient.getActivationStatus(activationId);
+        assertEquals(ActivationStatus.BLOCKED, statusResponseBlocked.getActivationStatus());
+
+        powerAuthClient.removeActivation(activationId, "test");
+    }
+
+    private static ActivationLayer1Response fetchLayer1Response(final ObjectStepLogger stepLogger) {
+        return stepLogger.getItems().stream()
+                .filter(item -> "Decrypted Layer 1 Response".equals(item.name()))
+                .map(item -> (ActivationLayer1Response) item.object())
+                .findAny()
+                .orElseThrow(() -> AssertionFailureBuilder.assertionFailure().message("Response was not successfully decrypted").build());
+    }
+
+    private static ActivationLayer2Response fetchLayer2Response(final ObjectStepLogger stepLogger) {
+        return stepLogger.getItems().stream()
+                .filter(item -> "Decrypted Layer 2 Response".equals(item.name()))
+                .map(item -> (ActivationLayer2Response) item.object())
+                .findAny()
+                .orElseThrow(() -> AssertionFailureBuilder.assertionFailure().message("Response was not successfully decrypted").build());
+    }
+}

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthDynamicFactorShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthDynamicFactorShared.java
@@ -1,0 +1,44 @@
+/*
+ * PowerAuth test and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.security.powerauth.test.shared.v4;
+
+import com.wultra.security.powerauth.crypto.lib.v4.encryptor.model.response.AeadEncryptedResponse;
+import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
+import com.wultra.security.powerauth.lib.cmd.steps.ChangePasswordStep;
+import com.wultra.security.powerauth.lib.cmd.steps.model.ChangePasswordStepModel;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * PowerAuth dynamic factor test shared logic.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class PowerAuthDynamicFactorShared {
+
+    public static void passwordChangeTest(final ChangePasswordStepModel model, final ObjectStepLogger stepLogger) throws Exception {
+        new ChangePasswordStep().execute(stepLogger, model.toMap());
+        assertTrue(stepLogger.getResult().success());
+        assertEquals(200, stepLogger.getResponse().statusCode());
+
+        final AeadEncryptedResponse response = (AeadEncryptedResponse) stepLogger.getResponse().responseObject();
+        assertNotNull(response.getEncryptedData());
+        assertNotNull(response.getTimestamp());
+    }
+
+}

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthDynamicFactorShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthDynamicFactorShared.java
@@ -20,7 +20,11 @@ package com.wultra.security.powerauth.test.shared.v4;
 import com.wultra.security.powerauth.crypto.lib.v4.encryptor.model.response.AeadEncryptedResponse;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
 import com.wultra.security.powerauth.lib.cmd.steps.ChangePasswordStep;
+import com.wultra.security.powerauth.lib.cmd.steps.RemoveBiometryStep;
+import com.wultra.security.powerauth.lib.cmd.steps.SetupBiometryStep;
 import com.wultra.security.powerauth.lib.cmd.steps.model.ChangePasswordStepModel;
+import com.wultra.security.powerauth.lib.cmd.steps.model.RemoveBiometryStepModel;
+import com.wultra.security.powerauth.lib.cmd.steps.model.SetupBiometryStepModel;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -39,6 +43,22 @@ public class PowerAuthDynamicFactorShared {
         final AeadEncryptedResponse response = (AeadEncryptedResponse) stepLogger.getResponse().responseObject();
         assertNotNull(response.getEncryptedData());
         assertNotNull(response.getTimestamp());
+    }
+
+    public static void addBiometryTest(final SetupBiometryStepModel addBiometryModel, final ObjectStepLogger stepLogger) throws Exception {
+        new SetupBiometryStep().execute(stepLogger, addBiometryModel.toMap());
+        assertTrue(stepLogger.getResult().success());
+        assertEquals(200, stepLogger.getResponse().statusCode());
+
+        final AeadEncryptedResponse response = (AeadEncryptedResponse) stepLogger.getResponse().responseObject();
+        assertNotNull(response.getEncryptedData());
+        assertNotNull(response.getTimestamp());
+    }
+
+    public static void removeBiometryTest(final RemoveBiometryStepModel removeBiometryModel, final ObjectStepLogger stepLogger) throws Exception {
+        new RemoveBiometryStep().execute(stepLogger, removeBiometryModel.toMap());
+        assertTrue(stepLogger.getResult().success());
+        assertEquals(200, stepLogger.getResponse().statusCode());
     }
 
 }

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthEncryptionShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthEncryptionShared.java
@@ -444,6 +444,26 @@ public class PowerAuthEncryptionShared {
         assertEquals("ERROR", errorResponse.getStatus());
     }
 
+    public static void signAndEncryptBiometryTest(PowerAuthTestConfiguration config, VerifyAuthenticationStepModel signatureModel, ObjectStepLogger stepLogger) throws Exception {
+        signatureModel.setResourceId("/exchange/signed");
+        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/signed");
+        signatureModel.setAuthenticationCodeType(PowerAuthCodeType.POSSESSION_BIOMETRY);
+
+        new SignAndEncryptStep().execute(stepLogger, signatureModel.toMap());
+        assertTrue(stepLogger.getResult().success());
+        assertEquals(200, stepLogger.getResponse().statusCode());
+    }
+
+    public static void signAndEncryptThreeFactorTest(PowerAuthTestConfiguration config, VerifyAuthenticationStepModel signatureModel, ObjectStepLogger stepLogger) throws Exception {
+        signatureModel.setResourceId("/exchange/signed");
+        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/signed");
+        signatureModel.setAuthenticationCodeType(PowerAuthCodeType.POSSESSION_KNOWLEDGE_BIOMETRY);
+
+        new SignAndEncryptStep().execute(stepLogger, signatureModel.toMap());
+        assertTrue(stepLogger.getResult().success());
+        assertEquals(200, stepLogger.getResponse().statusCode());
+    }
+
     public static void encryptedResponseTest(final PowerAuthTestConfiguration config, EncryptStepModel encryptModel, ObjectStepLogger stepLogger, PowerAuthVersion version) throws Exception {
         encryptModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v4/activation");
         encryptModel.setScope("activation");

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthEncryptionShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthEncryptionShared.java
@@ -109,19 +109,18 @@ public class PowerAuthEncryptionShared {
     }
 
     public static void encryptEmptyDataTest(PowerAuthTestConfiguration config, EncryptStepModel encryptModel, ObjectStepLogger stepLogger) throws Exception {
-        File emptyDataFile = File.createTempFile("data_empty_signed", ".json");
+        File emptyDataFile = File.createTempFile("data_empty", ".txt");
         emptyDataFile.deleteOnExit();
         FileWriter fw = new FileWriter(emptyDataFile);
         fw.close();
 
         encryptModel.setData(Files.readAllBytes(Paths.get(emptyDataFile.getAbsolutePath())));
-        encryptModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v4/activation");
+        encryptModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v4/raw");
         encryptModel.setScope("activation");
 
         new EncryptStep().execute(stepLogger, encryptModel.toMap());
-        // It is not allowed to encrypt empty data in v4
-        assertFalse(stepLogger.getResult().success());
-        assertEquals(400, stepLogger.getResponse().statusCode());
+        assertTrue(stepLogger.getResult().success());
+        assertEquals(200, stepLogger.getResponse().statusCode());
     }
 
     public static void encryptBlockedActivationTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config, EncryptStepModel encryptModel, ObjectStepLogger stepLogger, PowerAuthVersion version) throws Exception {
@@ -200,7 +199,7 @@ public class PowerAuthEncryptionShared {
     public static void signAndEncryptEmptyDataTest(PowerAuthTestConfiguration config, VerifyAuthenticationStepModel signatureModel, EncryptStepModel encryptModel, ObjectStepLogger stepLogger) throws Exception {
         signatureModel.setResourceId("/exchange/signed");
         signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v4/signed");
-        File emptyDataFile = File.createTempFile("data_empty_signed", ".json");
+        File emptyDataFile = File.createTempFile("data_empty_signed", ".txt");
         emptyDataFile.deleteOnExit();
         FileWriter fw = new FileWriter(emptyDataFile);
         fw.close();

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthEncryptionShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthEncryptionShared.java
@@ -1,6 +1,6 @@
 /*
  * PowerAuth test and related software components
- * Copyright (C) 2023 Wultra s.r.o.
+ * Copyright (C) 2025 Wultra s.r.o.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
@@ -15,34 +15,23 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.wultra.security.powerauth.test.shared;
+package com.wultra.security.powerauth.test.shared.v4;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.wultra.security.powerauth.client.v3.PowerAuthClient;
-import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
-import com.wultra.security.powerauth.client.model.request.v3.GetEciesDecryptorRequest;
-import com.wultra.security.powerauth.client.model.response.v3.GetEciesDecryptorResponse;
-import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ClientEciesSecrets;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedRequest;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedResponse;
-import com.wultra.security.powerauth.model.TemporaryKey;
-import com.wultra.security.powerauth.test.shared.util.TemporaryKeyFetchUtil;
 import com.wultra.core.rest.model.base.response.ErrorResponse;
-import com.wultra.security.powerauth.crypto.lib.encryptor.ClientEncryptor;
+import com.wultra.security.powerauth.client.v4.PowerAuthClient;
+import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
 import com.wultra.security.powerauth.crypto.lib.encryptor.EncryptorFactory;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorParameters;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorScope;
 import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;
 import com.wultra.security.powerauth.crypto.lib.generator.HashBasedCounter;
+import com.wultra.security.powerauth.crypto.lib.v4.encryptor.model.response.AeadEncryptedResponse;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
 import com.wultra.security.powerauth.lib.cmd.logging.model.StepItem;
-import com.wultra.security.powerauth.lib.cmd.steps.model.EncryptStepModel;
-import com.wultra.security.powerauth.lib.cmd.steps.model.VerifyAuthenticationStepModel;
 import com.wultra.security.powerauth.lib.cmd.steps.EncryptStep;
 import com.wultra.security.powerauth.lib.cmd.steps.SignAndEncryptStep;
+import com.wultra.security.powerauth.lib.cmd.steps.model.EncryptStepModel;
+import com.wultra.security.powerauth.lib.cmd.steps.model.VerifyAuthenticationStepModel;
 import com.wultra.security.powerauth.lib.cmd.util.CounterUtil;
 import org.junit.jupiter.api.AssertionFailureBuilder;
 
@@ -68,16 +57,16 @@ public class PowerAuthEncryptionShared {
     private static final EncryptorFactory ENCRYPTOR_FACTORY = new EncryptorFactory();
 
     public static void encryptInActivationScopeTest(PowerAuthTestConfiguration config, EncryptStepModel encryptModel, ObjectStepLogger stepLogger) throws Exception {
-        encryptModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/activation");
+        encryptModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v4/activation");
         encryptModel.setScope("activation");
 
         new EncryptStep().execute(stepLogger, encryptModel.toMap());
         assertTrue(stepLogger.getResult().success());
         assertEquals(200, stepLogger.getResponse().statusCode());
 
-        final EciesEncryptedResponse responseOK = (EciesEncryptedResponse) stepLogger.getResponse().responseObject();
+        final AeadEncryptedResponse responseOK = (AeadEncryptedResponse) stepLogger.getResponse().responseObject();
         assertNotNull(responseOK.getEncryptedData());
-        assertNotNull(responseOK.getMac());
+        assertNotNull(responseOK.getTimestamp());
 
         final Object result = fetchDecryptedResponse(stepLogger);
 
@@ -85,16 +74,16 @@ public class PowerAuthEncryptionShared {
     }
 
     public static void encryptInApplicationScopeTest(PowerAuthTestConfiguration config, EncryptStepModel encryptModel, ObjectStepLogger stepLogger) throws Exception {
-        encryptModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/application");
+        encryptModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v4/application");
         encryptModel.setScope("application");
 
         new EncryptStep().execute(stepLogger, encryptModel.toMap());
         assertTrue(stepLogger.getResult().success());
         assertEquals(200, stepLogger.getResponse().statusCode());
 
-        final EciesEncryptedResponse responseOK = (EciesEncryptedResponse) stepLogger.getResponse().responseObject();
+        final AeadEncryptedResponse responseOK = (AeadEncryptedResponse) stepLogger.getResponse().responseObject();
         assertNotNull(responseOK.getEncryptedData());
-        assertNotNull(responseOK.getMac());
+        assertNotNull(responseOK.getTimestamp());
 
         final Object result = fetchDecryptedResponse(stepLogger);
 
@@ -102,7 +91,7 @@ public class PowerAuthEncryptionShared {
     }
 
     public static void encryptInInvalidScope1Test(PowerAuthTestConfiguration config, EncryptStepModel encryptModel, ObjectStepLogger stepLogger) throws Exception {
-        encryptModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/activation");
+        encryptModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v4/activation");
         encryptModel.setScope("application");
 
         new EncryptStep().execute(stepLogger, encryptModel.toMap());
@@ -111,7 +100,7 @@ public class PowerAuthEncryptionShared {
     }
 
     public static void encryptInInvalidScope2Test(PowerAuthTestConfiguration config, EncryptStepModel encryptModel, ObjectStepLogger stepLogger) throws Exception {
-        encryptModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/application");
+        encryptModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v4/application");
         encryptModel.setScope("activation");
 
         new EncryptStep().execute(stepLogger, encryptModel.toMap());
@@ -126,17 +115,17 @@ public class PowerAuthEncryptionShared {
         fw.close();
 
         encryptModel.setData(Files.readAllBytes(Paths.get(emptyDataFile.getAbsolutePath())));
-        encryptModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/activation");
+        encryptModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v4/activation");
         encryptModel.setScope("activation");
 
         new EncryptStep().execute(stepLogger, encryptModel.toMap());
-        // It is allowed to encrypt empty data
-        assertTrue(stepLogger.getResult().success());
-        assertEquals(200, stepLogger.getResponse().statusCode());
+        // It is not allowed to encrypt empty data in v4
+        assertFalse(stepLogger.getResult().success());
+        assertEquals(400, stepLogger.getResponse().statusCode());
     }
 
     public static void encryptBlockedActivationTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config, EncryptStepModel encryptModel, ObjectStepLogger stepLogger, PowerAuthVersion version) throws Exception {
-        encryptModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/activation");
+        encryptModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v4/activation");
         encryptModel.setScope("activation");
 
         // Block activation and verify that data exchange fails
@@ -155,9 +144,9 @@ public class PowerAuthEncryptionShared {
         assertTrue(stepLoggerSuccess.getResult().success());
         assertEquals(200, stepLoggerSuccess.getResponse().statusCode());
 
-        final EciesEncryptedResponse responseOK = (EciesEncryptedResponse) stepLoggerSuccess.getResponse().responseObject();
+        final AeadEncryptedResponse responseOK = (AeadEncryptedResponse) stepLoggerSuccess.getResponse().responseObject();
         assertNotNull(responseOK.getEncryptedData());
-        assertNotNull(responseOK.getMac());
+        assertNotNull(responseOK.getTimestamp());
 
         boolean responseSuccessfullyDecrypted = false;
         for (StepItem item: stepLoggerSuccess.getItems()) {
@@ -171,16 +160,16 @@ public class PowerAuthEncryptionShared {
     }
 
     public static void signAndEncryptTest(PowerAuthTestConfiguration config, VerifyAuthenticationStepModel signatureModel, ObjectStepLogger stepLogger, PowerAuthVersion version) throws Exception {
-        signatureModel.setResourceId("/exchange/v3/signed");
-        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/signed");
+        signatureModel.setResourceId("/exchange/signed");
+        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v4/signed");
 
         new SignAndEncryptStep().execute(stepLogger, signatureModel.toMap());
         assertTrue(stepLogger.getResult().success());
         assertEquals(200, stepLogger.getResponse().statusCode());
 
-        final EciesEncryptedResponse responseOK = (EciesEncryptedResponse) stepLogger.getResponse().responseObject();
+        final AeadEncryptedResponse responseOK = (AeadEncryptedResponse) stepLogger.getResponse().responseObject();
         assertNotNull(responseOK.getEncryptedData());
-        assertNotNull(responseOK.getMac());
+        assertNotNull(responseOK.getTimestamp());
 
         final Object result = fetchDecryptedResponse(stepLogger);
 
@@ -188,8 +177,8 @@ public class PowerAuthEncryptionShared {
     }
 
     public static void signAndEncryptWeakSignatureTypeTest(PowerAuthTestConfiguration config, VerifyAuthenticationStepModel signatureModel, ObjectStepLogger stepLogger) throws Exception {
-        signatureModel.setResourceId("/exchange/v3/signed");
-        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/signed");
+        signatureModel.setResourceId("/exchange/signed");
+        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v4/signed");
 
         signatureModel.setAuthenticationCodeType(PowerAuthCodeType.POSSESSION);
 
@@ -199,8 +188,8 @@ public class PowerAuthEncryptionShared {
     }
 
     public static void signAndEncryptInvalidPasswordTest(PowerAuthTestConfiguration config, VerifyAuthenticationStepModel signatureModel, ObjectStepLogger stepLogger) throws Exception {
-        signatureModel.setResourceId("/exchange/v3/signed");
-        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/signed");
+        signatureModel.setResourceId("/exchange/signed");
+        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v4/signed");
         signatureModel.setPassword("0000");
 
         new SignAndEncryptStep().execute(stepLogger, signatureModel.toMap());
@@ -209,8 +198,8 @@ public class PowerAuthEncryptionShared {
     }
 
     public static void signAndEncryptEmptyDataTest(PowerAuthTestConfiguration config, VerifyAuthenticationStepModel signatureModel, EncryptStepModel encryptModel, ObjectStepLogger stepLogger) throws Exception {
-        signatureModel.setResourceId("/exchange/v3/signed");
-        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/signed");
+        signatureModel.setResourceId("/exchange/signed");
+        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v4/signed");
         File emptyDataFile = File.createTempFile("data_empty_signed", ".json");
         emptyDataFile.deleteOnExit();
         FileWriter fw = new FileWriter(emptyDataFile);
@@ -225,8 +214,8 @@ public class PowerAuthEncryptionShared {
     }
 
     public static void signAndEncryptLargeDataTest(PowerAuthTestConfiguration config, VerifyAuthenticationStepModel signatureModel, ObjectStepLogger stepLogger, PowerAuthVersion version) throws Exception {
-        signatureModel.setResourceId("/exchange/v3/signed");
-        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/signed");
+        signatureModel.setResourceId("/exchange/signed");
+        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v4/signed");
 
         SecureRandom secureRandom = new SecureRandom();
         File dataFileLarge = File.createTempFile("data_large_" + version, ".dat");
@@ -249,8 +238,8 @@ public class PowerAuthEncryptionShared {
     }
 
     public static void signAndEncryptStringDataTest(PowerAuthTestConfiguration config, VerifyAuthenticationStepModel signatureModel, ObjectStepLogger stepLogger, PowerAuthVersion version) throws Exception {
-        signatureModel.setResourceId("/exchange/v3/signed/string");
-        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/signed/string");
+        signatureModel.setResourceId("/exchange/signed/string");
+        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v4/signed/string");
 
         File dataFile = File.createTempFile("data_string" + version, ".dat");
         dataFile.deleteOnExit();
@@ -273,8 +262,8 @@ public class PowerAuthEncryptionShared {
     }
 
     public static void signAndEncryptRawDataTest(PowerAuthTestConfiguration config, VerifyAuthenticationStepModel signatureModel, ObjectStepLogger stepLogger, PowerAuthVersion version) throws Exception {
-        signatureModel.setResourceId("/exchange/v3/signed/raw");
-        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/signed/raw");
+        signatureModel.setResourceId("/exchange/signed/raw");
+        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v4/signed/raw");
 
         File dataFile = File.createTempFile("data_raw_" + version, ".dat");
         dataFile.deleteOnExit();
@@ -296,8 +285,8 @@ public class PowerAuthEncryptionShared {
     }
 
     public static void signAndEncryptGenerifiedDataTest(PowerAuthTestConfiguration config, VerifyAuthenticationStepModel signatureModel, ObjectStepLogger stepLogger) throws Exception {
-        signatureModel.setResourceId("/exchange/v3/signed/generics");
-        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/signed/generics");
+        signatureModel.setResourceId("/exchange/signed/generics");
+        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v4/signed/generics");
         File dataFileWithGenerics = File.createTempFile("data-generics", ".json");
         dataFileWithGenerics.deleteOnExit();
         FileWriter fw = new FileWriter(dataFileWithGenerics);
@@ -324,8 +313,8 @@ public class PowerAuthEncryptionShared {
     }
 
     public static void signAndEncryptInvalidResourceIdTest(PowerAuthTestConfiguration config, VerifyAuthenticationStepModel signatureModel, ObjectStepLogger stepLogger) throws Exception {
-        signatureModel.setResourceId("/exchange/v3/invalid");
-        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/signed");
+        signatureModel.setResourceId("/exchange/invalid");
+        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v4/signed");
 
         new SignAndEncryptStep().execute(stepLogger, signatureModel.toMap());
         assertFalse(stepLogger.getResult().success());
@@ -333,8 +322,8 @@ public class PowerAuthEncryptionShared {
     }
 
     public static void signAndEncryptBlockedActivationTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config, VerifyAuthenticationStepModel signatureModel, ObjectStepLogger stepLogger, PowerAuthVersion version) throws Exception {
-        signatureModel.setResourceId("/exchange/v3/signed");
-        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/signed");
+        signatureModel.setResourceId("/exchange/signed");
+        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v4/signed");
 
         // Block activation and verify that data exchange fails
         powerAuthClient.blockActivation(config.getActivationId(version), "test", "test");
@@ -350,9 +339,9 @@ public class PowerAuthEncryptionShared {
         assertTrue(stepLoggerSuccess.getResult().success());
         assertEquals(200, stepLoggerSuccess.getResponse().statusCode());
 
-        EciesEncryptedResponse responseOK = (EciesEncryptedResponse) stepLoggerSuccess.getResponse().responseObject();
+        AeadEncryptedResponse responseOK = (AeadEncryptedResponse) stepLoggerSuccess.getResponse().responseObject();
         assertNotNull(responseOK.getEncryptedData());
-        assertNotNull(responseOK.getMac());
+        assertNotNull(responseOK.getTimestamp());
 
         boolean responseSuccessfullyDecrypted = false;
         for (StepItem item: stepLoggerSuccess.getItems()) {
@@ -366,8 +355,8 @@ public class PowerAuthEncryptionShared {
     }
 
     public static void signAndEncryptUnsupportedApplicationTest(PowerAuthClient powerAuthClient, PowerAuthTestConfiguration config, VerifyAuthenticationStepModel signatureModel, PowerAuthVersion version) throws Exception {
-        signatureModel.setResourceId("/exchange/v3/signed");
-        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/signed");
+        signatureModel.setResourceId("/exchange/signed");
+        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v4/signed");
 
         powerAuthClient.unsupportApplicationVersion(config.getApplicationId(), config.getApplicationVersionId());
 
@@ -386,9 +375,9 @@ public class PowerAuthEncryptionShared {
         assertTrue(stepLogger2.getResult().success());
         assertEquals(200, stepLogger2.getResponse().statusCode());
 
-        final EciesEncryptedResponse responseOK = (EciesEncryptedResponse) stepLogger2.getResponse().responseObject();
+        final AeadEncryptedResponse responseOK = (AeadEncryptedResponse) stepLogger2.getResponse().responseObject();
         assertNotNull(responseOK.getEncryptedData());
-        assertNotNull(responseOK.getMac());
+        assertNotNull(responseOK.getTimestamp());
 
         boolean responseSuccessfullyDecrypted = false;
         for (StepItem item: stepLogger2.getItems()) {
@@ -402,8 +391,8 @@ public class PowerAuthEncryptionShared {
     }
 
     public static void signAndEncryptCounterIncrementTest(PowerAuthTestConfiguration config, VerifyAuthenticationStepModel signatureModel, ObjectStepLogger stepLogger, PowerAuthVersion version) throws Exception {
-        signatureModel.setResourceId("/exchange/v3/signed");
-        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/signed");
+        signatureModel.setResourceId("/exchange/signed");
+        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v4/signed");
 
         byte[] ctrData = CounterUtil.getCtrData(signatureModel, stepLogger);
         HashBasedCounter counter = new HashBasedCounter(version.value());
@@ -420,8 +409,8 @@ public class PowerAuthEncryptionShared {
     }
 
     public static void signAndEncryptLookAheadTest(PowerAuthTestConfiguration config, VerifyAuthenticationStepModel signatureModel) throws Exception {
-        signatureModel.setResourceId("/exchange/v3/signed");
-        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/signed");
+        signatureModel.setResourceId("/exchange/signed");
+        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v4/signed");
 
         // Move counter by 1-4, next signature should succeed thanks to counter lookahead and it is still in max failure limit
         for (int i = 1; i < 4; i++) {
@@ -442,8 +431,8 @@ public class PowerAuthEncryptionShared {
     }
 
     public static void signAndEncryptSingleFactorTest(PowerAuthTestConfiguration config, VerifyAuthenticationStepModel signatureModel, ObjectStepLogger stepLogger) throws Exception {
-        signatureModel.setResourceId("/exchange/v3/signed");
-        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/signed");
+        signatureModel.setResourceId("/exchange/signed");
+        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v4/signed");
         signatureModel.setAuthenticationCodeType(PowerAuthCodeType.POSSESSION);
 
         new SignAndEncryptStep().execute(stepLogger, signatureModel.toMap());
@@ -455,74 +444,16 @@ public class PowerAuthEncryptionShared {
         assertEquals("ERROR", errorResponse.getStatus());
     }
 
-    public static void signAndEncryptBiometryTest(PowerAuthTestConfiguration config, VerifyAuthenticationStepModel signatureModel, ObjectStepLogger stepLogger) throws Exception {
-        signatureModel.setResourceId("/exchange/v3/signed");
-        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/signed");
-        signatureModel.setAuthenticationCodeType(PowerAuthCodeType.POSSESSION_BIOMETRY);
-
-        new SignAndEncryptStep().execute(stepLogger, signatureModel.toMap());
-        assertTrue(stepLogger.getResult().success());
-        assertEquals(200, stepLogger.getResponse().statusCode());
-    }
-
-    public static void signAndEncryptThreeFactorTest(PowerAuthTestConfiguration config, VerifyAuthenticationStepModel signatureModel, ObjectStepLogger stepLogger) throws Exception {
-        signatureModel.setResourceId("/exchange/v3/signed");
-        signatureModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/signed");
-        signatureModel.setAuthenticationCodeType(PowerAuthCodeType.POSSESSION_KNOWLEDGE_BIOMETRY);
-
-        new SignAndEncryptStep().execute(stepLogger, signatureModel.toMap());
-        assertTrue(stepLogger.getResult().success());
-        assertEquals(200, stepLogger.getResponse().statusCode());
-    }
-
-    public static void replayAttackEciesDecryptorTest(final PowerAuthClient powerAuthClient, final PowerAuthTestConfiguration config, PowerAuthVersion version) throws Exception {
-        final TemporaryKey temporaryKey = TemporaryKeyFetchUtil.fetchTemporaryKey(version, EncryptorScope.APPLICATION_SCOPE, config);
-        String requestData = "test_data";
-        ClientEncryptor<EciesEncryptedRequest, EciesEncryptedResponse> clientEncryptor = ENCRYPTOR_FACTORY.getClientEncryptor(
-                EncryptorId.APPLICATION_SCOPE_GENERIC,
-                new EncryptorParameters(version.value(), config.getApplicationKey(), null, temporaryKey != null ? temporaryKey.getId() : null),
-                new ClientEciesSecrets(config.getMasterPublicKeyP256(), config.getApplicationSecret())
-        );
-        EciesEncryptedRequest encryptedRequest = clientEncryptor.encryptRequest(requestData.getBytes(StandardCharsets.UTF_8));
-        final GetEciesDecryptorRequest eciesDecryptorRequest = new GetEciesDecryptorRequest();
-        eciesDecryptorRequest.setProtocolVersion(version.value());
-        eciesDecryptorRequest.setActivationId(null);
-        eciesDecryptorRequest.setApplicationKey(config.getApplicationKey());
-        eciesDecryptorRequest.setEphemeralPublicKey(encryptedRequest.getEphemeralPublicKey());
-        eciesDecryptorRequest.setNonce(encryptedRequest.getNonce());
-        eciesDecryptorRequest.setTimestamp(encryptedRequest.getTimestamp());
-        eciesDecryptorRequest.setTemporaryKeyId(temporaryKey != null ? temporaryKey.getId() : null);
-        GetEciesDecryptorResponse decryptorResponse = powerAuthClient.getEciesDecryptor(eciesDecryptorRequest);
-        assertNotNull(decryptorResponse.getSecretKey());
-        assertNotNull(decryptorResponse.getSharedInfo2());
-
-        // Replay attack simulation - send the same request twice, expect error ERR0024
-        final PowerAuthClientException ex = assertThrows(PowerAuthClientException.class, () ->
-                powerAuthClient.getEciesDecryptor(eciesDecryptorRequest));
-        assertEquals("ERR0024", ex.getPowerAuthError().get().getCode());
-    }
-
     public static void encryptedResponseTest(final PowerAuthTestConfiguration config, EncryptStepModel encryptModel, ObjectStepLogger stepLogger, PowerAuthVersion version) throws Exception {
-        encryptModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v3/activation");
+        encryptModel.setUriString(config.getEnrollmentServiceUrl() + "/exchange/v4/activation");
         encryptModel.setScope("activation");
 
         new EncryptStep().execute(stepLogger, encryptModel.toMap());
         assertTrue(stepLogger.getResult().success());
         assertEquals(200, stepLogger.getResponse().statusCode());
-        EciesEncryptedResponse responseObject = (EciesEncryptedResponse) stepLogger.getResponse().responseObject();
+        AeadEncryptedResponse responseObject = (AeadEncryptedResponse) stepLogger.getResponse().responseObject();
         assertNotNull(responseObject.getEncryptedData());
-        assertNotNull(responseObject.getMac());
-        switch (version) {
-            case V3_0, V3_1 -> {
-                assertNull(responseObject.getNonce());
-                assertNull(responseObject.getTimestamp());
-            }
-            case V3_2, V3_3 -> {
-                assertNotNull(responseObject.getNonce());
-                assertNotNull(responseObject.getTimestamp());
-            }
-            default -> fail("Unsupported version");
-        }
+        assertNotNull(responseObject.getTimestamp());
     }
 
     private static String generateRandomString() {

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthInfoShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthInfoShared.java
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.wultra.security.powerauth.test.shared;
+package com.wultra.security.powerauth.test.shared.v4;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -23,15 +23,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.wultra.core.rest.client.base.DefaultRestClient;
 import com.wultra.core.rest.client.base.RestClient;
-import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
 import com.wultra.core.rest.model.base.request.ObjectRequest;
 import com.wultra.core.rest.model.base.response.ObjectResponse;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedResponse;
+import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
+import com.wultra.security.powerauth.crypto.lib.v4.encryptor.model.response.AeadEncryptedResponse;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
 import com.wultra.security.powerauth.lib.cmd.logging.model.StepItem;
-import com.wultra.security.powerauth.lib.cmd.steps.model.EncryptStepModel;
 import com.wultra.security.powerauth.lib.cmd.steps.EncryptStep;
+import com.wultra.security.powerauth.lib.cmd.steps.model.EncryptStepModel;
 import com.wultra.security.powerauth.rest.api.model.request.UserInfoRequest;
 import com.wultra.security.powerauth.rest.api.model.response.ServerStatusResponse;
 import org.opentest4j.AssertionFailedError;
@@ -55,7 +55,7 @@ public class PowerAuthInfoShared {
     private static final long SERVER_CLIENT_TIME_DIFF_TOLERANCE_MILLIS = 60000;
 
     public static void testUserInfo(final PowerAuthTestConfiguration config, final EncryptStepModel encryptModel, final PowerAuthVersion version) throws Exception {
-        encryptModel.setUriString(config.getEnrollmentServiceUrl() + "/pa/v3/user/info");
+        encryptModel.setUriString(config.getEnrollmentServiceUrl() + "/pa/v4/user/info");
         encryptModel.setScope("activation");
         encryptModel.setData(objectMapper.writeValueAsBytes(new UserInfoRequest()));
 
@@ -64,9 +64,9 @@ public class PowerAuthInfoShared {
         assertTrue(stepLogger.getResult().success());
         assertEquals(200, stepLogger.getResponse().statusCode());
 
-        final EciesEncryptedResponse response = (EciesEncryptedResponse) stepLogger.getResponse().responseObject();
+        final AeadEncryptedResponse response = (AeadEncryptedResponse) stepLogger.getResponse().responseObject();
         assertNotNull(response.getEncryptedData());
-        assertNotNull(response.getMac());
+        assertNotNull(response.getTimestamp());
 
         final Map<String, Object> decryptedData = stepLogger.getItems().stream()
                 .filter(isStepItemDecryptedResponse())
@@ -84,7 +84,7 @@ public class PowerAuthInfoShared {
 
     public static void testServerStatus(final PowerAuthTestConfiguration config) throws Exception {
         final RestClient restClient = new DefaultRestClient(config.getEnrollmentServiceUrl());
-        final ObjectResponse<ServerStatusResponse> objectResponse = restClient.postObject("/pa/v3/status", new ObjectRequest<>(), ServerStatusResponse.class);
+        final ObjectResponse<ServerStatusResponse> objectResponse = restClient.postObject("/pa/v4/status", new ObjectRequest<>(), ServerStatusResponse.class);
         assertTrue(Math.abs(objectResponse.getResponseObject().serverTime() - System.currentTimeMillis()) < SERVER_CLIENT_TIME_DIFF_TOLERANCE_MILLIS);
     }
 

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthTokenShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthTokenShared.java
@@ -15,22 +15,21 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.wultra.security.powerauth.test.shared;
+package com.wultra.security.powerauth.test.shared.v4;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wultra.core.rest.model.base.response.ErrorResponse;
 import com.wultra.security.powerauth.client.v4.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.core.rest.model.base.response.ErrorResponse;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedResponse;
 import com.wultra.security.powerauth.crypto.lib.generator.HashBasedCounter;
 import com.wultra.security.powerauth.crypto.lib.v4.encryptor.model.response.AeadEncryptedResponse;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
 import com.wultra.security.powerauth.lib.cmd.logging.model.StepItem;
+import com.wultra.security.powerauth.lib.cmd.steps.CreateTokenStep;
 import com.wultra.security.powerauth.lib.cmd.steps.VerifyTokenStep;
 import com.wultra.security.powerauth.lib.cmd.steps.model.CreateTokenStepModel;
 import com.wultra.security.powerauth.lib.cmd.steps.model.VerifyTokenStepModel;
-import com.wultra.security.powerauth.lib.cmd.steps.CreateTokenStep;
 import com.wultra.security.powerauth.lib.cmd.util.CounterUtil;
 
 import java.io.File;
@@ -210,7 +209,7 @@ public class PowerAuthTokenShared {
         assertTrue(stepLogger2.getResult().success());
         assertEquals(200, stepLogger2.getResponse().statusCode());
 
-        checkResponse(model.getVersion(), stepLogger2);
+        checkResponse(stepLogger2);
     }
 
     public static void tokenCounterIncrementTest(final CreateTokenStepModel model, final ObjectStepLogger stepLogger, final PowerAuthVersion version) throws Exception {
@@ -233,16 +232,9 @@ public class PowerAuthTokenShared {
         return config.getPowerAuthIntegrationUrl() + "/api/auth/token/app/operation/list";
     }
 
-    private static void checkResponse(PowerAuthVersion version, ObjectStepLogger stepLogger) {
-        if (version.getMajorVersion() == 3) {
-            final EciesEncryptedResponse responseOK = (EciesEncryptedResponse) stepLogger.getResponse().responseObject();
-            assertNotNull(responseOK.getEncryptedData());
-            assertNotNull(responseOK.getMac());
-        } else {
-            final AeadEncryptedResponse responseOK = (AeadEncryptedResponse) stepLogger.getResponse().responseObject();
-            assertNotNull(responseOK.getEncryptedData());
-            assertNotNull(responseOK.getTimestamp());
-        }
-
+    private static void checkResponse(ObjectStepLogger stepLogger) {
+        final AeadEncryptedResponse responseOK = (AeadEncryptedResponse) stepLogger.getResponse().responseObject();
+        assertNotNull(responseOK.getEncryptedData());
+        assertNotNull(responseOK.getTimestamp());
     }
 }

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthVaultUnlockShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthVaultUnlockShared.java
@@ -43,8 +43,6 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 public class PowerAuthVaultUnlockShared {
 
-    private static final SignatureUtils SIGNATURE_UTILS = new SignatureUtils();
-
     public static void vaultUnlockTest(final VaultUnlockStepModel model, final ObjectStepLogger stepLogger) throws Exception {
         new VaultUnlockStep().execute(stepLogger, model.toMap());
         assertTrue(stepLogger.getResult().success());
@@ -92,9 +90,10 @@ public class PowerAuthVaultUnlockShared {
     public static void vaultUnlockBiometryFactorTest(final VaultUnlockStepModel model, final ObjectStepLogger stepLogger) throws Exception {
         model.setAuthenticationCodeType(PowerAuthCodeType.POSSESSION_BIOMETRY);
 
+        // Biometry can be used for vault unlock unlike in v3 where it is disabled by default
         new VaultUnlockStep().execute(stepLogger, model.toMap());
-        assertFalse(stepLogger.getResult().success());
-        assertEquals(400, stepLogger.getResponse().statusCode());
+        assertTrue(stepLogger.getResult().success());
+        assertEquals(200, stepLogger.getResponse().statusCode());
     }
 
     public static void vaultUnlockThreeFactorTest(final VaultUnlockStepModel model, final ObjectStepLogger stepLogger) throws Exception {

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthVaultUnlockShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthVaultUnlockShared.java
@@ -23,7 +23,6 @@ import com.wultra.security.powerauth.client.v4.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
 import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;
 import com.wultra.security.powerauth.crypto.lib.generator.HashBasedCounter;
-import com.wultra.security.powerauth.crypto.lib.util.SignatureUtils;
 import com.wultra.security.powerauth.crypto.lib.v4.encryptor.model.response.AeadEncryptedResponse;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
@@ -90,10 +89,21 @@ public class PowerAuthVaultUnlockShared {
     public static void vaultUnlockBiometryFactorTest(final VaultUnlockStepModel model, final ObjectStepLogger stepLogger) throws Exception {
         model.setAuthenticationCodeType(PowerAuthCodeType.POSSESSION_BIOMETRY);
 
-        // Biometry can be used for vault unlock unlike in v3 where it is disabled by default
+        // Biometry can be used for vault unlock unlike in v3:
+        // KEK_DEVICE_PRIVATE - biometry is enabled by default (can be disabled)
+        // KDK_APP_VAULT_2FA - biometry is enabled
         new VaultUnlockStep().execute(stepLogger, model.toMap());
         assertTrue(stepLogger.getResult().success());
         assertEquals(200, stepLogger.getResponse().statusCode());
+    }
+
+    public static void vaultUnlockBiometryFactorFailTest(final VaultUnlockStepModel model, final ObjectStepLogger stepLogger) throws Exception {
+        model.setAuthenticationCodeType(PowerAuthCodeType.POSSESSION_BIOMETRY);
+
+        // Biometry test for disabled biometry key identifier KDK_APP_VAULT_KNOWLEDGE
+        new VaultUnlockStep().execute(stepLogger, model.toMap());
+        assertFalse(stepLogger.getResult().success());
+        assertEquals(400, stepLogger.getResponse().statusCode());
     }
 
     public static void vaultUnlockThreeFactorTest(final VaultUnlockStepModel model, final ObjectStepLogger stepLogger) throws Exception {
@@ -180,15 +190,15 @@ public class PowerAuthVaultUnlockShared {
     }
 
     private static void checkAuthenticationError(ErrorResponse errorResponse) {
-        assertTrue("ERR_AUTHENTICATION".equals(errorResponse.getResponseObject().getCode()));
+        assertEquals("ERR_AUTHENTICATION", errorResponse.getResponseObject().getCode());
     }
 
     private static void checkTemporaryKeyError(ErrorResponse errorResponse) {
-        assertTrue("ERR_TEMPORARY_KEY".equals(errorResponse.getResponseObject().getCode()));
+        assertEquals("ERR_TEMPORARY_KEY", errorResponse.getResponseObject().getCode());
     }
 
     private static void checkSecureVaultError(ErrorResponse errorResponse) {
-        assertTrue("ERR_SECURE_VAULT".equals(errorResponse.getResponseObject().getCode()));
+        assertEquals("ERR_SECURE_VAULT", errorResponse.getResponseObject().getCode());
     }
 
 }

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthVaultUnlockShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthVaultUnlockShared.java
@@ -1,0 +1,195 @@
+/*
+ * PowerAuth test and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.security.powerauth.test.shared.v4;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wultra.core.rest.model.base.response.ErrorResponse;
+import com.wultra.security.powerauth.client.v4.PowerAuthClient;
+import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
+import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;
+import com.wultra.security.powerauth.crypto.lib.generator.HashBasedCounter;
+import com.wultra.security.powerauth.crypto.lib.util.SignatureUtils;
+import com.wultra.security.powerauth.crypto.lib.v4.encryptor.model.response.AeadEncryptedResponse;
+import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
+import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
+import com.wultra.security.powerauth.lib.cmd.steps.VaultUnlockStep;
+import com.wultra.security.powerauth.lib.cmd.steps.model.VaultUnlockStepModel;
+import com.wultra.security.powerauth.lib.cmd.util.CounterUtil;
+
+import java.util.Map;
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * PowerAuth vault unlock test shared logic.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class PowerAuthVaultUnlockShared {
+
+    private static final SignatureUtils SIGNATURE_UTILS = new SignatureUtils();
+
+    public static void vaultUnlockTest(final VaultUnlockStepModel model, final ObjectStepLogger stepLogger) throws Exception {
+        new VaultUnlockStep().execute(stepLogger, model.toMap());
+        assertTrue(stepLogger.getResult().success());
+        assertEquals(200, stepLogger.getResponse().statusCode());
+
+        final boolean keyDecryptionSuccessful = stepLogger.getItems().stream()
+                .filter(item -> item.name().equals("Vault Unlocked"))
+                .map(item -> (Map<String, Object>) item.object())
+                .map(item -> (String) item.get("vaultEncryptionKey"))
+                .map(Objects::nonNull)
+                .findAny()
+                .orElse(false);
+
+        assertTrue(keyDecryptionSuccessful);
+    }
+
+    public static void vaultUnlockInvalidPasswordTest(final PowerAuthTestConfiguration config, final VaultUnlockStepModel model, final ObjectStepLogger stepLogger) throws Exception {
+        model.setPassword("1111");
+
+        new VaultUnlockStep().execute(stepLogger, model.toMap());
+        assertFalse(stepLogger.getResult().success());
+        assertEquals(401, stepLogger.getResponse().statusCode());
+
+        ObjectMapper objectMapper = config.getObjectMapper();
+        final ErrorResponse errorResponse = objectMapper.readValue(stepLogger.getResponse().responseObject().toString(), ErrorResponse.class);
+        assertEquals("ERROR", errorResponse.getStatus());
+        checkAuthenticationError(errorResponse);
+    }
+
+    public static void vaultUnlockSingleFactorTest(final PowerAuthTestConfiguration config, final VaultUnlockStepModel model, final ObjectStepLogger stepLogger) throws Exception {
+        model.setAuthenticationCodeType(PowerAuthCodeType.POSSESSION);
+
+        new VaultUnlockStep().execute(stepLogger, model.toMap());
+        assertFalse(stepLogger.getResult().success());
+        // Verify BAD_REQUEST status code
+        assertEquals(400, stepLogger.getResponse().statusCode());
+
+        ObjectMapper objectMapper = config.getObjectMapper();
+        final ErrorResponse errorResponse = objectMapper.readValue(stepLogger.getResponse().responseObject().toString(), ErrorResponse.class);
+        assertEquals("ERROR", errorResponse.getStatus());
+        assertEquals("ERR_SECURE_VAULT", errorResponse.getResponseObject().getCode());
+        assertEquals("POWER_AUTH_SECURE_VAULT_INVALID", errorResponse.getResponseObject().getMessage());
+    }
+
+    public static void vaultUnlockBiometryFactorTest(final VaultUnlockStepModel model, final ObjectStepLogger stepLogger) throws Exception {
+        model.setAuthenticationCodeType(PowerAuthCodeType.POSSESSION_BIOMETRY);
+
+        new VaultUnlockStep().execute(stepLogger, model.toMap());
+        assertFalse(stepLogger.getResult().success());
+        assertEquals(400, stepLogger.getResponse().statusCode());
+    }
+
+    public static void vaultUnlockThreeFactorTest(final VaultUnlockStepModel model, final ObjectStepLogger stepLogger) throws Exception {
+        model.setAuthenticationCodeType(PowerAuthCodeType.POSSESSION_KNOWLEDGE_BIOMETRY);
+
+        new VaultUnlockStep().execute(stepLogger, model.toMap());
+        assertFalse(stepLogger.getResult().success());
+        assertEquals(400, stepLogger.getResponse().statusCode());
+    }
+
+    public static void vaultUnlockBlockedActivationTest(final PowerAuthClient powerAuthClient, final PowerAuthTestConfiguration config, final VaultUnlockStepModel model, final PowerAuthVersion version) throws Exception {
+        powerAuthClient.blockActivation(config.getActivationId(version), "test", "test");
+
+        ObjectStepLogger stepLogger1 = new ObjectStepLogger(System.out);
+        new VaultUnlockStep().execute(stepLogger1, model.toMap());
+        assertFalse(stepLogger1.getResult().success());
+        assertEquals(400, stepLogger1.getResponse().statusCode());
+
+        ObjectMapper objectMapper = config.getObjectMapper();
+        final ErrorResponse errorResponse = objectMapper.readValue(stepLogger1.getResponse().responseObject().toString(), ErrorResponse.class);
+        assertEquals("ERROR", errorResponse.getStatus());
+        checkSecureVaultError(errorResponse);
+
+        powerAuthClient.unblockActivation(config.getActivationId(version), "test");
+
+        ObjectStepLogger stepLogger2 = new ObjectStepLogger();
+        new VaultUnlockStep().execute(stepLogger2, model.toMap());
+        assertTrue(stepLogger2.getResult().success());
+        assertEquals(200, stepLogger2.getResponse().statusCode());
+    }
+
+    public static void vaultUnlockUnsupportedApplicationTest(final PowerAuthClient powerAuthClient, final PowerAuthTestConfiguration config, final VaultUnlockStepModel model) throws Exception {
+        powerAuthClient.unsupportApplicationVersion(config.getApplicationId(), config.getApplicationVersionId());
+
+        ObjectStepLogger stepLogger1 = new ObjectStepLogger(System.out);
+        new VaultUnlockStep().execute(stepLogger1, model.toMap());
+        assertFalse(stepLogger1.getResult().success());
+        if (model.getVersion().useTemporaryKeys()) {
+            assertEquals(400, stepLogger1.getResponse().statusCode());
+        } else {
+            assertEquals(401, stepLogger1.getResponse().statusCode());
+        }
+
+        ObjectMapper objectMapper = config.getObjectMapper();
+        final ErrorResponse errorResponse = objectMapper.readValue(stepLogger1.getResponse().responseObject().toString(), ErrorResponse.class);
+        assertEquals("ERROR", errorResponse.getStatus());
+        checkTemporaryKeyError(errorResponse);
+
+        powerAuthClient.supportApplicationVersion(config.getApplicationId(), config.getApplicationVersionId());
+
+        ObjectStepLogger stepLogger2 = new ObjectStepLogger(System.out);
+        new VaultUnlockStep().execute(stepLogger2, model.toMap());
+        assertTrue(stepLogger2.getResult().success());
+        assertEquals(200, stepLogger2.getResponse().statusCode());
+
+        final AeadEncryptedResponse responseOK = (AeadEncryptedResponse) stepLogger2.getResponse().responseObject();
+        assertNotNull(responseOK.getEncryptedData());
+        assertNotNull(responseOK.getTimestamp());
+    }
+
+    public static void vaultUnlockCounterIncrementTest(final VaultUnlockStepModel model, final ObjectStepLogger stepLogger, final PowerAuthVersion version) throws Exception {
+        byte[] ctrData = CounterUtil.getCtrData(model, stepLogger);
+        new VaultUnlockStep().execute(stepLogger, model.toMap());
+        assertTrue(stepLogger.getResult().success());
+        assertEquals(200, stepLogger.getResponse().statusCode());
+
+        // Verify counter after createToken - in version 3.0 the counter is incremented once
+        byte[] ctrDataExpected = new HashBasedCounter(version.value()).next(ctrData);
+        assertArrayEquals(ctrDataExpected, CounterUtil.getCtrData(model, stepLogger));
+    }
+
+    public static void vaultUnlockTooLongReasonTest(final PowerAuthTestConfiguration config, final VaultUnlockStepModel model, final ObjectStepLogger stepLogger) throws Exception {
+        model.setReason("vt39nW6ZM963PJ8qxiREICZqK5medvUN8YizLDaLYTlMUtXyvdkqG3fMda29eCRHwAeAUsB415HqUlYZoDeEkvCOQzhu8ZpTGahAZVROi0YcNNGizecpzLDQUzRPbzVbHfJRd5zUasU3npS7FE9WZSqVfpLEthrPRN40efWxmKHxTzCUbHkk11odipkavelkG64mUgrdX0STh22vL4hE8jMjOM86HIT0rZHx2EhC1muJvtdDxWK3pz3Z9s2GHKj0");
+
+        new VaultUnlockStep().execute(stepLogger, model.toMap());
+        assertFalse(stepLogger.getResult().success());
+        assertEquals(400, stepLogger.getResponse().statusCode());
+
+        ObjectMapper objectMapper = config.getObjectMapper();
+        final ErrorResponse errorResponse = objectMapper.readValue(stepLogger.getResponse().responseObject().toString(), ErrorResponse.class);
+        assertEquals("ERROR", errorResponse.getStatus());
+        assertEquals("ERR_SECURE_VAULT", errorResponse.getResponseObject().getCode());
+        assertEquals("POWER_AUTH_SECURE_VAULT_INVALID", errorResponse.getResponseObject().getMessage());
+    }
+
+    private static void checkAuthenticationError(ErrorResponse errorResponse) {
+        assertTrue("ERR_AUTHENTICATION".equals(errorResponse.getResponseObject().getCode()));
+    }
+
+    private static void checkTemporaryKeyError(ErrorResponse errorResponse) {
+        assertTrue("ERR_TEMPORARY_KEY".equals(errorResponse.getResponseObject().getCode()));
+    }
+
+    private static void checkSecureVaultError(ErrorResponse errorResponse) {
+        assertTrue("ERR_SECURE_VAULT".equals(errorResponse.getResponseObject().getCode()));
+    }
+
+}

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v30/PowerAuthActivationTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v30/PowerAuthActivationTest.java
@@ -20,7 +20,7 @@ package com.wultra.security.powerauth.test.v30;
 import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.PowerAuthActivationShared;
+import com.wultra.security.powerauth.test.shared.v3.PowerAuthActivationShared;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.steps.model.PrepareActivationStepModel;
 import org.json.simple.JSONObject;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v30/PowerAuthCustomActivationTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v30/PowerAuthCustomActivationTest.java
@@ -19,7 +19,7 @@ package com.wultra.security.powerauth.test.v30;
 
 import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.PowerAuthCustomActivationShared;
+import com.wultra.security.powerauth.test.shared.v3.PowerAuthCustomActivationShared;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
 import com.wultra.security.powerauth.lib.cmd.steps.model.CreateActivationStepModel;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v30/PowerAuthCustomActivationTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v30/PowerAuthCustomActivationTest.java
@@ -74,9 +74,9 @@ class PowerAuthCustomActivationTest {
 
     @BeforeAll
     static void setUpBeforeClass() throws IOException {
-        dataFile = File.createTempFile("data", ".json");
+        dataFile = File.createTempFile("data", ".txt");
         FileWriter fw = new FileWriter(dataFile);
-        fw.write("All your base are belong to us!");
+        fw.write("Confidential test message used for testing");
         fw.close();
     }
 

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v30/PowerAuthEncryptionTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v30/PowerAuthEncryptionTest.java
@@ -19,7 +19,7 @@ package com.wultra.security.powerauth.test.v30;
 
 import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.PowerAuthEncryptionShared;
+import com.wultra.security.powerauth.test.shared.v3.PowerAuthEncryptionShared;
 import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v30/PowerAuthSignatureTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v30/PowerAuthSignatureTest.java
@@ -74,9 +74,9 @@ public class PowerAuthSignatureTest {
 
     @BeforeAll
     static void setUpBeforeClass() throws IOException {
-        dataFile = File.createTempFile("data", ".json");
+        dataFile = File.createTempFile("data", ".txt");
         FileWriter fw = new FileWriter(dataFile);
-        fw.write("All your base are belong to us!");
+        fw.write("Confidential test message used for testing");
         fw.close();
     }
 

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v30/PowerAuthSignatureTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v30/PowerAuthSignatureTest.java
@@ -19,7 +19,7 @@ package com.wultra.security.powerauth.test.v30;
 
 import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.PowerAuthSignatureShared;
+import com.wultra.security.powerauth.test.shared.v3.PowerAuthSignatureShared;
 import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v30/PowerAuthTokenTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v30/PowerAuthTokenTest.java
@@ -17,7 +17,7 @@
  */
 package com.wultra.security.powerauth.test.v30;
 
-import com.wultra.security.powerauth.client.v3.PowerAuthClient;
+import com.wultra.security.powerauth.client.v4.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
 import com.wultra.security.powerauth.test.shared.PowerAuthTokenShared;
 import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v30/PowerAuthTokenTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v30/PowerAuthTokenTest.java
@@ -72,9 +72,9 @@ class PowerAuthTokenTest {
 
     @BeforeAll
     static void setUpBeforeClass() throws IOException {
-        dataFile = File.createTempFile("data", ".json");
+        dataFile = File.createTempFile("data", ".txt");
         FileWriter fw = new FileWriter(dataFile);
-        fw.write("All your base are belong to us!");
+        fw.write("Confidential test message used for testing");
         fw.close();
     }
 

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v30/PowerAuthTokenTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v30/PowerAuthTokenTest.java
@@ -17,9 +17,9 @@
  */
 package com.wultra.security.powerauth.test.v30;
 
-import com.wultra.security.powerauth.client.v4.PowerAuthClient;
+import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.PowerAuthTokenShared;
+import com.wultra.security.powerauth.test.shared.v3.PowerAuthTokenShared;
 import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v30/PowerAuthVaultUnlockTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v30/PowerAuthVaultUnlockTest.java
@@ -19,7 +19,7 @@ package com.wultra.security.powerauth.test.v30;
 
 import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.PowerAuthVaultUnlockShared;
+import com.wultra.security.powerauth.test.shared.v3.PowerAuthVaultUnlockShared;
 import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthActivationCodeTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthActivationCodeTest.java
@@ -86,7 +86,7 @@ public class PowerAuthActivationCodeTest {
         signatureModel = new VerifyAuthenticationStepModel();
         signatureModel.setApplicationKey(config.getApplicationKey());
         signatureModel.setApplicationSecret(config.getApplicationSecret());
-        signatureModel.setAuthenticationCodeType(PowerAuthCodeType.POSSESSION_BIOMETRY);
+        signatureModel.setAuthenticationCodeType(PowerAuthCodeType.POSSESSION_KNOWLEDGE);
         signatureModel.setPassword(config.getPassword());
         signatureModel.setHttpMethod("POST");
         signatureModel.setHeaders(new HashMap<>());

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthActivationCommitPhaseTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthActivationCommitPhaseTest.java
@@ -17,10 +17,9 @@
  */
 package com.wultra.security.powerauth.test.v31;
 
-import com.wultra.security.powerauth.client.v3.PowerAuthClient;
+import com.wultra.security.powerauth.client.v4.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
 import com.wultra.security.powerauth.test.shared.PowerAuthActivationCommitPhaseShared;
-import com.wultra.security.powerauth.crypto.client.activation.PowerAuthClientActivation;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.steps.model.GetStatusStepModel;
 import com.wultra.security.powerauth.lib.cmd.steps.model.PrepareActivationStepModel;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthActivationCommitPhaseTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthActivationCommitPhaseTest.java
@@ -60,8 +60,6 @@ class PowerAuthActivationCommitPhaseTest {
     private final String validOtpValue = "1234-5678";
     private final String invalidOtpValue = "8765-4321";
 
-    private static final PowerAuthClientActivation activation = new PowerAuthClientActivation();
-
     @Autowired
     public void setPowerAuthClient(PowerAuthClient powerAuthClient) {
         this.powerAuthClient = powerAuthClient;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthActivationCommitPhaseTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthActivationCommitPhaseTest.java
@@ -17,9 +17,9 @@
  */
 package com.wultra.security.powerauth.test.v31;
 
-import com.wultra.security.powerauth.client.v4.PowerAuthClient;
+import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.PowerAuthActivationCommitPhaseShared;
+import com.wultra.security.powerauth.test.shared.v3.PowerAuthActivationCommitPhaseShared;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.steps.model.GetStatusStepModel;
 import com.wultra.security.powerauth.lib.cmd.steps.model.PrepareActivationStepModel;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthActivationCommitPhaseTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthActivationCommitPhaseTest.java
@@ -101,13 +101,13 @@ class PowerAuthActivationCommitPhaseTest {
     }
 
     @Test
-    void validOtpOnKeysExchangeTest() throws Exception {
-        PowerAuthActivationCommitPhaseShared.validOtpOnKeysExchangeTest(powerAuthClient, config, model, validOtpValue, VERSION);
+    void validOtpOnKeyExchangeTest() throws Exception {
+        PowerAuthActivationCommitPhaseShared.validOtpOnKeyExchangeTest(powerAuthClient, config, model, validOtpValue, VERSION);
     }
 
     @Test
-    void invalidOtpOnKeysExchangeTest() throws Exception {
-        PowerAuthActivationCommitPhaseShared.invalidOtpOnKeysExchangeTest(powerAuthClient, config, model, validOtpValue, invalidOtpValue, VERSION);
+    void invalidOtpOnKeyExchangeTest() throws Exception {
+        PowerAuthActivationCommitPhaseShared.invalidOtpOnKeyExchangeTest(powerAuthClient, config, model, validOtpValue, invalidOtpValue, VERSION);
     }
 
     @Test

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthActivationOtpTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthActivationOtpTest.java
@@ -101,13 +101,13 @@ class PowerAuthActivationOtpTest {
     }
 
     @Test
-    void validOtpOnKeysExchangeTest() throws Exception {
-        PowerAuthActivationOtpShared.validOtpOnKeysExchangeTest(powerAuthClient, config, model, validOtpValue, VERSION);
+    void validOtpOnKeyExchangeTest() throws Exception {
+        PowerAuthActivationOtpShared.validOtpOnKeyExchangeTest(powerAuthClient, config, model, validOtpValue, VERSION);
     }
 
     @Test
-    void invalidOtpOnKeysExchangeTest() throws Exception {
-        PowerAuthActivationOtpShared.invalidOtpOnKeysExchangeTest(powerAuthClient, config, model, validOtpValue, invalidOtpValue, VERSION);
+    void invalidOtpOnKeyExchangeTest() throws Exception {
+        PowerAuthActivationOtpShared.invalidOtpOnKeyExchangeTest(powerAuthClient, config, model, validOtpValue, invalidOtpValue, VERSION);
     }
 
     @Test
@@ -156,8 +156,8 @@ class PowerAuthActivationOtpTest {
     }
 
     @Test
-    void missingOtpOnKeysExchangeTest() throws Exception {
-        PowerAuthActivationOtpShared.missingOtpOnKeysExchangeTest(powerAuthClient, config, model, validOtpValue, VERSION);
+    void missingOtpOnKeyExchangeTest() throws Exception {
+        PowerAuthActivationOtpShared.missingOtpOnKeyExchangeTest(powerAuthClient, config, model, validOtpValue, VERSION);
     }
 
 }

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthActivationOtpTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthActivationOtpTest.java
@@ -17,9 +17,9 @@
  */
 package com.wultra.security.powerauth.test.v31;
 
-import com.wultra.security.powerauth.client.v4.PowerAuthClient;
+import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.PowerAuthActivationOtpShared;
+import com.wultra.security.powerauth.test.shared.v3.PowerAuthActivationOtpShared;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.steps.model.GetStatusStepModel;
 import com.wultra.security.powerauth.lib.cmd.steps.model.PrepareActivationStepModel;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthActivationOtpTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthActivationOtpTest.java
@@ -17,7 +17,7 @@
  */
 package com.wultra.security.powerauth.test.v31;
 
-import com.wultra.security.powerauth.client.v3.PowerAuthClient;
+import com.wultra.security.powerauth.client.v4.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
 import com.wultra.security.powerauth.test.shared.PowerAuthActivationOtpShared;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthActivationTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthActivationTest.java
@@ -20,7 +20,7 @@ package com.wultra.security.powerauth.test.v31;
 import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.PowerAuthActivationShared;
+import com.wultra.security.powerauth.test.shared.v3.PowerAuthActivationShared;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.steps.model.PrepareActivationStepModel;
 import org.json.simple.JSONObject;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthCustomActivationOtpTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthCustomActivationOtpTest.java
@@ -80,9 +80,9 @@ class PowerAuthCustomActivationOtpTest {
 
     @BeforeAll
     static void setUpBeforeClass() throws IOException {
-        dataFile = File.createTempFile("data", ".json");
+        dataFile = File.createTempFile("data", ".txt");
         FileWriter fw = new FileWriter(dataFile);
-        fw.write("All your base are belong to us!");
+        fw.write("Confidential test message used for testing");
         fw.close();
     }
 

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthCustomActivationTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthCustomActivationTest.java
@@ -19,7 +19,7 @@ package com.wultra.security.powerauth.test.v31;
 
 import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.PowerAuthCustomActivationShared;
+import com.wultra.security.powerauth.test.shared.v3.PowerAuthCustomActivationShared;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
 import com.wultra.security.powerauth.lib.cmd.steps.model.CreateActivationStepModel;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthCustomActivationTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthCustomActivationTest.java
@@ -74,9 +74,9 @@ class PowerAuthCustomActivationTest {
 
     @BeforeAll
     static void setUpBeforeClass() throws IOException {
-        dataFile = File.createTempFile("data", ".json");
+        dataFile = File.createTempFile("data", ".txt");
         FileWriter fw = new FileWriter(dataFile);
-        fw.write("All your base are belong to us!");
+        fw.write("Confidential test message used for testing");
         fw.close();
     }
 

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthEncryptionTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthEncryptionTest.java
@@ -19,7 +19,7 @@ package com.wultra.security.powerauth.test.v31;
 
 import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.PowerAuthEncryptionShared;
+import com.wultra.security.powerauth.test.shared.v3.PowerAuthEncryptionShared;
 import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthIdentityVerificationTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthIdentityVerificationTest.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.PowerAuthIdentityVerificationShared;
+import com.wultra.security.powerauth.test.shared.v3.PowerAuthIdentityVerificationShared;
 import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthOnboardingTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthOnboardingTest.java
@@ -20,7 +20,7 @@ package com.wultra.security.powerauth.test.v31;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.PowerAuthOnboardingShared;
+import com.wultra.security.powerauth.test.shared.v3.PowerAuthOnboardingShared;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
 import com.wultra.security.powerauth.lib.cmd.steps.model.CreateActivationStepModel;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthSignatureTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthSignatureTest.java
@@ -19,7 +19,7 @@ package com.wultra.security.powerauth.test.v31;
 
 import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.PowerAuthSignatureShared;
+import com.wultra.security.powerauth.test.shared.v3.PowerAuthSignatureShared;
 import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthSignatureTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthSignatureTest.java
@@ -74,9 +74,9 @@ class PowerAuthSignatureTest {
 
     @BeforeAll
     static void setUpBeforeClass() throws IOException {
-        dataFile = File.createTempFile("data", ".json");
+        dataFile = File.createTempFile("data", ".txt");
         FileWriter fw = new FileWriter(dataFile);
-        fw.write("All your base are belong to us!");
+        fw.write("Confidential test message used for testing");
         fw.close();
     }
 

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthTokenTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthTokenTest.java
@@ -17,9 +17,9 @@
  */
 package com.wultra.security.powerauth.test.v31;
 
-import com.wultra.security.powerauth.client.v4.PowerAuthClient;
+import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.PowerAuthTokenShared;
+import com.wultra.security.powerauth.test.shared.v3.PowerAuthTokenShared;
 import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthTokenTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthTokenTest.java
@@ -72,9 +72,9 @@ class PowerAuthTokenTest {
 
     @BeforeAll
     static void setUpBeforeClass() throws IOException {
-        dataFile = File.createTempFile("data", ".json");
+        dataFile = File.createTempFile("data", ".txt");
         FileWriter fw = new FileWriter(dataFile);
-        fw.write("All your base are belong to us!");
+        fw.write("Confidential test message used for testing");
         fw.close();
     }
 

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v32/PowerAuthActivationCodeTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v32/PowerAuthActivationCodeTest.java
@@ -86,7 +86,7 @@ public class PowerAuthActivationCodeTest {
         signatureModel = new VerifyAuthenticationStepModel();
         signatureModel.setApplicationKey(config.getApplicationKey());
         signatureModel.setApplicationSecret(config.getApplicationSecret());
-        signatureModel.setAuthenticationCodeType(PowerAuthCodeType.POSSESSION_BIOMETRY);
+        signatureModel.setAuthenticationCodeType(PowerAuthCodeType.POSSESSION_KNOWLEDGE);
         signatureModel.setPassword(config.getPassword());
         signatureModel.setHttpMethod("POST");
         signatureModel.setHeaders(new HashMap<>());

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v32/PowerAuthActivationCommitPhaseTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v32/PowerAuthActivationCommitPhaseTest.java
@@ -60,8 +60,6 @@ class PowerAuthActivationCommitPhaseTest {
     private final String validOtpValue = "1234-5678";
     private final String invalidOtpValue = "8765-4321";
 
-    private static final PowerAuthClientActivation activation = new PowerAuthClientActivation();
-
     @Autowired
     public void setPowerAuthClient(PowerAuthClient powerAuthClient) {
         this.powerAuthClient = powerAuthClient;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v32/PowerAuthActivationCommitPhaseTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v32/PowerAuthActivationCommitPhaseTest.java
@@ -17,10 +17,9 @@
  */
 package com.wultra.security.powerauth.test.v32;
 
-import com.wultra.security.powerauth.client.v3.PowerAuthClient;
+import com.wultra.security.powerauth.client.v4.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
 import com.wultra.security.powerauth.test.shared.PowerAuthActivationCommitPhaseShared;
-import com.wultra.security.powerauth.crypto.client.activation.PowerAuthClientActivation;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.steps.model.GetStatusStepModel;
 import com.wultra.security.powerauth.lib.cmd.steps.model.PrepareActivationStepModel;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v32/PowerAuthActivationCommitPhaseTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v32/PowerAuthActivationCommitPhaseTest.java
@@ -101,13 +101,13 @@ class PowerAuthActivationCommitPhaseTest {
     }
 
     @Test
-    void validOtpOnKeysExchangeTest() throws Exception {
-        PowerAuthActivationCommitPhaseShared.validOtpOnKeysExchangeTest(powerAuthClient, config, model, validOtpValue, VERSION);
+    void validOtpOnKeyExchangeTest() throws Exception {
+        PowerAuthActivationCommitPhaseShared.validOtpOnKeyExchangeTest(powerAuthClient, config, model, validOtpValue, VERSION);
     }
 
     @Test
-    void invalidOtpOnKeysExchangeTest() throws Exception {
-        PowerAuthActivationCommitPhaseShared.invalidOtpOnKeysExchangeTest(powerAuthClient, config, model, validOtpValue, invalidOtpValue, VERSION);
+    void invalidOtpOnKeyExchangeTest() throws Exception {
+        PowerAuthActivationCommitPhaseShared.invalidOtpOnKeyExchangeTest(powerAuthClient, config, model, validOtpValue, invalidOtpValue, VERSION);
     }
 
     @Test

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v32/PowerAuthActivationOtpTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v32/PowerAuthActivationOtpTest.java
@@ -17,9 +17,9 @@
  */
 package com.wultra.security.powerauth.test.v32;
 
-import com.wultra.security.powerauth.client.v4.PowerAuthClient;
+import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.PowerAuthActivationOtpShared;
+import com.wultra.security.powerauth.test.shared.v3.PowerAuthActivationOtpShared;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.steps.model.GetStatusStepModel;
 import com.wultra.security.powerauth.lib.cmd.steps.model.PrepareActivationStepModel;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v32/PowerAuthActivationOtpTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v32/PowerAuthActivationOtpTest.java
@@ -101,13 +101,13 @@ class PowerAuthActivationOtpTest {
     }
 
     @Test
-    void validOtpOnKeysExchangeTest() throws Exception {
-        PowerAuthActivationOtpShared.validOtpOnKeysExchangeTest(powerAuthClient, config, model, validOtpValue, VERSION);
+    void validOtpOnKeyExchangeTest() throws Exception {
+        PowerAuthActivationOtpShared.validOtpOnKeyExchangeTest(powerAuthClient, config, model, validOtpValue, VERSION);
     }
 
     @Test
-    void invalidOtpOnKeysExchangeTest() throws Exception {
-        PowerAuthActivationOtpShared.invalidOtpOnKeysExchangeTest(powerAuthClient, config, model, validOtpValue, invalidOtpValue, VERSION);
+    void invalidOtpOnKeyExchangeTest() throws Exception {
+        PowerAuthActivationOtpShared.invalidOtpOnKeyExchangeTest(powerAuthClient, config, model, validOtpValue, invalidOtpValue, VERSION);
     }
 
     @Test
@@ -156,8 +156,8 @@ class PowerAuthActivationOtpTest {
     }
 
     @Test
-    void missingOtpOnKeysExchangeTest() throws Exception {
-        PowerAuthActivationOtpShared.missingOtpOnKeysExchangeTest(powerAuthClient, config, model, validOtpValue, VERSION);
+    void missingOtpOnKeyExchangeTest() throws Exception {
+        PowerAuthActivationOtpShared.missingOtpOnKeyExchangeTest(powerAuthClient, config, model, validOtpValue, VERSION);
     }
 
 }

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v32/PowerAuthActivationOtpTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v32/PowerAuthActivationOtpTest.java
@@ -17,7 +17,7 @@
  */
 package com.wultra.security.powerauth.test.v32;
 
-import com.wultra.security.powerauth.client.v3.PowerAuthClient;
+import com.wultra.security.powerauth.client.v4.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
 import com.wultra.security.powerauth.test.shared.PowerAuthActivationOtpShared;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v32/PowerAuthActivationTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v32/PowerAuthActivationTest.java
@@ -20,7 +20,7 @@ package com.wultra.security.powerauth.test.v32;
 import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.PowerAuthActivationShared;
+import com.wultra.security.powerauth.test.shared.v3.PowerAuthActivationShared;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.steps.model.PrepareActivationStepModel;
 import org.json.simple.JSONObject;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v32/PowerAuthCustomActivationOtpTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v32/PowerAuthCustomActivationOtpTest.java
@@ -19,7 +19,7 @@ package com.wultra.security.powerauth.test.v32;
 
 import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.PowerAuthCustomActivationOtpShared;
+import com.wultra.security.powerauth.test.shared.v3.PowerAuthCustomActivationOtpShared;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
 import com.wultra.security.powerauth.lib.cmd.steps.model.CreateActivationStepModel;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v32/PowerAuthCustomActivationOtpTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v32/PowerAuthCustomActivationOtpTest.java
@@ -80,9 +80,9 @@ class PowerAuthCustomActivationOtpTest {
 
     @BeforeAll
     static void setUpBeforeClass() throws IOException {
-        dataFile = File.createTempFile("data", ".json");
+        dataFile = File.createTempFile("data", ".txt");
         FileWriter fw = new FileWriter(dataFile);
-        fw.write("All your base are belong to us!");
+        fw.write("Confidential test message used for testing");
         fw.close();
     }
 

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v32/PowerAuthCustomActivationTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v32/PowerAuthCustomActivationTest.java
@@ -74,9 +74,9 @@ class PowerAuthCustomActivationTest {
 
     @BeforeAll
     static void setUpBeforeClass() throws IOException {
-        dataFile = File.createTempFile("data", ".json");
+        dataFile = File.createTempFile("data", ".txt");
         FileWriter fw = new FileWriter(dataFile);
-        fw.write("All your base are belong to us!");
+        fw.write("Confidential test message used for testing");
         fw.close();
     }
 

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v32/PowerAuthIdentityVerificationTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v32/PowerAuthIdentityVerificationTest.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.PowerAuthIdentityVerificationShared;
+import com.wultra.security.powerauth.test.shared.v3.PowerAuthIdentityVerificationShared;
 import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v32/PowerAuthOidcActivationTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v32/PowerAuthOidcActivationTest.java
@@ -107,9 +107,9 @@ class PowerAuthOidcActivationTest {
 
     @BeforeAll
     static void setUpBeforeClass() throws IOException {
-        dataFile = File.createTempFile("data", ".json");
+        dataFile = File.createTempFile("data", ".txt");
         FileWriter fw = new FileWriter(dataFile);
-        fw.write("All your base are belong to us!");
+        fw.write("Confidential test message used for testing");
         fw.close();
     }
 

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v32/PowerAuthOnboardingTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v32/PowerAuthOnboardingTest.java
@@ -20,7 +20,7 @@ package com.wultra.security.powerauth.test.v32;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.PowerAuthOnboardingShared;
+import com.wultra.security.powerauth.test.shared.v3.PowerAuthOnboardingShared;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
 import com.wultra.security.powerauth.lib.cmd.steps.model.CreateActivationStepModel;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v32/PowerAuthSignatureTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v32/PowerAuthSignatureTest.java
@@ -19,7 +19,7 @@ package com.wultra.security.powerauth.test.v32;
 
 import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.PowerAuthSignatureShared;
+import com.wultra.security.powerauth.test.shared.v3.PowerAuthSignatureShared;
 import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v32/PowerAuthSignatureTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v32/PowerAuthSignatureTest.java
@@ -74,9 +74,9 @@ class PowerAuthSignatureTest {
 
     @BeforeAll
     static void setUpBeforeClass() throws IOException {
-        dataFile = File.createTempFile("data", ".json");
+        dataFile = File.createTempFile("data", ".txt");
         FileWriter fw = new FileWriter(dataFile);
-        fw.write("All your base are belong to us!");
+        fw.write("Confidential test message used for testing");
         fw.close();
     }
 

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v32/PowerAuthTokenTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v32/PowerAuthTokenTest.java
@@ -17,7 +17,7 @@
  */
 package com.wultra.security.powerauth.test.v32;
 
-import com.wultra.security.powerauth.client.v3.PowerAuthClient;
+import com.wultra.security.powerauth.client.v4.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
 import com.wultra.security.powerauth.test.shared.PowerAuthTokenShared;
 import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v32/PowerAuthTokenTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v32/PowerAuthTokenTest.java
@@ -72,9 +72,9 @@ class PowerAuthTokenTest {
 
     @BeforeAll
     static void setUpBeforeClass() throws IOException {
-        dataFile = File.createTempFile("data", ".json");
+        dataFile = File.createTempFile("data", ".txt");
         FileWriter fw = new FileWriter(dataFile);
-        fw.write("All your base are belong to us!");
+        fw.write("Confidential test message used for testing");
         fw.close();
     }
 

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v32/PowerAuthTokenTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v32/PowerAuthTokenTest.java
@@ -17,9 +17,9 @@
  */
 package com.wultra.security.powerauth.test.v32;
 
-import com.wultra.security.powerauth.client.v4.PowerAuthClient;
+import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.PowerAuthTokenShared;
+import com.wultra.security.powerauth.test.shared.v3.PowerAuthTokenShared;
 import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v32/PowerAuthVaultUnlockTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v32/PowerAuthVaultUnlockTest.java
@@ -19,7 +19,7 @@ package com.wultra.security.powerauth.test.v32;
 
 import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.PowerAuthVaultUnlockShared;
+import com.wultra.security.powerauth.test.shared.v3.PowerAuthVaultUnlockShared;
 import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v33/PowerAuthActivationCommitPhaseTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v33/PowerAuthActivationCommitPhaseTest.java
@@ -17,10 +17,9 @@
  */
 package com.wultra.security.powerauth.test.v33;
 
-import com.wultra.security.powerauth.client.v3.PowerAuthClient;
+import com.wultra.security.powerauth.client.v4.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
 import com.wultra.security.powerauth.test.shared.PowerAuthActivationCommitPhaseShared;
-import com.wultra.security.powerauth.crypto.client.activation.PowerAuthClientActivation;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.steps.model.GetStatusStepModel;
 import com.wultra.security.powerauth.lib.cmd.steps.model.PrepareActivationStepModel;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v33/PowerAuthActivationCommitPhaseTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v33/PowerAuthActivationCommitPhaseTest.java
@@ -17,9 +17,9 @@
  */
 package com.wultra.security.powerauth.test.v33;
 
-import com.wultra.security.powerauth.client.v4.PowerAuthClient;
+import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.PowerAuthActivationCommitPhaseShared;
+import com.wultra.security.powerauth.test.shared.v3.PowerAuthActivationCommitPhaseShared;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.steps.model.GetStatusStepModel;
 import com.wultra.security.powerauth.lib.cmd.steps.model.PrepareActivationStepModel;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v33/PowerAuthActivationCommitPhaseTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v33/PowerAuthActivationCommitPhaseTest.java
@@ -101,13 +101,13 @@ class PowerAuthActivationCommitPhaseTest {
     }
 
     @Test
-    void validOtpOnKeysExchangeTest() throws Exception {
-        PowerAuthActivationCommitPhaseShared.validOtpOnKeysExchangeTest(powerAuthClient, config, model, validOtpValue, VERSION);
+    void validOtpOnKeyExchangeTest() throws Exception {
+        PowerAuthActivationCommitPhaseShared.validOtpOnKeyExchangeTest(powerAuthClient, config, model, validOtpValue, VERSION);
     }
 
     @Test
-    void invalidOtpOnKeysExchangeTest() throws Exception {
-        PowerAuthActivationCommitPhaseShared.invalidOtpOnKeysExchangeTest(powerAuthClient, config, model, validOtpValue, invalidOtpValue, VERSION);
+    void invalidOtpOnKeyExchangeTest() throws Exception {
+        PowerAuthActivationCommitPhaseShared.invalidOtpOnKeyExchangeTest(powerAuthClient, config, model, validOtpValue, invalidOtpValue, VERSION);
     }
 
     @Test

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v33/PowerAuthActivationOtpTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v33/PowerAuthActivationOtpTest.java
@@ -17,7 +17,7 @@
  */
 package com.wultra.security.powerauth.test.v33;
 
-import com.wultra.security.powerauth.client.v3.PowerAuthClient;
+import com.wultra.security.powerauth.client.v4.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
 import com.wultra.security.powerauth.test.shared.PowerAuthActivationOtpShared;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v33/PowerAuthActivationOtpTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v33/PowerAuthActivationOtpTest.java
@@ -101,13 +101,13 @@ class PowerAuthActivationOtpTest {
     }
 
     @Test
-    void validOtpOnKeysExchangeTest() throws Exception {
-        PowerAuthActivationOtpShared.validOtpOnKeysExchangeTest(powerAuthClient, config, model, validOtpValue, VERSION);
+    void validOtpOnKeyExchangeTest() throws Exception {
+        PowerAuthActivationOtpShared.validOtpOnKeyExchangeTest(powerAuthClient, config, model, validOtpValue, VERSION);
     }
 
     @Test
-    void invalidOtpOnKeysExchangeTest() throws Exception {
-        PowerAuthActivationOtpShared.invalidOtpOnKeysExchangeTest(powerAuthClient, config, model, validOtpValue, invalidOtpValue, VERSION);
+    void invalidOtpOnKeyExchangeTest() throws Exception {
+        PowerAuthActivationOtpShared.invalidOtpOnKeyExchangeTest(powerAuthClient, config, model, validOtpValue, invalidOtpValue, VERSION);
     }
 
     @Test
@@ -156,8 +156,8 @@ class PowerAuthActivationOtpTest {
     }
 
     @Test
-    void missingOtpOnKeysExchangeTest() throws Exception {
-        PowerAuthActivationOtpShared.missingOtpOnKeysExchangeTest(powerAuthClient, config, model, validOtpValue, VERSION);
+    void missingOtpOnKeyExchangeTest() throws Exception {
+        PowerAuthActivationOtpShared.missingOtpOnKeyExchangeTest(powerAuthClient, config, model, validOtpValue, VERSION);
     }
 
 }

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v33/PowerAuthActivationOtpTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v33/PowerAuthActivationOtpTest.java
@@ -17,9 +17,9 @@
  */
 package com.wultra.security.powerauth.test.v33;
 
-import com.wultra.security.powerauth.client.v4.PowerAuthClient;
+import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.PowerAuthActivationOtpShared;
+import com.wultra.security.powerauth.test.shared.v3.PowerAuthActivationOtpShared;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.steps.model.GetStatusStepModel;
 import com.wultra.security.powerauth.lib.cmd.steps.model.PrepareActivationStepModel;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v33/PowerAuthActivationTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v33/PowerAuthActivationTest.java
@@ -20,7 +20,7 @@ package com.wultra.security.powerauth.test.v33;
 import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.PowerAuthActivationShared;
+import com.wultra.security.powerauth.test.shared.v3.PowerAuthActivationShared;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.steps.model.PrepareActivationStepModel;
 import org.json.simple.JSONObject;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v33/PowerAuthCustomActivationOtpTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v33/PowerAuthCustomActivationOtpTest.java
@@ -19,7 +19,7 @@ package com.wultra.security.powerauth.test.v33;
 
 import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.PowerAuthCustomActivationOtpShared;
+import com.wultra.security.powerauth.test.shared.v3.PowerAuthCustomActivationOtpShared;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
 import com.wultra.security.powerauth.lib.cmd.steps.model.CreateActivationStepModel;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v33/PowerAuthCustomActivationOtpTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v33/PowerAuthCustomActivationOtpTest.java
@@ -80,9 +80,9 @@ class PowerAuthCustomActivationOtpTest {
 
     @BeforeAll
     static void setUpBeforeClass() throws IOException {
-        dataFile = File.createTempFile("data", ".json");
+        dataFile = File.createTempFile("data", ".txt");
         FileWriter fw = new FileWriter(dataFile);
-        fw.write("All your base are belong to us!");
+        fw.write("Confidential test message used for testing");
         fw.close();
     }
 

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v33/PowerAuthCustomActivationTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v33/PowerAuthCustomActivationTest.java
@@ -74,9 +74,9 @@ class PowerAuthCustomActivationTest {
 
     @BeforeAll
     static void setUpBeforeClass() throws IOException {
-        dataFile = File.createTempFile("data", ".json");
+        dataFile = File.createTempFile("data", ".txt");
         FileWriter fw = new FileWriter(dataFile);
-        fw.write("All your base are belong to us!");
+        fw.write("Confidential test message used for testing");
         fw.close();
     }
 

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v33/PowerAuthCustomActivationTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v33/PowerAuthCustomActivationTest.java
@@ -19,7 +19,7 @@ package com.wultra.security.powerauth.test.v33;
 
 import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.PowerAuthCustomActivationShared;
+import com.wultra.security.powerauth.test.shared.v3.PowerAuthCustomActivationShared;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
 import com.wultra.security.powerauth.lib.cmd.steps.model.CreateActivationStepModel;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v33/PowerAuthEncryptionTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v33/PowerAuthEncryptionTest.java
@@ -19,7 +19,7 @@ package com.wultra.security.powerauth.test.v33;
 
 import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.PowerAuthEncryptionShared;
+import com.wultra.security.powerauth.test.shared.v3.PowerAuthEncryptionShared;
 import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v33/PowerAuthIdentityVerificationTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v33/PowerAuthIdentityVerificationTest.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.PowerAuthIdentityVerificationShared;
+import com.wultra.security.powerauth.test.shared.v3.PowerAuthIdentityVerificationShared;
 import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v33/PowerAuthOidcActivationTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v33/PowerAuthOidcActivationTest.java
@@ -107,9 +107,9 @@ class PowerAuthOidcActivationTest {
 
     @BeforeAll
     static void setUpBeforeClass() throws IOException {
-        dataFile = File.createTempFile("data", ".json");
+        dataFile = File.createTempFile("data", ".txt");
         FileWriter fw = new FileWriter(dataFile);
-        fw.write("All your base are belong to us!");
+        fw.write("Confidential test message used for testing");
         fw.close();
     }
 

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v33/PowerAuthOnboardingTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v33/PowerAuthOnboardingTest.java
@@ -20,7 +20,7 @@ package com.wultra.security.powerauth.test.v33;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.PowerAuthOnboardingShared;
+import com.wultra.security.powerauth.test.shared.v3.PowerAuthOnboardingShared;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
 import com.wultra.security.powerauth.lib.cmd.steps.model.CreateActivationStepModel;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v33/PowerAuthSignatureTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v33/PowerAuthSignatureTest.java
@@ -19,7 +19,7 @@ package com.wultra.security.powerauth.test.v33;
 
 import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.PowerAuthSignatureShared;
+import com.wultra.security.powerauth.test.shared.v3.PowerAuthSignatureShared;
 import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v33/PowerAuthSignatureTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v33/PowerAuthSignatureTest.java
@@ -74,9 +74,9 @@ class PowerAuthSignatureTest {
 
     @BeforeAll
     static void setUpBeforeClass() throws IOException {
-        dataFile = File.createTempFile("data", ".json");
+        dataFile = File.createTempFile("data", ".txt");
         FileWriter fw = new FileWriter(dataFile);
-        fw.write("All your base are belong to us!");
+        fw.write("Confidential test message used for testing");
         fw.close();
     }
 

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v33/PowerAuthTokenTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v33/PowerAuthTokenTest.java
@@ -17,7 +17,7 @@
  */
 package com.wultra.security.powerauth.test.v33;
 
-import com.wultra.security.powerauth.client.v3.PowerAuthClient;
+import com.wultra.security.powerauth.client.v4.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
 import com.wultra.security.powerauth.test.shared.PowerAuthTokenShared;
 import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v33/PowerAuthTokenTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v33/PowerAuthTokenTest.java
@@ -17,9 +17,9 @@
  */
 package com.wultra.security.powerauth.test.v33;
 
-import com.wultra.security.powerauth.client.v4.PowerAuthClient;
+import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.PowerAuthTokenShared;
+import com.wultra.security.powerauth.test.shared.v3.PowerAuthTokenShared;
 import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v33/PowerAuthTokenTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v33/PowerAuthTokenTest.java
@@ -72,9 +72,9 @@ class PowerAuthTokenTest {
 
     @BeforeAll
     static void setUpBeforeClass() throws IOException {
-        dataFile = File.createTempFile("data", ".json");
+        dataFile = File.createTempFile("data", ".txt");
         FileWriter fw = new FileWriter(dataFile);
-        fw.write("All your base are belong to us!");
+        fw.write("Confidential test message used for testing");
         fw.close();
     }
 

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v33/PowerAuthVaultUnlockTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v33/PowerAuthVaultUnlockTest.java
@@ -19,7 +19,7 @@ package com.wultra.security.powerauth.test.v33;
 
 import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.PowerAuthVaultUnlockShared;
+import com.wultra.security.powerauth.test.shared.v3.PowerAuthVaultUnlockShared;
 import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v3x/PowerAuthApiTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v3x/PowerAuthApiTest.java
@@ -20,7 +20,7 @@ package com.wultra.security.powerauth.test.v3x;
 import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.PowerAuthApiShared;
+import com.wultra.security.powerauth.test.shared.v3.PowerAuthApiShared;
 import com.wultra.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
 import com.wultra.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v3x/PowerAuthHttpTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v3x/PowerAuthHttpTest.java
@@ -1,0 +1,140 @@
+/*
+ * PowerAuth test and related software components
+ * Copyright (C) 2018 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation either version 3 of the License or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.security.powerauth.test.v3x;
+
+import com.wultra.core.rest.client.base.RestClientException;
+import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
+import com.wultra.core.rest.model.base.response.ErrorResponse;
+import com.wultra.core.rest.model.base.response.Response;
+import com.wultra.security.powerauth.http.PowerAuthAuthorizationHttpHeader;
+import com.wultra.security.powerauth.http.PowerAuthTokenHttpHeader;
+import com.wultra.security.powerauth.lib.cmd.util.MapUtil;
+import com.wultra.security.powerauth.lib.cmd.util.RestClientFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = PowerAuthTestConfiguration.class)
+@EnableConfigurationProperties
+class PowerAuthHttpTest {
+
+    private PowerAuthTestConfiguration config;
+
+    @Autowired
+    public void setPowerAuthTestConfiguration(PowerAuthTestConfiguration config) {
+        this.config = config;
+    }
+
+    @Test
+    void invalidSignatureHeaderTest() {
+        final byte[] data = "test".getBytes(StandardCharsets.UTF_8);
+        final String signatureHeaderInvalid = "PowerAuth pa_activation_id=\"79b910a6-b058-49bd-a56d-d54b5aada048\" pa_application_key=\"4rVingHqXITsWvGj1K+EBQ==\" pa_nonce=\"inZWJ5hCFBk+nnZ1sYTnjg==\" pa_signature_type=\"possession_knowledge\" pa_signature=\"77419567-47712563\" pa_version=\"3.0\"";
+
+        final Map<String, String> headers = Map.of(
+                "Accept", "application/json",
+                "Content-Type", "application/json",
+                PowerAuthAuthorizationHttpHeader.HEADER_NAME, signatureHeaderInvalid);
+
+        final RestClientException exception = assertThrows(RestClientException.class, () ->
+                RestClientFactory.getRestClient().post(
+                        config.getPowerAuthIntegrationUrl() + "/pa/v3/signature/validate",
+                        data,
+                        null,
+                        MapUtil.toMultiValueMap(headers),
+                        new ParameterizedTypeReference<Response>() {}
+                ));
+
+        assertEquals(401, exception.getStatusCode().value());
+        assertNotNull(exception.getErrorResponse());
+        final ErrorResponse errorResponse = exception.getErrorResponse();
+        assertEquals("ERROR", errorResponse.getStatus());
+        checkError(errorResponse);
+    }
+
+    @Test
+    void invalidTokenHeaderTest() {
+        byte[] data = "test".getBytes(StandardCharsets.UTF_8);
+        String tokenHeaderInvalid = "PowerAuth token_id=\"0f3da4d7-427d-4b54-8211-b1995214810b\" token_digest=\"rMYL7jvUhBqdGyNjiGJED+9cM0tAM9JhAhSdfbatPg4=\" nonce=\"jHaHL1mWWZoB/+QQbGTAwg==\" timestamp=\"1541000429960\" version=\"3.0\"";
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Accept", "application/json");
+        headers.put("Content-Type", "application/json");
+        headers.put(PowerAuthTokenHttpHeader.HEADER_NAME, tokenHeaderInvalid);
+        String tokenUrl;
+        tokenUrl = config.getPowerAuthIntegrationUrl() + "/api/auth/token/app/operation/list";
+
+        try {
+            RestClientFactory.getRestClient().post(
+                    tokenUrl,
+                    data,
+                    null,
+                    MapUtil.toMultiValueMap(headers),
+                    new ParameterizedTypeReference<Response>() {}
+            );
+        } catch (RestClientException ex) {
+            assertEquals(401, ex.getStatusCode().value());
+            ErrorResponse errorResponse = Objects.requireNonNull(ex.getErrorResponse());
+            assertEquals("ERROR", errorResponse.getStatus());
+            checkError(errorResponse);
+        }
+    }
+
+    @Test
+    void invalidEncryptionHeaderTest() {
+        byte[] data = "{\"ephemeralPublicKey\":\"BHBy8Apj7BFxjGaiKs8nFRkD4rjlSuo1rguWnjlSChLKhRGUdooT0Geh8rE6u2QOnY2rBaIj+Stzqj6A/cs3WUY=\",\"encryptedData\":\"rZKU++q2HE3uwZRMLSlYfuUvHrKt9CVGYUGB21CjdaNyflyTOei7dvRAVACQRyJmcyWePAl0BQHRaN1trJyw8Ue1YzYVx7fGEQ9l9WtCJYeYBPS4krR7ZFo4ydmeFm/rhklClUVJZ2OSSt2Z/O9HctA8W/BlwAMSVDj496wdZ3ozxDLhDwd+sBx03Y3812GD0s3HbxK4wHN/OCj+jAczowI0FzI1cT5DA+M7e7Hc0golN1SExVqw1aMVAwA32gwjbc0nuqecXPB0op4AhGTAOZFQDtmQH/U1chcykTXso4Y7FF1fKjyeyZN73imO3lImhKETBc+2hg3/KEVjP43OqtB5DgaCatoWXjAVHJY/mSLWJd7WtfCAq1+xNSbwuhAEt8y2+/2BzvaRQFs8WuqAuBlTx/c1u2hddCpfQFRb0a3x2l7FYrBtYYfmQZb38s+zsix6Ju4esZ9HibmX8XvdMZB9F4E+tUfLrRwJmFpRm5dC6ufZp8+Qur8c+SM5aOVqLRWf/by6rC/6P+Pm35UNwAYA5sbrZU+0za4TlT7hNR4bkxkHStz5moBRyrwIYtJVMKDg3pXMzLW/j35lN9mnlQHEKPbt7ZlRjeKotXGAjrztXDOT3bOHBayMHm/fjCk+cHUIEYvR3jd4PvgG6YuU9W6F/jCxG8XnFumuBVJzRVnHYlCC+eZ2XxwLxSxTpO3D\",\"mac\":\"RLhrZebxh03EssLgC265flJ06Wp67QdOhkAeXxAMxSk=\"}".getBytes(StandardCharsets.UTF_8);
+        String tokenHeaderInvalid = "PowerAuth application_key=\"4rVingHqXITsWvGj1K+EBQ==\" version=\"3.0\"";
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Accept", "application/json");
+        headers.put("Content-Type", "application/json");
+        headers.put(PowerAuthTokenHttpHeader.HEADER_NAME, tokenHeaderInvalid);
+
+        try {
+            RestClientFactory.getRestClient().post(
+                    config.getPowerAuthIntegrationUrl() + "/pa/v3/activation/create",
+                    data,
+                    null,
+                    MapUtil.toMultiValueMap(headers),
+                    new ParameterizedTypeReference<Response>() {}
+            );
+        } catch (RestClientException ex) {
+            assertEquals(400, ex.getStatusCode().value());
+            ErrorResponse errorResponse = Objects.requireNonNull(ex.getErrorResponse());
+            assertEquals("ERROR", errorResponse.getStatus());
+            assertEquals("ERR_ACTIVATION", errorResponse.getResponseObject().getCode());
+            assertEquals("POWER_AUTH_ACTIVATION_INVALID", errorResponse.getResponseObject().getMessage());
+        }
+    }
+
+    private void checkError(ErrorResponse errorResponse) {
+        assertTrue("POWERAUTH_AUTH_FAIL".equals(errorResponse.getResponseObject().getCode()) || "ERR_AUTHENTICATION".equals(errorResponse.getResponseObject().getCode()));
+    }
+
+}

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v3x/PowerAuthSignatureTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v3x/PowerAuthSignatureTest.java
@@ -15,15 +15,15 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.wultra.security.powerauth.test.v4x;
+package com.wultra.security.powerauth.test.v3x;
 
+import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
-import com.wultra.security.powerauth.client.v4.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
+import com.wultra.security.powerauth.test.shared.v3.PowerAuthApiShared;
 import com.wultra.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
 import com.wultra.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
-import com.wultra.security.powerauth.test.shared.v4.PowerAuthApiShared;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,16 +34,16 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import java.security.InvalidKeyException;
 
 /**
- * PowerAuth API tests.
+ * PowerAuth additional signature and token tests.
  *
  * @author Roman Strobl, roman.strobl@wultra.com
  */
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = PowerAuthTestConfiguration.class)
 @EnableConfigurationProperties
-class PowerAuthApiTest {
+class PowerAuthSignatureTest {
 
-    private static final PowerAuthVersion VERSION = PowerAuthVersion.V4_0;
+    private static final PowerAuthVersion VERSION = PowerAuthVersion.V3_3;
 
     private PowerAuthClient powerAuthClient;
     private PowerAuthTestConfiguration config;
@@ -59,8 +59,18 @@ class PowerAuthApiTest {
     }
 
     @Test
-    void verifyAuthenticationTest() throws GenericCryptoException, CryptoProviderException, InvalidKeyException, PowerAuthClientException {
-        PowerAuthApiShared.verifyAuthenticationTest(powerAuthClient, config, VERSION);
+    void verifySignatureTest() throws GenericCryptoException, CryptoProviderException, InvalidKeyException, PowerAuthClientException {
+        PowerAuthApiShared.verifySignatureTest(powerAuthClient, config, VERSION);
+    }
+
+    @Test
+    void unlockVaultAndECDSASignatureTest() throws Exception {
+        PowerAuthApiShared.unlockVaultAndECDSASignatureTest(powerAuthClient, config, VERSION);
+    }
+
+    @Test
+    void createValidateAndRemoveTokenTestActiveActivation() throws Exception {
+        PowerAuthApiShared.createValidateAndRemoveTokenTestActiveActivation(powerAuthClient, config, VERSION);
     }
 
 }

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthActivationCodeTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthActivationCodeTest.java
@@ -1,6 +1,6 @@
 /*
  * PowerAuth test and related software components
- * Copyright (C) 2018 Wultra s.r.o.
+ * Copyright (C) 2025 Wultra s.r.o.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
@@ -15,15 +15,16 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.wultra.security.powerauth.test.v33;
+package com.wultra.security.powerauth.test.v40;
 
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.PowerAuthActivationCodeShared;
 import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;
+import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
 import com.wultra.security.powerauth.lib.cmd.steps.model.PrepareActivationStepModel;
 import com.wultra.security.powerauth.lib.cmd.steps.model.VerifyAuthenticationStepModel;
+import com.wultra.security.powerauth.test.shared.PowerAuthActivationCodeShared;
 import org.json.simple.JSONObject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,7 +52,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @EnableConfigurationProperties
 public class PowerAuthActivationCodeTest {
 
-    private static final PowerAuthVersion VERSION = PowerAuthVersion.V3_3;
+    private static final PowerAuthVersion VERSION = PowerAuthVersion.V4_0;
 
     private PowerAuthTestConfiguration config;
     private PrepareActivationStepModel activationModel;
@@ -75,11 +76,14 @@ public class PowerAuthActivationCodeTest {
         activationModel.setApplicationKey(config.getApplicationKey());
         activationModel.setApplicationSecret(config.getApplicationSecret());
         activationModel.setMasterPublicKeyP256(config.getMasterPublicKeyP256());
+        activationModel.setMasterPublicKeyP384(config.getMasterPublicKeyP384());
+        activationModel.setMasterPublicKeyMlDsa65(config.getMasterPublicKeyMlDsa65());
         activationModel.setHeaders(new HashMap<>());
         activationModel.setPassword(config.getPassword());
         activationModel.setStatusFileName(tempStatusFile.getAbsolutePath());
         activationModel.setResultStatusObject(new JSONObject());
         activationModel.setUriString(config.getPowerAuthIntegrationUrl());
+        activationModel.setSharedSecretAlgorithm(SharedSecretAlgorithm.EC_P384_ML_L3);
         activationModel.setVersion(VERSION);
         activationModel.setDeviceInfo("backend-tests");
 

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthActivationCodeTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthActivationCodeTest.java
@@ -75,7 +75,6 @@ public class PowerAuthActivationCodeTest {
         activationModel.setActivationName("test v" + VERSION);
         activationModel.setApplicationKey(config.getApplicationKey());
         activationModel.setApplicationSecret(config.getApplicationSecret());
-        activationModel.setMasterPublicKeyP256(config.getMasterPublicKeyP256());
         activationModel.setMasterPublicKeyP384(config.getMasterPublicKeyP384());
         activationModel.setMasterPublicKeyMlDsa65(config.getMasterPublicKeyMlDsa65());
         activationModel.setHeaders(new HashMap<>());

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthActivationCommitPhaseTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthActivationCommitPhaseTest.java
@@ -80,7 +80,6 @@ class PowerAuthActivationCommitPhaseTest {
         model.setActivationName("test v" + VERSION);
         model.setApplicationKey(config.getApplicationKey());
         model.setApplicationSecret(config.getApplicationSecret());
-        model.setMasterPublicKeyP256(config.getMasterPublicKeyP256());
         model.setMasterPublicKeyP384(config.getMasterPublicKeyP384());
         model.setMasterPublicKeyMlDsa65(config.getMasterPublicKeyMlDsa65());
         model.setHeaders(new HashMap<>());

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthActivationCommitPhaseTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthActivationCommitPhaseTest.java
@@ -17,9 +17,8 @@
  */
 package com.wultra.security.powerauth.test.v40;
 
-import com.wultra.security.powerauth.client.v3.PowerAuthClient;
+import com.wultra.security.powerauth.client.v4.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.crypto.client.activation.PowerAuthClientActivation;
 import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.steps.model.GetStatusStepModel;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthActivationCommitPhaseTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthActivationCommitPhaseTest.java
@@ -107,13 +107,13 @@ class PowerAuthActivationCommitPhaseTest {
     }
 
     @Test
-    void validOtpOnKeysExchangeTest() throws Exception {
-        PowerAuthActivationCommitPhaseShared.validOtpOnKeysExchangeTest(powerAuthClient, config, model, validOtpValue, VERSION);
+    void validOtpOnKeyExchangeTest() throws Exception {
+        PowerAuthActivationCommitPhaseShared.validOtpOnKeyExchangeTest(powerAuthClient, config, model, validOtpValue, VERSION);
     }
 
     @Test
-    void invalidOtpOnKeysExchangeTest() throws Exception {
-        PowerAuthActivationCommitPhaseShared.invalidOtpOnKeysExchangeTest(powerAuthClient, config, model, validOtpValue, invalidOtpValue, VERSION);
+    void invalidOtpOnKeyExchangeTest() throws Exception {
+        PowerAuthActivationCommitPhaseShared.invalidOtpOnKeyExchangeTest(powerAuthClient, config, model, validOtpValue, invalidOtpValue, VERSION);
     }
 
     @Test

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthActivationCommitPhaseTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthActivationCommitPhaseTest.java
@@ -23,7 +23,7 @@ import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlg
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.steps.model.GetStatusStepModel;
 import com.wultra.security.powerauth.lib.cmd.steps.model.PrepareActivationStepModel;
-import com.wultra.security.powerauth.test.shared.PowerAuthActivationCommitPhaseShared;
+import com.wultra.security.powerauth.test.shared.v4.PowerAuthActivationCommitPhaseShared;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthActivationCommitPhaseTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthActivationCommitPhaseTest.java
@@ -1,6 +1,6 @@
 /*
  * PowerAuth test and related software components
- * Copyright (C) 2024 Wultra s.r.o.
+ * Copyright (C) 2025 Wultra s.r.o.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
@@ -15,15 +15,16 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.wultra.security.powerauth.test.v33;
+package com.wultra.security.powerauth.test.v40;
 
 import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.PowerAuthActivationCommitPhaseShared;
 import com.wultra.security.powerauth.crypto.client.activation.PowerAuthClientActivation;
+import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.steps.model.GetStatusStepModel;
 import com.wultra.security.powerauth.lib.cmd.steps.model.PrepareActivationStepModel;
+import com.wultra.security.powerauth.test.shared.PowerAuthActivationCommitPhaseShared;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -49,7 +50,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @EnableConfigurationProperties
 class PowerAuthActivationCommitPhaseTest {
 
-    private static final PowerAuthVersion VERSION = PowerAuthVersion.V3_3;
+    private static final PowerAuthVersion VERSION = PowerAuthVersion.V4_0;
 
     private PowerAuthClient powerAuthClient;
     private PowerAuthTestConfiguration config;
@@ -81,11 +82,14 @@ class PowerAuthActivationCommitPhaseTest {
         model.setApplicationKey(config.getApplicationKey());
         model.setApplicationSecret(config.getApplicationSecret());
         model.setMasterPublicKeyP256(config.getMasterPublicKeyP256());
+        model.setMasterPublicKeyP384(config.getMasterPublicKeyP384());
+        model.setMasterPublicKeyMlDsa65(config.getMasterPublicKeyMlDsa65());
         model.setHeaders(new HashMap<>());
         model.setPassword(config.getPassword());
         model.setStatusFileName(tempStatusFile.getAbsolutePath());
         model.setResultStatusObject(config.getResultStatusObject(VERSION));
         model.setUriString(config.getPowerAuthIntegrationUrl());
+        model.setSharedSecretAlgorithm(SharedSecretAlgorithm.EC_P384_ML_L3);
         model.setVersion(VERSION);
         model.setDeviceInfo("backend-tests");
 
@@ -93,6 +97,8 @@ class PowerAuthActivationCommitPhaseTest {
         statusModel.setHeaders(new HashMap<>());
         statusModel.setResultStatusObject(config.getResultStatusObject(VERSION));
         statusModel.setUriString(config.getPowerAuthIntegrationUrl());
+        statusModel.setApplicationKey(config.getApplicationKey());
+        statusModel.setApplicationSecret(config.getApplicationSecret());
         statusModel.setVersion(VERSION);
     }
 

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthActivationOtpTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthActivationOtpTest.java
@@ -23,7 +23,7 @@ import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlg
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.steps.model.GetStatusStepModel;
 import com.wultra.security.powerauth.lib.cmd.steps.model.PrepareActivationStepModel;
-import com.wultra.security.powerauth.test.shared.PowerAuthActivationOtpShared;
+import com.wultra.security.powerauth.test.shared.v4.PowerAuthActivationOtpShared;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthActivationOtpTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthActivationOtpTest.java
@@ -80,7 +80,6 @@ class PowerAuthActivationOtpTest {
         model.setActivationName("test v" + VERSION);
         model.setApplicationKey(config.getApplicationKey());
         model.setApplicationSecret(config.getApplicationSecret());
-        model.setMasterPublicKeyP256(config.getMasterPublicKeyP256());
         model.setMasterPublicKeyP384(config.getMasterPublicKeyP384());
         model.setMasterPublicKeyMlDsa65(config.getMasterPublicKeyMlDsa65());
         model.setHeaders(new HashMap<>());

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthActivationOtpTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthActivationOtpTest.java
@@ -107,13 +107,13 @@ class PowerAuthActivationOtpTest {
     }
 
     @Test
-    void validOtpOnKeysExchangeTest() throws Exception {
-        PowerAuthActivationOtpShared.validOtpOnKeysExchangeTest(powerAuthClient, config, model, validOtpValue, VERSION);
+    void validOtpOnKeyExchangeTest() throws Exception {
+        PowerAuthActivationOtpShared.validOtpOnKeyExchangeTest(powerAuthClient, config, model, validOtpValue, VERSION);
     }
 
     @Test
-    void invalidOtpOnKeysExchangeTest() throws Exception {
-        PowerAuthActivationOtpShared.invalidOtpOnKeysExchangeTest(powerAuthClient, config, model, validOtpValue, invalidOtpValue, VERSION);
+    void invalidOtpOnKeyExchangeTest() throws Exception {
+        PowerAuthActivationOtpShared.invalidOtpOnKeyExchangeTest(powerAuthClient, config, model, validOtpValue, invalidOtpValue, VERSION);
     }
 
     @Test
@@ -162,8 +162,8 @@ class PowerAuthActivationOtpTest {
     }
 
     @Test
-    void missingOtpOnKeysExchangeTest() throws Exception {
-        PowerAuthActivationOtpShared.missingOtpOnKeysExchangeTest(powerAuthClient, config, model, validOtpValue, VERSION);
+    void missingOtpOnKeyExchangeTest() throws Exception {
+        PowerAuthActivationOtpShared.missingOtpOnKeyExchangeTest(powerAuthClient, config, model, validOtpValue, VERSION);
     }
 
 }

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthActivationOtpTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthActivationOtpTest.java
@@ -1,0 +1,169 @@
+/*
+ * PowerAuth test and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.security.powerauth.test.v40;
+
+import com.wultra.security.powerauth.client.v3.PowerAuthClient;
+import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
+import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
+import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
+import com.wultra.security.powerauth.lib.cmd.steps.model.GetStatusStepModel;
+import com.wultra.security.powerauth.lib.cmd.steps.model.PrepareActivationStepModel;
+import com.wultra.security.powerauth.test.shared.PowerAuthActivationOtpShared;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * PowerAuth activation OTP tests.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = PowerAuthTestConfiguration.class)
+@EnableConfigurationProperties
+class PowerAuthActivationOtpTest {
+
+    private static final PowerAuthVersion VERSION = PowerAuthVersion.V4_0;
+
+    private PowerAuthClient powerAuthClient;
+    private PowerAuthTestConfiguration config;
+    private PrepareActivationStepModel model;
+    private GetStatusStepModel statusModel;
+    private File tempStatusFile;
+
+    private final String validOtpValue = "1234-5678";
+    private final String invalidOtpValue = "8765-4321";
+
+    @Autowired
+    public void setPowerAuthClient(PowerAuthClient powerAuthClient) {
+        this.powerAuthClient = powerAuthClient;
+    }
+
+    @Autowired
+    public void setPowerAuthTestConfiguration(PowerAuthTestConfiguration config) {
+        this.config = config;
+    }
+
+    @BeforeEach
+    void setUp() throws IOException {
+        // Create temp status file
+        tempStatusFile = File.createTempFile("pa_status_" + VERSION, ".json");
+
+        // Models shared among tests
+        model = new PrepareActivationStepModel();
+        model.setActivationName("test v" + VERSION);
+        model.setApplicationKey(config.getApplicationKey());
+        model.setApplicationSecret(config.getApplicationSecret());
+        model.setMasterPublicKeyP256(config.getMasterPublicKeyP256());
+        model.setMasterPublicKeyP384(config.getMasterPublicKeyP384());
+        model.setMasterPublicKeyMlDsa65(config.getMasterPublicKeyMlDsa65());
+        model.setHeaders(new HashMap<>());
+        model.setPassword(config.getPassword());
+        model.setStatusFileName(tempStatusFile.getAbsolutePath());
+        model.setResultStatusObject(config.getResultStatusObject(VERSION));
+        model.setUriString(config.getPowerAuthIntegrationUrl());
+        model.setSharedSecretAlgorithm(SharedSecretAlgorithm.EC_P384_ML_L3);
+        model.setVersion(VERSION);
+        model.setDeviceInfo("backend-tests");
+
+        statusModel = new GetStatusStepModel();
+        statusModel.setHeaders(new HashMap<>());
+        statusModel.setResultStatusObject(config.getResultStatusObject(VERSION));
+        statusModel.setUriString(config.getPowerAuthIntegrationUrl());
+        statusModel.setApplicationKey(config.getApplicationKey());
+        statusModel.setApplicationSecret(config.getApplicationSecret());
+        statusModel.setVersion(VERSION);
+    }
+
+    @AfterEach
+    void tearDown() {
+        assertTrue(tempStatusFile.delete());
+    }
+
+    @Test
+    void validOtpOnKeysExchangeTest() throws Exception {
+        PowerAuthActivationOtpShared.validOtpOnKeysExchangeTest(powerAuthClient, config, model, validOtpValue, VERSION);
+    }
+
+    @Test
+    void invalidOtpOnKeysExchangeTest() throws Exception {
+        PowerAuthActivationOtpShared.invalidOtpOnKeysExchangeTest(powerAuthClient, config, model, validOtpValue, invalidOtpValue, VERSION);
+    }
+
+    @Test
+    void validOtpOnCommitTest() throws Exception {
+        PowerAuthActivationOtpShared.validOtpOnCommitTest(powerAuthClient, config, model, validOtpValue, invalidOtpValue, VERSION);
+    }
+
+    @Test
+    void invalidOtpOnCommitTest() throws Exception {
+        PowerAuthActivationOtpShared.invalidOtpOnCommitTest(powerAuthClient, config, model, validOtpValue, invalidOtpValue, VERSION);
+    }
+
+    @Test
+    void updateValidOtpOnCommitTest() throws Exception {
+        PowerAuthActivationOtpShared.updateValidOtpOnCommitTest(powerAuthClient, config, model, statusModel, validOtpValue, invalidOtpValue, VERSION);
+    }
+
+    @Test
+    void updateInvalidOtpOnCommitTest() throws Exception {
+        PowerAuthActivationOtpShared.updateInvalidOtpOnCommitTest(powerAuthClient, config, model, validOtpValue, invalidOtpValue, VERSION);
+    }
+
+    @Test
+    void wrongActivationInitParamTest1() {
+        PowerAuthActivationOtpShared.wrongActivationInitParamTest1(powerAuthClient, config, VERSION);
+    }
+
+    @Test
+    void wrongActivationInitParamTest2() {
+        PowerAuthActivationOtpShared.wrongActivationInitParamTest2(powerAuthClient, config, VERSION);
+    }
+
+    @Test
+    void wrongActivationInitParamTest3() {
+        PowerAuthActivationOtpShared.wrongActivationInitParamTest3(powerAuthClient, config, VERSION);
+    }
+
+    @Test
+    void wrongActivationInitParamTest4() {
+        PowerAuthActivationOtpShared.wrongActivationInitParamTest4(powerAuthClient, config, VERSION);
+    }
+
+    @Test
+    void missingOtpOnCommitTest() throws Exception {
+        PowerAuthActivationOtpShared.missingOtpOnCommitTest(powerAuthClient, config, model, validOtpValue, VERSION);
+    }
+
+    @Test
+    void missingOtpOnKeysExchangeTest() throws Exception {
+        PowerAuthActivationOtpShared.missingOtpOnKeysExchangeTest(powerAuthClient, config, model, validOtpValue, VERSION);
+    }
+
+}

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthActivationOtpTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthActivationOtpTest.java
@@ -17,7 +17,7 @@
  */
 package com.wultra.security.powerauth.test.v40;
 
-import com.wultra.security.powerauth.client.v3.PowerAuthClient;
+import com.wultra.security.powerauth.client.v4.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
 import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthActivationTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthActivationTest.java
@@ -78,7 +78,6 @@ class PowerAuthActivationTest {
         model.setActivationName("test v" + VERSION);
         model.setApplicationKey(config.getApplicationKey());
         model.setApplicationSecret(config.getApplicationSecret());
-        model.setMasterPublicKeyP256(config.getMasterPublicKeyP256());
         model.setMasterPublicKeyP384(config.getMasterPublicKeyP384());
         model.setMasterPublicKeyMlDsa65(config.getMasterPublicKeyMlDsa65());
         model.setHeaders(new HashMap<>());

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthActivationTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthActivationTest.java
@@ -37,6 +37,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -96,8 +97,17 @@ class PowerAuthActivationTest {
     }
 
     @Test
-    void activationPrepareTest() throws Exception {
+    void activationPrepareHybridTest() throws Exception {
         PowerAuthActivationShared.activationPrepareTest(powerAuthClient, config, model, VERSION);
+    }
+
+    @Test
+    void activationPrepareEcTest() throws Exception {
+        final Map<String, Object> modelMap = model.toMap();
+        final PrepareActivationStepModel modelEc = new PrepareActivationStepModel();
+        modelEc.fromMap(modelMap);
+        modelEc.setSharedSecretAlgorithm(SharedSecretAlgorithm.EC_P384);
+        PowerAuthActivationShared.activationPrepareTest(powerAuthClient, config, modelEc, VERSION);
     }
 
     @Test

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthActivationTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthActivationTest.java
@@ -140,9 +140,6 @@ class PowerAuthActivationTest {
         PowerAuthActivationShared.activationPrepareWithoutInitTest(config, model);
     }
 
-    // Test activationPrepareBadMasterPublicKeyTest is skipped, because master public key is not used
-    // in protocol version 4.0 for encryption due to use of temporary keys.
-
     @Test
     void activationStatusTest() throws Exception {
         PowerAuthActivationShared.activationStatusTest(powerAuthClient, config, model, VERSION);

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthActivationTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthActivationTest.java
@@ -111,6 +111,16 @@ class PowerAuthActivationTest {
     }
 
     @Test
+    void activationConfirmBiometryEnabledTest() throws Exception {
+        PowerAuthActivationShared.activationConfirmTest(powerAuthClient, config, model, VERSION, true);
+    }
+
+    @Test
+    void activationConfirmBiometryDisabledTest() throws Exception {
+        PowerAuthActivationShared.activationConfirmTest(powerAuthClient, config, model, VERSION, false);
+    }
+
+    @Test
     void activationNonExistentTest() throws PowerAuthClientException {
         PowerAuthActivationShared.activationNonExistentTest(powerAuthClient);
     }

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthActivationTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthActivationTest.java
@@ -1,0 +1,186 @@
+/*
+ * PowerAuth test and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.security.powerauth.test.v40;
+
+import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
+import com.wultra.security.powerauth.client.v3.PowerAuthClient;
+import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
+import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
+import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
+import com.wultra.security.powerauth.lib.cmd.steps.model.PrepareActivationStepModel;
+import com.wultra.security.powerauth.test.shared.PowerAuthActivationShared;
+import org.json.simple.JSONObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * PowerAuth activation tests.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = PowerAuthTestConfiguration.class)
+@EnableConfigurationProperties
+class PowerAuthActivationTest {
+
+    private static final PowerAuthVersion VERSION = PowerAuthVersion.V4_0;
+
+    private PowerAuthClient powerAuthClient;
+    private PowerAuthTestConfiguration config;
+    private PrepareActivationStepModel model;
+    private File tempStatusFile;
+
+    @Autowired
+    public void setPowerAuthClient(PowerAuthClient powerAuthClient) {
+        this.powerAuthClient = powerAuthClient;
+    }
+
+    @Autowired
+    public void setPowerAuthTestConfiguration(PowerAuthTestConfiguration config) {
+        this.config = config;
+    }
+
+    @BeforeEach
+    void setUp() throws IOException {
+        // Create temp status file
+        tempStatusFile = File.createTempFile("pa_status_" + VERSION, ".json");
+
+        // Model shared among tests
+        model = new PrepareActivationStepModel();
+        model.setActivationName("test v" + VERSION);
+        model.setApplicationKey(config.getApplicationKey());
+        model.setApplicationSecret(config.getApplicationSecret());
+        model.setMasterPublicKeyP256(config.getMasterPublicKeyP256());
+        model.setMasterPublicKeyP384(config.getMasterPublicKeyP384());
+        model.setMasterPublicKeyMlDsa65(config.getMasterPublicKeyMlDsa65());
+        model.setHeaders(new HashMap<>());
+        model.setPassword(config.getPassword());
+        model.setStatusFileName(tempStatusFile.getAbsolutePath());
+        model.setResultStatusObject(new JSONObject());
+        model.setUriString(config.getPowerAuthIntegrationUrl());
+        model.setSharedSecretAlgorithm(SharedSecretAlgorithm.EC_P384_ML_L3);
+        model.setVersion(VERSION);
+        model.setDeviceInfo("backend-tests");
+    }
+
+    @AfterEach
+    void tearDown() {
+        assertTrue(tempStatusFile.delete());
+    }
+
+    @Test
+    void activationPrepareTest() throws Exception {
+        PowerAuthActivationShared.activationPrepareTest(powerAuthClient, config, model, VERSION);
+    }
+
+    @Test
+    void activationNonExistentTest() throws PowerAuthClientException {
+        PowerAuthActivationShared.activationNonExistentTest(powerAuthClient);
+    }
+
+    @Test
+    void activationPrepareUnsupportedApplicationTest() throws Exception {
+        PowerAuthActivationShared.activationPrepareUnsupportedApplicationTest(powerAuthClient, config, model, VERSION);
+    }
+
+    @Test
+    void activationPrepareExpirationTest() throws Exception {
+        PowerAuthActivationShared.activationPrepareExpirationTest(powerAuthClient, config, model, VERSION);
+    }
+
+    @Test
+    void activationPrepareWithoutInitTest() throws Exception {
+        PowerAuthActivationShared.activationPrepareWithoutInitTest(config, model);
+    }
+
+    // Test activationPrepareBadMasterPublicKeyTest is skipped, because master public key is not used
+    // in protocol version 4.0 for encryption due to use of temporary keys.
+
+    @Test
+    void activationStatusTest() throws Exception {
+        PowerAuthActivationShared.activationStatusTest(powerAuthClient, config, model, VERSION);
+    }
+
+    @Test
+    void activationInvalidApplicationKeyTest() throws Exception {
+        PowerAuthActivationShared.activationInvalidApplicationKeyTest(powerAuthClient, config, model, VERSION);
+    }
+
+    @Test
+    void activationInvalidApplicationSecretTest() throws Exception {
+        PowerAuthActivationShared.activationInvalidApplicationSecretTest(powerAuthClient, config, model, VERSION);
+    }
+
+    @Test
+    void lookupActivationsTest() throws Exception {
+        PowerAuthActivationShared.lookupActivationsTest(powerAuthClient, config, VERSION);
+    }
+
+    @Test
+    void lookupActivationsNonExistentUserTest() throws Exception {
+        PowerAuthActivationShared.lookupActivationsNonExistentUserTest(powerAuthClient);
+    }
+
+    @Test
+    void lookupActivationsApplicationTest() throws Exception {
+        PowerAuthActivationShared.lookupActivationsApplicationTest(powerAuthClient, config, VERSION);
+    }
+
+    @Test
+    void lookupActivationsNonExistentApplicationTest() throws Exception {
+        PowerAuthActivationShared.lookupActivationsNonExistentApplicationTest(powerAuthClient, config, VERSION);
+    }
+
+    @Test
+    void lookupActivationsStatusTest() throws Exception {
+        PowerAuthActivationShared.lookupActivationsStatusTest(powerAuthClient, config, VERSION);
+    }
+
+    @Test
+    void lookupActivationsInvalidStatusTest() throws Exception {
+        PowerAuthActivationShared.lookupActivationsInvalidStatusTest(powerAuthClient, config, VERSION);
+    }
+
+    @Test
+    void lookupActivationsDateValidTest() throws Exception {
+        PowerAuthActivationShared.lookupActivationsDateValidTest(powerAuthClient, config, VERSION);
+    }
+
+    @Test
+    void lookupActivationsDateInvalidTest() throws Exception {
+        PowerAuthActivationShared.lookupActivationsDateInvalidTest(powerAuthClient, config, VERSION);
+    }
+
+    @Test
+    void updateActivationStatusTest() throws Exception {
+        PowerAuthActivationShared.updateActivationStatusTest(powerAuthClient, config, model, VERSION);
+    }
+
+}

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthActivationTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthActivationTest.java
@@ -18,12 +18,12 @@
 package com.wultra.security.powerauth.test.v40;
 
 import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
-import com.wultra.security.powerauth.client.v3.PowerAuthClient;
+import com.wultra.security.powerauth.client.v4.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
 import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.steps.model.PrepareActivationStepModel;
-import com.wultra.security.powerauth.test.shared.PowerAuthActivationShared;
+import com.wultra.security.powerauth.test.shared.v4.PowerAuthActivationShared;
 import org.json.simple.JSONObject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthAuthenticationTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthAuthenticationTest.java
@@ -156,7 +156,7 @@ class PowerAuthAuthenticationTest {
 
     @Test
     void authValidGetNoParamTest() throws Exception {
-        PowerAuthAuthenticationShared.authValidGetNoParamTest(config, model, stepLogger);
+        PowerAuthAuthenticationShared.authValidGetNoParamTest(model, stepLogger);
     }
 
     @Test

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthAuthenticationTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthAuthenticationTest.java
@@ -74,9 +74,9 @@ class PowerAuthAuthenticationTest {
 
     @BeforeAll
     static void setUpBeforeClass() throws IOException {
-        dataFile = File.createTempFile("data", ".json");
+        dataFile = File.createTempFile("data", ".txt");
         FileWriter fw = new FileWriter(dataFile);
-        fw.write("All your base are belong to us!");
+        fw.write("Confidential test message used for testing");
         fw.close();
     }
 

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthAuthenticationTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthAuthenticationTest.java
@@ -105,87 +105,97 @@ class PowerAuthAuthenticationTest {
     }
 
     @Test
-    void signatureValidTest() throws Exception {
+    void authValidTest() throws Exception {
         PowerAuthAuthenticationShared.authValidTest(model, stepLogger);
     }
 
     @Test
-    void signatureInvalidPasswordTest() throws Exception {
+    void authInvalidPasswordTest() throws Exception {
         PowerAuthAuthenticationShared.authInvalidPasswordTest(config, model, stepLogger);
     }
 
     @Test
-    void signatureIncorrectPasswordFormatTest() throws Exception {
+    void authIncorrectPasswordFormatTest() throws Exception {
         PowerAuthAuthenticationShared.authIncorrectPasswordFormatTest(config, model, stepLogger);
     }
 
     @Test
-    void signatureCounterLookAheadTest() throws Exception {
+    void authCounterLookAheadTest() throws Exception {
         PowerAuthAuthenticationShared.authCounterLookAheadTest(config, model);
     }
 
     @Test
-    void signatureBlockedActivationTest() throws Exception {
+    void authBlockedActivationTest() throws Exception {
         PowerAuthAuthenticationShared.authBlockedActivationTest(powerAuthClient, config, model, VERSION);
     }
 
     @Test
-    void signatureSingleFactorTest() throws Exception {
+    void authSingleFactorTest() throws Exception {
         PowerAuthAuthenticationShared.authSingleFactorTest(model, stepLogger);
     }
 
     @Test
-    void signatureEmptyDataTest() throws Exception {
+    void authBiometryTest() throws Exception {
+        PowerAuthAuthenticationShared.authBiometryTest(model, stepLogger);
+    }
+
+    @Test
+    void authThreeFactorTest() throws Exception {
+        PowerAuthAuthenticationShared.authThreeFactorTest(model, stepLogger);
+    }
+
+    @Test
+    void authEmptyDataTest() throws Exception {
         PowerAuthAuthenticationShared.authEmptyDataTest(model, stepLogger, VERSION);
     }
 
     @Test
-    void signatureValidGetTest() throws Exception {
+    void authValidGetTest() throws Exception {
         PowerAuthAuthenticationShared.authValidGetTest(config, model, stepLogger);
     }
 
     @Test
-    void signatureValidGetNoParamTest() throws Exception {
+    void authValidGetNoParamTest() throws Exception {
         PowerAuthAuthenticationShared.authValidGetNoParamTest(config, model, stepLogger);
     }
 
     @Test
-    void signatureGetInvalidPasswordTest() throws Exception {
+    void authGetInvalidPasswordTest() throws Exception {
         PowerAuthAuthenticationShared.authGetInvalidPasswordTest(config, model, stepLogger);
     }
 
     @Test
-    void signatureUnsupportedApplicationTest() throws Exception {
+    void authUnsupportedApplicationTest() throws Exception {
         PowerAuthAuthenticationShared.authUnsupportedApplicationTest(powerAuthClient, config, model);
     }
 
     @Test
-    void signatureMaxFailedAttemptsTest() throws Exception {
+    void authMaxFailedAttemptsTest() throws Exception {
         PowerAuthAuthenticationShared.authMaxFailedAttemptsTest(powerAuthClient, config, model, VERSION);
     }
 
     @Test
-    void signatureLookAheadTest() throws Exception {
+    void authLookAheadTest() throws Exception {
         PowerAuthAuthenticationShared.authLookAheadTest(powerAuthClient, config, model, VERSION);
     }
 
     @Test
-    void signatureCounterIncrementTest() throws Exception {
+    void authCounterIncrementTest() throws Exception {
         PowerAuthAuthenticationShared.authCounterIncrementTest(model, stepLogger, VERSION);
     }
 
     @Test
-    void signatureLargeDataTest() throws Exception {
+    void authLargeDataTest() throws Exception {
         PowerAuthAuthenticationShared.authLargeDataTest(model, stepLogger, VERSION);
     }
 
     @Test
-    void signatureSwappedKeyTest() throws Exception {
+    void authSwappedKeyTest() throws Exception {
         PowerAuthAuthenticationShared.authSwappedKeyTest(config, model, stepLogger);
     }
 
     @Test
-    void signatureInvalidResourceIdTest() throws Exception {
+    void authInvalidResourceIdTest() throws Exception {
         PowerAuthAuthenticationShared.authInvalidResourceIdTest(config, model, stepLogger);
     }
 

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthAuthenticationTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthAuthenticationTest.java
@@ -17,13 +17,13 @@
  */
 package com.wultra.security.powerauth.test.v40;
 
-import com.wultra.security.powerauth.client.v3.PowerAuthClient;
+import com.wultra.security.powerauth.client.v4.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
 import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
 import com.wultra.security.powerauth.lib.cmd.steps.model.VerifyAuthenticationStepModel;
-import com.wultra.security.powerauth.test.shared.PowerAuthSignatureShared;
+import com.wultra.security.powerauth.test.shared.v4.PowerAuthAuthenticationShared;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,7 +51,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = PowerAuthTestConfiguration.class)
 @EnableConfigurationProperties
-class PowerAuthSignatureTest {
+class PowerAuthAuthenticationTest {
 
     private static final PowerAuthVersion VERSION = PowerAuthVersion.V4_0;
 
@@ -106,87 +106,87 @@ class PowerAuthSignatureTest {
 
     @Test
     void signatureValidTest() throws Exception {
-        PowerAuthSignatureShared.signatureValidTest(model, stepLogger);
+        PowerAuthAuthenticationShared.authValidTest(model, stepLogger);
     }
 
     @Test
     void signatureInvalidPasswordTest() throws Exception {
-        PowerAuthSignatureShared.signatureInvalidPasswordTest(config, model, stepLogger);
+        PowerAuthAuthenticationShared.authInvalidPasswordTest(config, model, stepLogger);
     }
 
     @Test
     void signatureIncorrectPasswordFormatTest() throws Exception {
-        PowerAuthSignatureShared.signatureIncorrectPasswordFormatTest(config, model, stepLogger);
+        PowerAuthAuthenticationShared.authIncorrectPasswordFormatTest(config, model, stepLogger);
     }
 
     @Test
     void signatureCounterLookAheadTest() throws Exception {
-        PowerAuthSignatureShared.signatureCounterLookAheadTest(config, model);
+        PowerAuthAuthenticationShared.authCounterLookAheadTest(config, model);
     }
 
     @Test
     void signatureBlockedActivationTest() throws Exception {
-        PowerAuthSignatureShared.signatureBlockedActivationTest(powerAuthClient, config, model, VERSION);
+        PowerAuthAuthenticationShared.authBlockedActivationTest(powerAuthClient, config, model, VERSION);
     }
 
     @Test
     void signatureSingleFactorTest() throws Exception {
-        PowerAuthSignatureShared.signatureSingleFactorTest(model, stepLogger);
+        PowerAuthAuthenticationShared.authSingleFactorTest(model, stepLogger);
     }
 
     @Test
     void signatureEmptyDataTest() throws Exception {
-        PowerAuthSignatureShared.signatureEmptyDataTest(model, stepLogger, VERSION);
+        PowerAuthAuthenticationShared.authEmptyDataTest(model, stepLogger, VERSION);
     }
 
     @Test
     void signatureValidGetTest() throws Exception {
-        PowerAuthSignatureShared.signatureValidGetTest(config, model, stepLogger);
+        PowerAuthAuthenticationShared.authValidGetTest(config, model, stepLogger);
     }
 
     @Test
     void signatureValidGetNoParamTest() throws Exception {
-        PowerAuthSignatureShared.signatureValidGetNoParamTest(config, model, stepLogger);
+        PowerAuthAuthenticationShared.authValidGetNoParamTest(config, model, stepLogger);
     }
 
     @Test
     void signatureGetInvalidPasswordTest() throws Exception {
-        PowerAuthSignatureShared.signatureGetInvalidPasswordTest(config, model, stepLogger);
+        PowerAuthAuthenticationShared.authGetInvalidPasswordTest(config, model, stepLogger);
     }
 
     @Test
     void signatureUnsupportedApplicationTest() throws Exception {
-        PowerAuthSignatureShared.signatureUnsupportedApplicationTest(powerAuthClient, config, model);
+        PowerAuthAuthenticationShared.authUnsupportedApplicationTest(powerAuthClient, config, model);
     }
 
     @Test
     void signatureMaxFailedAttemptsTest() throws Exception {
-        PowerAuthSignatureShared.signatureMaxFailedAttemptsTest(powerAuthClient, config, model, VERSION);
+        PowerAuthAuthenticationShared.authMaxFailedAttemptsTest(powerAuthClient, config, model, VERSION);
     }
 
     @Test
     void signatureLookAheadTest() throws Exception {
-        PowerAuthSignatureShared.signatureLookAheadTest(powerAuthClient, config, model, VERSION);
+        PowerAuthAuthenticationShared.authLookAheadTest(powerAuthClient, config, model, VERSION);
     }
 
     @Test
     void signatureCounterIncrementTest() throws Exception {
-        PowerAuthSignatureShared.signatureCounterIncrementTest(model, stepLogger, VERSION);
+        PowerAuthAuthenticationShared.authCounterIncrementTest(model, stepLogger, VERSION);
     }
 
     @Test
     void signatureLargeDataTest() throws Exception {
-        PowerAuthSignatureShared.signatureLargeDataTest(model, stepLogger, VERSION);
+        PowerAuthAuthenticationShared.authLargeDataTest(model, stepLogger, VERSION);
     }
 
     @Test
     void signatureSwappedKeyTest() throws Exception {
-        PowerAuthSignatureShared.signatureSwappedKeyTest(config, model, stepLogger);
+        PowerAuthAuthenticationShared.authSwappedKeyTest(config, model, stepLogger);
     }
 
     @Test
     void signatureInvalidResourceIdTest() throws Exception {
-        PowerAuthSignatureShared.signatureInvalidResourceIdTest(config, model, stepLogger);
+        PowerAuthAuthenticationShared.authInvalidResourceIdTest(config, model, stepLogger);
     }
 
 }

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthCustomActivationOtpTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthCustomActivationOtpTest.java
@@ -81,9 +81,9 @@ class PowerAuthCustomActivationOtpTest {
 
     @BeforeAll
     static void setUpBeforeClass() throws IOException {
-        dataFile = File.createTempFile("data", ".json");
+        dataFile = File.createTempFile("data", ".txt");
         FileWriter fw = new FileWriter(dataFile);
-        fw.write("All your base are belong to us!");
+        fw.write("Confidential test message used for testing");
         fw.close();
     }
 

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthCustomActivationOtpTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthCustomActivationOtpTest.java
@@ -1,6 +1,6 @@
 /*
  * PowerAuth test and related software components
- * Copyright (C) 2018 Wultra s.r.o.
+ * Copyright (C) 2025 Wultra s.r.o.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthCustomActivationOtpTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthCustomActivationOtpTest.java
@@ -15,15 +15,16 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.wultra.security.powerauth.test.v31;
+package com.wultra.security.powerauth.test.v40;
 
-import com.wultra.security.powerauth.client.v3.PowerAuthClient;
+import com.wultra.security.powerauth.client.v4.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.v3.PowerAuthCustomActivationOtpShared;
+import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
 import com.wultra.security.powerauth.lib.cmd.steps.model.CreateActivationStepModel;
 import com.wultra.security.powerauth.lib.cmd.steps.model.GetStatusStepModel;
+import com.wultra.security.powerauth.test.shared.v4.PowerAuthCustomActivationOtpShared;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -51,7 +52,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @ComponentScan(basePackages = "com.wultra.security.powerauth")
 class PowerAuthCustomActivationOtpTest {
 
-    private static final PowerAuthVersion VERSION = PowerAuthVersion.V3_1;
+    private static final PowerAuthVersion VERSION = PowerAuthVersion.V4_0;
 
     private PowerAuthClient powerAuthClient;
     private PowerAuthTestConfiguration config;
@@ -102,11 +103,14 @@ class PowerAuthCustomActivationOtpTest {
         createModel.setApplicationKey(config.getApplicationKey());
         createModel.setApplicationSecret(config.getApplicationSecret());
         createModel.setMasterPublicKeyP256(config.getMasterPublicKeyP256());
+        createModel.setMasterPublicKeyP384(config.getMasterPublicKeyP384());
+        createModel.setMasterPublicKeyMlDsa65(config.getMasterPublicKeyMlDsa65());
         createModel.setHeaders(new HashMap<>());
         createModel.setPassword(config.getPassword());
         createModel.setStatusFileName(tempStatusFile.getAbsolutePath());
         createModel.setResultStatusObject(config.getResultStatusObject(VERSION));
         createModel.setUriString("http://localhost:" + port);
+        createModel.setSharedSecretAlgorithm(SharedSecretAlgorithm.EC_P384_ML_L3);
         createModel.setVersion(VERSION);
         createModel.setDeviceInfo("backend-tests");
 
@@ -114,6 +118,8 @@ class PowerAuthCustomActivationOtpTest {
         statusModel.setHeaders(new HashMap<>());
         statusModel.setResultStatusObject(config.getResultStatusObject(VERSION));
         statusModel.setUriString(config.getPowerAuthIntegrationUrl());
+        statusModel.setApplicationKey(config.getApplicationKey());
+        statusModel.setApplicationSecret(config.getApplicationSecret());
         statusModel.setVersion(VERSION);
 
         // Prepare step logger

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthCustomActivationOtpTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthCustomActivationOtpTest.java
@@ -102,7 +102,6 @@ class PowerAuthCustomActivationOtpTest {
         createModel.setActivationName("test v" + VERSION);
         createModel.setApplicationKey(config.getApplicationKey());
         createModel.setApplicationSecret(config.getApplicationSecret());
-        createModel.setMasterPublicKeyP256(config.getMasterPublicKeyP256());
         createModel.setMasterPublicKeyP384(config.getMasterPublicKeyP384());
         createModel.setMasterPublicKeyMlDsa65(config.getMasterPublicKeyMlDsa65());
         createModel.setHeaders(new HashMap<>());

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthCustomActivationTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthCustomActivationTest.java
@@ -96,7 +96,6 @@ class PowerAuthCustomActivationTest {
         model.setActivationName("test v" + VERSION);
         model.setApplicationKey(config.getApplicationKey());
         model.setApplicationSecret(config.getApplicationSecret());
-        model.setMasterPublicKeyP256(config.getMasterPublicKeyP256());
         model.setMasterPublicKeyP384(config.getMasterPublicKeyP384());
         model.setMasterPublicKeyMlDsa65(config.getMasterPublicKeyMlDsa65());
         model.setHeaders(new HashMap<>());

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthCustomActivationTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthCustomActivationTest.java
@@ -1,6 +1,6 @@
 /*
  * PowerAuth test and related software components
- * Copyright (C) 2018 Wultra s.r.o.
+ * Copyright (C) 2025 Wultra s.r.o.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
@@ -15,14 +15,15 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.wultra.security.powerauth.test.v32;
+package com.wultra.security.powerauth.test.v40;
 
-import com.wultra.security.powerauth.client.v3.PowerAuthClient;
+import com.wultra.security.powerauth.client.v4.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.v3.PowerAuthCustomActivationShared;
+import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
 import com.wultra.security.powerauth.lib.cmd.steps.model.CreateActivationStepModel;
+import com.wultra.security.powerauth.test.shared.v4.PowerAuthCustomActivationShared;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -50,7 +51,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @ComponentScan(basePackages = "com.wultra.security.powerauth")
 class PowerAuthCustomActivationTest {
 
-    private static final PowerAuthVersion VERSION = PowerAuthVersion.V3_2;
+    private static final PowerAuthVersion VERSION = PowerAuthVersion.V4_0;
 
     private PowerAuthClient powerAuthClient;
     private PowerAuthTestConfiguration config;
@@ -96,11 +97,14 @@ class PowerAuthCustomActivationTest {
         model.setApplicationKey(config.getApplicationKey());
         model.setApplicationSecret(config.getApplicationSecret());
         model.setMasterPublicKeyP256(config.getMasterPublicKeyP256());
+        model.setMasterPublicKeyP384(config.getMasterPublicKeyP384());
+        model.setMasterPublicKeyMlDsa65(config.getMasterPublicKeyMlDsa65());
         model.setHeaders(new HashMap<>());
         model.setPassword(config.getPassword());
         model.setStatusFileName(tempStatusFile.getAbsolutePath());
         model.setResultStatusObject(config.getResultStatusObject(VERSION));
         model.setUriString("http://localhost:" + port);
+        model.setSharedSecretAlgorithm(SharedSecretAlgorithm.EC_P384_ML_L3);
         model.setVersion(VERSION);
         model.setDeviceInfo("backend-tests");
 

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthCustomActivationTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthCustomActivationTest.java
@@ -75,9 +75,9 @@ class PowerAuthCustomActivationTest {
 
     @BeforeAll
     static void setUpBeforeClass() throws IOException {
-        dataFile = File.createTempFile("data", ".json");
+        dataFile = File.createTempFile("data", ".txt");
         FileWriter fw = new FileWriter(dataFile);
-        fw.write("All your base are belong to us!");
+        fw.write("Confidential test message used for testing");
         fw.close();
     }
 

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthDynamicFactorTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthDynamicFactorTest.java
@@ -22,6 +22,8 @@ import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
 import com.wultra.security.powerauth.lib.cmd.steps.model.ChangePasswordStepModel;
+import com.wultra.security.powerauth.lib.cmd.steps.model.RemoveBiometryStepModel;
+import com.wultra.security.powerauth.lib.cmd.steps.model.SetupBiometryStepModel;
 import com.wultra.security.powerauth.lib.cmd.steps.model.VerifyAuthenticationStepModel;
 import com.wultra.security.powerauth.test.shared.v4.PowerAuthAuthenticationShared;
 import com.wultra.security.powerauth.test.shared.v4.PowerAuthDynamicFactorShared;
@@ -42,6 +44,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.HashMap;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -58,9 +61,8 @@ class PowerAuthDynamicFactorTest {
 
     private PowerAuthTestConfiguration config;
     private static File dataFile;
-    private ChangePasswordStepModel changePasswordModel;
-    private VerifyAuthenticationStepModel verifyAuthenticationModel;
     private ObjectStepLogger stepLogger;
+    private VerifyAuthenticationStepModel verifyAuthenticationModel;
 
     @Autowired
     public void setPowerAuthTestConfiguration(PowerAuthTestConfiguration config) {
@@ -82,16 +84,6 @@ class PowerAuthDynamicFactorTest {
 
     @BeforeEach
     void setUp() throws IOException {
-        changePasswordModel = new ChangePasswordStepModel();
-        changePasswordModel.setApplicationKey(config.getApplicationKey());
-        changePasswordModel.setApplicationSecret(config.getApplicationSecret());
-        changePasswordModel.setHeaders(new HashMap<>());
-        changePasswordModel.setResultStatusObject(config.getResultStatusObject(VERSION));
-        changePasswordModel.setAuthenticationCodeType(PowerAuthCodeType.POSSESSION_KNOWLEDGE);
-        changePasswordModel.setStatusFileName(config.getStatusFile(VERSION).getAbsolutePath());
-        changePasswordModel.setUriString(config.getPowerAuthIntegrationUrl());
-        changePasswordModel.setVersion(VERSION);
-
         verifyAuthenticationModel = new VerifyAuthenticationStepModel();
         verifyAuthenticationModel.setApplicationKey(config.getApplicationKey());
         verifyAuthenticationModel.setApplicationSecret(config.getApplicationSecret());
@@ -99,6 +91,7 @@ class PowerAuthDynamicFactorTest {
         verifyAuthenticationModel.setHeaders(new HashMap<>());
         verifyAuthenticationModel.setHttpMethod("POST");
         verifyAuthenticationModel.setResourceId("/pa/auth/validate");
+        verifyAuthenticationModel.setPassword(config.getPassword());
         verifyAuthenticationModel.setResultStatusObject(config.getResultStatusObject(VERSION));
         verifyAuthenticationModel.setAuthenticationCodeType(PowerAuthCodeType.POSSESSION_KNOWLEDGE);
         verifyAuthenticationModel.setStatusFileName(config.getStatusFile(VERSION).getAbsolutePath());
@@ -108,6 +101,18 @@ class PowerAuthDynamicFactorTest {
 
     @Test
     void passwordChangeTest() throws Exception {
+        final ChangePasswordStepModel changePasswordModel = new ChangePasswordStepModel();
+        changePasswordModel.setApplicationKey(config.getApplicationKey());
+        changePasswordModel.setApplicationSecret(config.getApplicationSecret());
+        changePasswordModel.setHeaders(new HashMap<>());
+        changePasswordModel.setResultStatusObject(config.getResultStatusObject(VERSION));
+        changePasswordModel.setAuthenticationCodeType(PowerAuthCodeType.POSSESSION_KNOWLEDGE);
+        changePasswordModel.setStatusFileName(config.getStatusFile(VERSION).getAbsolutePath());
+        changePasswordModel.setUriString(config.getPowerAuthIntegrationUrl());
+        changePasswordModel.setVersion(VERSION);
+
+
+
         stepLogger = new ObjectStepLogger(System.out);
         changePasswordModel.setPassword(config.getPassword());
         changePasswordModel.setPasswordNew("3820");
@@ -125,6 +130,46 @@ class PowerAuthDynamicFactorTest {
         stepLogger = new ObjectStepLogger(System.out);
         verifyAuthenticationModel.setPassword(config.getPassword());
         PowerAuthAuthenticationShared.authValidTest(verifyAuthenticationModel, stepLogger);
+    }
+
+    @Test
+    void biometryLifecycleTest() throws Exception {
+        final SetupBiometryStepModel addBiometryModel = new SetupBiometryStepModel();
+        addBiometryModel.setApplicationKey(config.getApplicationKey());
+        addBiometryModel.setApplicationSecret(config.getApplicationSecret());
+        addBiometryModel.setHeaders(new HashMap<>());
+        addBiometryModel.setPassword(config.getPassword());
+        addBiometryModel.setResultStatusObject(config.getResultStatusObject(VERSION));
+        addBiometryModel.setAuthenticationCodeType(PowerAuthCodeType.POSSESSION_KNOWLEDGE);
+        addBiometryModel.setStatusFileName(config.getStatusFile(VERSION).getAbsolutePath());
+        addBiometryModel.setUriString(config.getPowerAuthIntegrationUrl());
+        addBiometryModel.setVersion(VERSION);
+
+        stepLogger = new ObjectStepLogger(System.out);
+        PowerAuthDynamicFactorShared.addBiometryTest(addBiometryModel, stepLogger);
+
+        stepLogger = new ObjectStepLogger(System.out);
+        PowerAuthAuthenticationShared.authBiometryTest(verifyAuthenticationModel, stepLogger);
+
+        final RemoveBiometryStepModel removeBiometryModel = new RemoveBiometryStepModel();
+        removeBiometryModel.setApplicationKey(config.getApplicationKey());
+        removeBiometryModel.setApplicationSecret(config.getApplicationSecret());
+        removeBiometryModel.setHeaders(new HashMap<>());
+        removeBiometryModel.setResultStatusObject(config.getResultStatusObject(VERSION));
+        removeBiometryModel.setAuthenticationCodeType(PowerAuthCodeType.POSSESSION);
+        removeBiometryModel.setStatusFileName(config.getStatusFile(VERSION).getAbsolutePath());
+        removeBiometryModel.setUriString(config.getPowerAuthIntegrationUrl());
+        removeBiometryModel.setVersion(VERSION);
+
+        stepLogger = new ObjectStepLogger(System.out);
+        PowerAuthDynamicFactorShared.removeBiometryTest(removeBiometryModel, stepLogger);
+
+        stepLogger = new ObjectStepLogger(System.out);
+        assertThrows(IllegalStateException.class, () -> PowerAuthAuthenticationShared.authBiometryNoResponseCheckTest(verifyAuthenticationModel, stepLogger));
+
+        // Read the biometry factor for other tests
+        stepLogger = new ObjectStepLogger(System.out);
+        PowerAuthDynamicFactorShared.addBiometryTest(addBiometryModel, stepLogger);
     }
 
 }

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthDynamicFactorTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthDynamicFactorTest.java
@@ -1,0 +1,130 @@
+/*
+ * PowerAuth test and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.security.powerauth.test.v40;
+
+import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
+import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;
+import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
+import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
+import com.wultra.security.powerauth.lib.cmd.steps.model.ChangePasswordStepModel;
+import com.wultra.security.powerauth.lib.cmd.steps.model.VerifyAuthenticationStepModel;
+import com.wultra.security.powerauth.test.shared.v4.PowerAuthAuthenticationShared;
+import com.wultra.security.powerauth.test.shared.v4.PowerAuthDynamicFactorShared;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * PowerAuth dynamic factor tests.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = PowerAuthTestConfiguration.class)
+@EnableConfigurationProperties
+class PowerAuthDynamicFactorTest {
+
+    private static final PowerAuthVersion VERSION = PowerAuthVersion.V4_0;
+
+    private PowerAuthTestConfiguration config;
+    private static File dataFile;
+    private ChangePasswordStepModel changePasswordModel;
+    private VerifyAuthenticationStepModel verifyAuthenticationModel;
+    private ObjectStepLogger stepLogger;
+
+    @Autowired
+    public void setPowerAuthTestConfiguration(PowerAuthTestConfiguration config) {
+        this.config = config;
+    }
+
+    @BeforeAll
+    static void setUpBeforeClass() throws IOException {
+        dataFile = File.createTempFile("data", ".txt");
+        FileWriter fw = new FileWriter(dataFile);
+        fw.write("Confidential test message used for testing");
+        fw.close();
+    }
+
+    @AfterAll
+    static void tearDownAfterClass() {
+        assertTrue(dataFile.delete());
+    }
+
+    @BeforeEach
+    void setUp() throws IOException {
+        changePasswordModel = new ChangePasswordStepModel();
+        changePasswordModel.setApplicationKey(config.getApplicationKey());
+        changePasswordModel.setApplicationSecret(config.getApplicationSecret());
+        changePasswordModel.setHeaders(new HashMap<>());
+        changePasswordModel.setResultStatusObject(config.getResultStatusObject(VERSION));
+        changePasswordModel.setAuthenticationCodeType(PowerAuthCodeType.POSSESSION_KNOWLEDGE);
+        changePasswordModel.setStatusFileName(config.getStatusFile(VERSION).getAbsolutePath());
+        changePasswordModel.setUriString(config.getPowerAuthIntegrationUrl());
+        changePasswordModel.setVersion(VERSION);
+
+        verifyAuthenticationModel = new VerifyAuthenticationStepModel();
+        verifyAuthenticationModel.setApplicationKey(config.getApplicationKey());
+        verifyAuthenticationModel.setApplicationSecret(config.getApplicationSecret());
+        verifyAuthenticationModel.setData(Files.readAllBytes(Paths.get(dataFile.getAbsolutePath())));
+        verifyAuthenticationModel.setHeaders(new HashMap<>());
+        verifyAuthenticationModel.setHttpMethod("POST");
+        verifyAuthenticationModel.setResourceId("/pa/auth/validate");
+        verifyAuthenticationModel.setResultStatusObject(config.getResultStatusObject(VERSION));
+        verifyAuthenticationModel.setAuthenticationCodeType(PowerAuthCodeType.POSSESSION_KNOWLEDGE);
+        verifyAuthenticationModel.setStatusFileName(config.getStatusFile(VERSION).getAbsolutePath());
+        verifyAuthenticationModel.setUriString(config.getPowerAuthIntegrationUrl() + "/pa/v4/auth/validate");
+        verifyAuthenticationModel.setVersion(VERSION);
+    }
+
+    @Test
+    void passwordChangeTest() throws Exception {
+        stepLogger = new ObjectStepLogger(System.out);
+        changePasswordModel.setPassword(config.getPassword());
+        changePasswordModel.setPasswordNew("3820");
+        PowerAuthDynamicFactorShared.passwordChangeTest(changePasswordModel, stepLogger);
+
+        stepLogger = new ObjectStepLogger(System.out);
+        verifyAuthenticationModel.setPassword("3820");
+        PowerAuthAuthenticationShared.authValidTest(verifyAuthenticationModel, stepLogger);
+
+        stepLogger = new ObjectStepLogger(System.out);
+        changePasswordModel.setPassword("3820");
+        changePasswordModel.setPasswordNew(config.getPassword());
+        PowerAuthDynamicFactorShared.passwordChangeTest(changePasswordModel, stepLogger);
+
+        stepLogger = new ObjectStepLogger(System.out);
+        verifyAuthenticationModel.setPassword(config.getPassword());
+        PowerAuthAuthenticationShared.authValidTest(verifyAuthenticationModel, stepLogger);
+    }
+
+}

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthEncryptionTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthEncryptionTest.java
@@ -220,6 +220,16 @@ class PowerAuthEncryptionTest {
     }
 
     @Test
+    void signAndEncryptBiometryTest() throws Exception {
+        PowerAuthEncryptionShared.signAndEncryptBiometryTest(config, signatureModel, stepLogger);
+    }
+
+    @Test
+    void signAndEncryptThreeFactorTest() throws Exception {
+        PowerAuthEncryptionShared.signAndEncryptThreeFactorTest(config, signatureModel, stepLogger);
+    }
+
+    @Test
     void encryptedResponseTest() throws Exception {
         PowerAuthEncryptionShared.encryptedResponseTest(config, encryptModel, stepLogger, VERSION);
     }

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthEncryptionTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthEncryptionTest.java
@@ -1,6 +1,6 @@
 /*
  * PowerAuth test and related software components
- * Copyright (C) 2018 Wultra s.r.o.
+ * Copyright (C) 2025 Wultra s.r.o.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
@@ -15,16 +15,16 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.wultra.security.powerauth.test.v32;
+package com.wultra.security.powerauth.test.v40;
 
-import com.wultra.security.powerauth.client.v3.PowerAuthClient;
+import com.wultra.security.powerauth.client.v4.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.v3.PowerAuthEncryptionShared;
 import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
 import com.wultra.security.powerauth.lib.cmd.steps.model.EncryptStepModel;
 import com.wultra.security.powerauth.lib.cmd.steps.model.VerifyAuthenticationStepModel;
+import com.wultra.security.powerauth.test.shared.v4.PowerAuthEncryptionShared;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -56,7 +56,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @EnabledIf(expression = "${powerauth.test.includeCustomTests}", loadContext = true)
 class PowerAuthEncryptionTest {
 
-    private static final PowerAuthVersion VERSION = PowerAuthVersion.V3_2;
+    private static final PowerAuthVersion VERSION = PowerAuthVersion.V4_0;
 
     private PowerAuthTestConfiguration config;
     private static File dataFile;
@@ -95,6 +95,8 @@ class PowerAuthEncryptionTest {
         encryptModel.setApplicationSecret(config.getApplicationSecret());
         encryptModel.setData(Files.readAllBytes(Paths.get(dataFile.getAbsolutePath())));
         encryptModel.setMasterPublicKeyP256(config.getMasterPublicKeyP256());
+        encryptModel.setMasterPublicKeyP384(config.getMasterPublicKeyP384());
+        encryptModel.setMasterPublicKeyMlDsa65(config.getMasterPublicKeyMlDsa65());
         encryptModel.setHeaders(new HashMap<>());
         encryptModel.setResultStatusObject(config.getResultStatusObject(VERSION));
         encryptModel.setBaseUriString(config.getPowerAuthIntegrationUrl());
@@ -110,7 +112,7 @@ class PowerAuthEncryptionTest {
         signatureModel.setResultStatusObject(config.getResultStatusObject(VERSION));
         signatureModel.setAuthenticationCodeType(PowerAuthCodeType.POSSESSION_KNOWLEDGE);
         signatureModel.setStatusFileName(config.getStatusFile(VERSION).getAbsolutePath());
-        signatureModel.setUriString(config.getPowerAuthIntegrationUrl() + "/pa/v3/signature/validate");
+        signatureModel.setUriString(config.getPowerAuthIntegrationUrl() + "/pa/v3/auth/validate");
         signatureModel.setBaseUriString(config.getPowerAuthIntegrationUrl());
         signatureModel.setVersion(VERSION);
 
@@ -215,21 +217,6 @@ class PowerAuthEncryptionTest {
     @Test
     void signAndEncryptSingleFactorTest() throws Exception {
         PowerAuthEncryptionShared.signAndEncryptSingleFactorTest(config, signatureModel, stepLogger);
-    }
-
-    @Test
-    void signAndEncryptBiometryTest() throws Exception {
-        PowerAuthEncryptionShared.signAndEncryptBiometryTest(config, signatureModel, stepLogger);
-    }
-
-    @Test
-    void signAndEncryptThreeFactorTest() throws Exception {
-        PowerAuthEncryptionShared.signAndEncryptThreeFactorTest(config, signatureModel, stepLogger);
-    }
-
-    @Test
-    void replayAttackEciesDecryptorTest() throws Exception {
-        PowerAuthEncryptionShared.replayAttackEciesDecryptorTest(powerAuthClient, config, VERSION);
     }
 
     @Test

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthEncryptionTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthEncryptionTest.java
@@ -94,7 +94,6 @@ class PowerAuthEncryptionTest {
         encryptModel.setApplicationKey(config.getApplicationKey());
         encryptModel.setApplicationSecret(config.getApplicationSecret());
         encryptModel.setData(Files.readAllBytes(Paths.get(dataFile.getAbsolutePath())));
-        encryptModel.setMasterPublicKeyP256(config.getMasterPublicKeyP256());
         encryptModel.setMasterPublicKeyP384(config.getMasterPublicKeyP384());
         encryptModel.setMasterPublicKeyMlDsa65(config.getMasterPublicKeyMlDsa65());
         encryptModel.setHeaders(new HashMap<>());

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthSignatureTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthSignatureTest.java
@@ -1,0 +1,192 @@
+/*
+ * PowerAuth test and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.security.powerauth.test.v40;
+
+import com.wultra.security.powerauth.client.v3.PowerAuthClient;
+import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
+import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;
+import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
+import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
+import com.wultra.security.powerauth.lib.cmd.steps.model.VerifyAuthenticationStepModel;
+import com.wultra.security.powerauth.test.shared.PowerAuthSignatureShared;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * PowerAuth signature tests.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = PowerAuthTestConfiguration.class)
+@EnableConfigurationProperties
+class PowerAuthSignatureTest {
+
+    private static final PowerAuthVersion VERSION = PowerAuthVersion.V4_0;
+
+    private PowerAuthTestConfiguration config;
+    private static File dataFile;
+    private VerifyAuthenticationStepModel model;
+    private ObjectStepLogger stepLogger;
+
+    private PowerAuthClient powerAuthClient;
+
+    @Autowired
+    public void setPowerAuthTestConfiguration(PowerAuthTestConfiguration config) {
+        this.config = config;
+    }
+
+    @Autowired
+    public void setPowerAuthClient(PowerAuthClient powerAuthClient) {
+        this.powerAuthClient = powerAuthClient;
+    }
+
+    @BeforeAll
+    static void setUpBeforeClass() throws IOException {
+        dataFile = File.createTempFile("data", ".json");
+        FileWriter fw = new FileWriter(dataFile);
+        fw.write("All your base are belong to us!");
+        fw.close();
+    }
+
+    @AfterAll
+    static void tearDownAfterClass() {
+        assertTrue(dataFile.delete());
+    }
+
+    @BeforeEach
+    void setUp() throws IOException {
+        model = new VerifyAuthenticationStepModel();
+        model.setApplicationKey(config.getApplicationKey());
+        model.setApplicationSecret(config.getApplicationSecret());
+        model.setData(Files.readAllBytes(Paths.get(dataFile.getAbsolutePath())));
+        model.setHeaders(new HashMap<>());
+        model.setHttpMethod("POST");
+        model.setPassword(config.getPassword());
+        model.setResourceId("/pa/auth/validate");
+        model.setResultStatusObject(config.getResultStatusObject(VERSION));
+        model.setAuthenticationCodeType(PowerAuthCodeType.POSSESSION_KNOWLEDGE);
+        model.setStatusFileName(config.getStatusFile(VERSION).getAbsolutePath());
+        model.setUriString(config.getPowerAuthIntegrationUrl() + "/pa/v4/auth/validate");
+        model.setVersion(VERSION);
+
+        stepLogger = new ObjectStepLogger(System.out);
+    }
+
+    @Test
+    void signatureValidTest() throws Exception {
+        PowerAuthSignatureShared.signatureValidTest(model, stepLogger);
+    }
+
+    @Test
+    void signatureInvalidPasswordTest() throws Exception {
+        PowerAuthSignatureShared.signatureInvalidPasswordTest(config, model, stepLogger);
+    }
+
+    @Test
+    void signatureIncorrectPasswordFormatTest() throws Exception {
+        PowerAuthSignatureShared.signatureIncorrectPasswordFormatTest(config, model, stepLogger);
+    }
+
+    @Test
+    void signatureCounterLookAheadTest() throws Exception {
+        PowerAuthSignatureShared.signatureCounterLookAheadTest(config, model);
+    }
+
+    @Test
+    void signatureBlockedActivationTest() throws Exception {
+        PowerAuthSignatureShared.signatureBlockedActivationTest(powerAuthClient, config, model, VERSION);
+    }
+
+    @Test
+    void signatureSingleFactorTest() throws Exception {
+        PowerAuthSignatureShared.signatureSingleFactorTest(model, stepLogger);
+    }
+
+    @Test
+    void signatureEmptyDataTest() throws Exception {
+        PowerAuthSignatureShared.signatureEmptyDataTest(model, stepLogger, VERSION);
+    }
+
+    @Test
+    void signatureValidGetTest() throws Exception {
+        PowerAuthSignatureShared.signatureValidGetTest(config, model, stepLogger);
+    }
+
+    @Test
+    void signatureValidGetNoParamTest() throws Exception {
+        PowerAuthSignatureShared.signatureValidGetNoParamTest(config, model, stepLogger);
+    }
+
+    @Test
+    void signatureGetInvalidPasswordTest() throws Exception {
+        PowerAuthSignatureShared.signatureGetInvalidPasswordTest(config, model, stepLogger);
+    }
+
+    @Test
+    void signatureUnsupportedApplicationTest() throws Exception {
+        PowerAuthSignatureShared.signatureUnsupportedApplicationTest(powerAuthClient, config, model);
+    }
+
+    @Test
+    void signatureMaxFailedAttemptsTest() throws Exception {
+        PowerAuthSignatureShared.signatureMaxFailedAttemptsTest(powerAuthClient, config, model, VERSION);
+    }
+
+    @Test
+    void signatureLookAheadTest() throws Exception {
+        PowerAuthSignatureShared.signatureLookAheadTest(powerAuthClient, config, model, VERSION);
+    }
+
+    @Test
+    void signatureCounterIncrementTest() throws Exception {
+        PowerAuthSignatureShared.signatureCounterIncrementTest(model, stepLogger, VERSION);
+    }
+
+    @Test
+    void signatureLargeDataTest() throws Exception {
+        PowerAuthSignatureShared.signatureLargeDataTest(model, stepLogger, VERSION);
+    }
+
+    @Test
+    void signatureSwappedKeyTest() throws Exception {
+        PowerAuthSignatureShared.signatureSwappedKeyTest(config, model, stepLogger);
+    }
+
+    @Test
+    void signatureInvalidResourceIdTest() throws Exception {
+        PowerAuthSignatureShared.signatureInvalidResourceIdTest(config, model, stepLogger);
+    }
+
+}

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthTokenTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthTokenTest.java
@@ -23,7 +23,7 @@ import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
 import com.wultra.security.powerauth.lib.cmd.steps.model.CreateTokenStepModel;
-import com.wultra.security.powerauth.test.shared.PowerAuthTokenShared;
+import com.wultra.security.powerauth.test.shared.v4.PowerAuthTokenShared;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthTokenTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthTokenTest.java
@@ -72,9 +72,9 @@ class PowerAuthTokenTest {
 
     @BeforeAll
     static void setUpBeforeClass() throws IOException {
-        dataFile = File.createTempFile("data", ".json");
+        dataFile = File.createTempFile("data", ".txt");
         FileWriter fw = new FileWriter(dataFile);
-        fw.write("All your base are belong to us!");
+        fw.write("Confidential test message used for testing");
         fw.close();
     }
 

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthTokenTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthTokenTest.java
@@ -1,6 +1,6 @@
 /*
  * PowerAuth test and related software components
- * Copyright (C) 2019 Wultra s.r.o.
+ * Copyright (C) 2025 Wultra s.r.o.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
@@ -15,15 +15,15 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.wultra.security.powerauth.test.v31;
+package com.wultra.security.powerauth.test.v40;
 
 import com.wultra.security.powerauth.client.v4.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.PowerAuthTokenShared;
 import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
 import com.wultra.security.powerauth.lib.cmd.steps.model.CreateTokenStepModel;
+import com.wultra.security.powerauth.test.shared.PowerAuthTokenShared;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,7 +51,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @EnableConfigurationProperties
 class PowerAuthTokenTest {
 
-    private static final PowerAuthVersion VERSION = PowerAuthVersion.V3_1;
+    private static final PowerAuthVersion VERSION = PowerAuthVersion.V4_0;
 
     private PowerAuthTestConfiguration config;
     private PowerAuthClient powerAuthClient;

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthVaultUnlockTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthVaultUnlockTest.java
@@ -85,6 +85,22 @@ class PowerAuthVaultUnlockTest {
     }
 
     @Test
+    void vaultUnlockKdkAppVault2faTest() throws Exception {
+        VaultUnlockStepModel modelAppVault2fa = new VaultUnlockStepModel();
+        modelAppVault2fa.fromMap(model.toMap());
+        modelAppVault2fa.setKeyIdentifier("KDK_APP_VAULT_2FA");
+        PowerAuthVaultUnlockShared.vaultUnlockTest(modelAppVault2fa, stepLogger);
+    }
+
+    @Test
+    void vaultUnlockKdkAppVaultKnowledgeTest() throws Exception {
+        VaultUnlockStepModel modelAppVaultKnowledge = new VaultUnlockStepModel();
+        modelAppVaultKnowledge.fromMap(model.toMap());
+        modelAppVaultKnowledge.setKeyIdentifier("KDK_APP_VAULT_KNOWLEDGE");
+        PowerAuthVaultUnlockShared.vaultUnlockTest(modelAppVaultKnowledge, stepLogger);
+    }
+
+    @Test
     void vaultUnlockInvalidPasswordTest() throws Exception {
         PowerAuthVaultUnlockShared.vaultUnlockInvalidPasswordTest(config, model, stepLogger);
     }
@@ -95,8 +111,24 @@ class PowerAuthVaultUnlockTest {
     }
 
     @Test
-    void vaultUnlockBiometryFactorTest() throws Exception {
+    void vaultUnlockKekDevicePrivateBiometryFactorTest() throws Exception {
         PowerAuthVaultUnlockShared.vaultUnlockBiometryFactorTest(model, stepLogger);
+    }
+
+    @Test
+    void vaultUnlockKdkAppVault2faBiometryFactorTest() throws Exception {
+        VaultUnlockStepModel modelAppVault2fa = new VaultUnlockStepModel();
+        modelAppVault2fa.fromMap(model.toMap());
+        modelAppVault2fa.setKeyIdentifier("KDK_APP_VAULT_2FA");
+        PowerAuthVaultUnlockShared.vaultUnlockBiometryFactorTest(modelAppVault2fa, stepLogger);
+    }
+
+    @Test
+    void vaultUnlockKdkAppVaultKnowledgeBiometryFactorFailTest() throws Exception {
+        VaultUnlockStepModel modelAppVaultKnowledge = new VaultUnlockStepModel();
+        modelAppVaultKnowledge.fromMap(model.toMap());
+        modelAppVaultKnowledge.setKeyIdentifier("KDK_APP_VAULT_KNOWLEDGE");
+        PowerAuthVaultUnlockShared.vaultUnlockBiometryFactorFailTest(modelAppVaultKnowledge, stepLogger);
     }
 
     @Test

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthVaultUnlockTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthVaultUnlockTest.java
@@ -1,6 +1,6 @@
 /*
  * PowerAuth test and related software components
- * Copyright (C) 2019 Wultra s.r.o.
+ * Copyright (C) 2025 Wultra s.r.o.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
@@ -15,15 +15,15 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.wultra.security.powerauth.test.v31;
+package com.wultra.security.powerauth.test.v40;
 
-import com.wultra.security.powerauth.client.v3.PowerAuthClient;
+import com.wultra.security.powerauth.client.v4.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.v3.PowerAuthVaultUnlockShared;
 import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
 import com.wultra.security.powerauth.lib.cmd.steps.model.VaultUnlockStepModel;
+import com.wultra.security.powerauth.test.shared.v4.PowerAuthVaultUnlockShared;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -44,7 +44,7 @@ import java.util.HashMap;
 @EnableConfigurationProperties
 class PowerAuthVaultUnlockTest {
 
-    private static final PowerAuthVersion VERSION = PowerAuthVersion.V3_1;
+    private static final PowerAuthVersion VERSION = PowerAuthVersion.V4_0;
 
     private PowerAuthTestConfiguration config;
     private PowerAuthClient powerAuthClient;
@@ -72,6 +72,7 @@ class PowerAuthVaultUnlockTest {
         model.setStatusFileName(config.getStatusFile(VERSION).getAbsolutePath());
         model.setAuthenticationCodeType(PowerAuthCodeType.POSSESSION_KNOWLEDGE);
         model.setUriString(config.getPowerAuthIntegrationUrl());
+        model.setKeyIdentifier("KEK_DEVICE_PRIVATE");
         model.setReason("TEST_" + VERSION);
         model.setVersion(VERSION);
 
@@ -121,26 +122,6 @@ class PowerAuthVaultUnlockTest {
     @Test
     void vaultUnlockTooLongReasonTest() throws Exception {
         PowerAuthVaultUnlockShared.vaultUnlockTooLongReasonTest(config, model, stepLogger);
-    }
-
-    @Test
-    void vaultUnlockAndECDSASignatureValidTest() throws Exception {
-        PowerAuthVaultUnlockShared.vaultUnlockAndECDSASignatureValidTest(powerAuthClient, config, model, stepLogger, VERSION);
-    }
-
-    @Test
-    void vaultUnlockAndECDSASignatureInvalidTest() throws Exception {
-        PowerAuthVaultUnlockShared.vaultUnlockAndECDSASignatureInvalidTest(powerAuthClient, config, model, stepLogger, VERSION);
-    }
-
-    @Test
-    void vaultUnlockAndECDSASignatureInvalidActivationTest() throws Exception {
-        PowerAuthVaultUnlockShared.vaultUnlockAndECDSASignatureInvalidActivationTest(powerAuthClient, config, model, stepLogger, VERSION);
-    }
-
-    @Test
-    void vaultUnlockAndECDSASignatureNonExistentActivationTest() throws Exception {
-        PowerAuthVaultUnlockShared.vaultUnlockAndECDSASignatureNonExistentActivationTest(powerAuthClient, config, model, stepLogger, VERSION);
     }
 
 }

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v4x/PowerAuthActivationFlagsTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v4x/PowerAuthActivationFlagsTest.java
@@ -83,7 +83,6 @@ public class PowerAuthActivationFlagsTest {
         model.setActivationName("test v4 flags");
         model.setApplicationKey(config.getApplicationKey());
         model.setApplicationSecret(config.getApplicationSecret());
-        model.setMasterPublicKeyP256(config.getMasterPublicKeyP256());
         model.setMasterPublicKeyP384(config.getMasterPublicKeyP384());
         model.setMasterPublicKeyMlDsa65(config.getMasterPublicKeyMlDsa65());
         model.setHeaders(new HashMap<>());

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v4x/PowerAuthActivationFlagsTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v4x/PowerAuthActivationFlagsTest.java
@@ -1,6 +1,6 @@
 /*
  * PowerAuth test and related software components
- * Copyright (C) 2024 Wultra s.r.o.
+ * Copyright (C) 2020 Wultra s.r.o.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
@@ -15,14 +15,15 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.wultra.security.powerauth.test.v32;
+package com.wultra.security.powerauth.test.v4x;
 
-import com.wultra.security.powerauth.client.v3.PowerAuthClient;
+import com.wultra.security.powerauth.client.v4.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.v3.PowerAuthActivationCommitPhaseShared;
+import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
-import com.wultra.security.powerauth.lib.cmd.steps.model.GetStatusStepModel;
 import com.wultra.security.powerauth.lib.cmd.steps.model.PrepareActivationStepModel;
+import com.wultra.security.powerauth.test.shared.v4.PowerAuthActivationFlagsShared;
+import org.json.simple.JSONObject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -30,6 +31,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.io.File;
@@ -39,25 +42,26 @@ import java.util.HashMap;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Tests for commit phase.
+ * Activation flag tests.
  *
  * @author Roman Strobl, roman.strobl@wultra.com
  */
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(classes = PowerAuthTestConfiguration.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableConfigurationProperties
-class PowerAuthActivationCommitPhaseTest {
+@ComponentScan(basePackages = "com.wultra.security.powerauth")
+public class PowerAuthActivationFlagsTest {
 
-    private static final PowerAuthVersion VERSION = PowerAuthVersion.V3_2;
+    // Test only in the latestPowerAuth protocol version
+    private static final PowerAuthVersion VERSION = PowerAuthVersion.V4_0;
 
     private PowerAuthClient powerAuthClient;
     private PowerAuthTestConfiguration config;
     private PrepareActivationStepModel model;
-    private GetStatusStepModel statusModel;
     private File tempStatusFile;
 
-    private final String validOtpValue = "1234-5678";
-    private final String invalidOtpValue = "8765-4321";
+    @LocalServerPort
+    private int port;
 
     @Autowired
     public void setPowerAuthClient(PowerAuthClient powerAuthClient) {
@@ -74,25 +78,22 @@ class PowerAuthActivationCommitPhaseTest {
         // Create temp status file
         tempStatusFile = File.createTempFile("pa_status_" + VERSION, ".json");
 
-        // Models shared among tests
+        // Model shared among tests
         model = new PrepareActivationStepModel();
-        model.setActivationName("test v" + VERSION);
+        model.setActivationName("test v4 flags");
         model.setApplicationKey(config.getApplicationKey());
         model.setApplicationSecret(config.getApplicationSecret());
         model.setMasterPublicKeyP256(config.getMasterPublicKeyP256());
+        model.setMasterPublicKeyP384(config.getMasterPublicKeyP384());
+        model.setMasterPublicKeyMlDsa65(config.getMasterPublicKeyMlDsa65());
         model.setHeaders(new HashMap<>());
         model.setPassword(config.getPassword());
         model.setStatusFileName(tempStatusFile.getAbsolutePath());
-        model.setResultStatusObject(config.getResultStatusObject(VERSION));
+        model.setResultStatusObject(new JSONObject());
         model.setUriString(config.getPowerAuthIntegrationUrl());
+        model.setSharedSecretAlgorithm(SharedSecretAlgorithm.EC_P384_ML_L3);
         model.setVersion(VERSION);
         model.setDeviceInfo("backend-tests");
-
-        statusModel = new GetStatusStepModel();
-        statusModel.setHeaders(new HashMap<>());
-        statusModel.setResultStatusObject(config.getResultStatusObject(VERSION));
-        statusModel.setUriString(config.getPowerAuthIntegrationUrl());
-        statusModel.setVersion(VERSION);
     }
 
     @AfterEach
@@ -101,38 +102,17 @@ class PowerAuthActivationCommitPhaseTest {
     }
 
     @Test
-    void validOtpOnKeysExchangeTest() throws Exception {
-        PowerAuthActivationCommitPhaseShared.validOtpOnKeysExchangeTest(powerAuthClient, config, model, validOtpValue, VERSION);
+    void activationFlagCrudTest() throws Exception {
+        PowerAuthActivationFlagsShared.activationFlagCrudTest(powerAuthClient, config, model, VERSION);
     }
 
     @Test
-    void invalidOtpOnKeysExchangeTest() throws Exception {
-        PowerAuthActivationCommitPhaseShared.invalidOtpOnKeysExchangeTest(powerAuthClient, config, model, validOtpValue, invalidOtpValue, VERSION);
+    void activationFlagLookupTest() throws Exception {
+        PowerAuthActivationFlagsShared.activationFlagLookupTest(powerAuthClient, config, model, VERSION);
     }
 
     @Test
-    void validOtpOnCommitTest() throws Exception {
-        PowerAuthActivationCommitPhaseShared.validOtpOnCommitTest(powerAuthClient, config, model, validOtpValue, invalidOtpValue, VERSION);
+    void activationProviderFlagTest() throws Exception {
+        PowerAuthActivationFlagsShared.activationProviderFlagTest(powerAuthClient, config, tempStatusFile, port, VERSION);
     }
-
-    @Test
-    void invalidOtpOnCommitTest() throws Exception {
-        PowerAuthActivationCommitPhaseShared.invalidOtpOnCommitTest(powerAuthClient, config, model, validOtpValue, invalidOtpValue, VERSION);
-    }
-
-    @Test
-    void updateValidOtpOnCommitTest() throws Exception {
-        PowerAuthActivationCommitPhaseShared.updateValidOtpOnCommitTest(powerAuthClient, config, model, statusModel, validOtpValue, invalidOtpValue, VERSION);
-    }
-
-    @Test
-    void updateInvalidOtpOnCommitTest() throws Exception {
-        PowerAuthActivationCommitPhaseShared.updateInvalidOtpOnCommitTest(powerAuthClient, config, model, validOtpValue, invalidOtpValue, VERSION);
-    }
-
-    @Test
-    void wrongActivationInitParamTest() {
-        PowerAuthActivationCommitPhaseShared.wrongActivationInitParamTest(powerAuthClient, config, VERSION);
-    }
-
 }

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v4x/PowerAuthApiTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v4x/PowerAuthApiTest.java
@@ -15,45 +15,38 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.wultra.security.powerauth.test.v3x;
+package com.wultra.security.powerauth.test.v4x;
 
-import com.wultra.core.rest.client.base.RestClientException;
-import com.wultra.security.powerauth.client.v3.PowerAuthClient;
-import com.wultra.security.powerauth.client.model.entity.CallbackUrl;
 import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
-import com.wultra.security.powerauth.client.model.response.GetCallbackUrlListResponse;
+import com.wultra.security.powerauth.client.v4.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.v3.PowerAuthCallbackShared;
+import com.wultra.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
+import com.wultra.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
-import org.junit.jupiter.api.AfterEach;
+import com.wultra.security.powerauth.test.shared.v4.PowerAuthApiShared;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.security.InvalidKeyException;
+
 /**
- * Callback tests.
+ * PowerAuth API tests.
  *
  * @author Roman Strobl, roman.strobl@wultra.com
  */
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(classes = PowerAuthTestConfiguration.class)
 @EnableConfigurationProperties
-@ComponentScan(basePackages = "com.wultra.security.powerauth")
-class PowerAuthCallbackTest {
+class PowerAuthApiTest {
 
-    // Test only in the latestPowerAuth protocol version
-    private static final PowerAuthVersion VERSION = PowerAuthVersion.V3_3;
+    private static final PowerAuthVersion VERSION = PowerAuthVersion.V4_0;
 
     private PowerAuthClient powerAuthClient;
     private PowerAuthTestConfiguration config;
-
-    @LocalServerPort
-    private int port;
 
     @Autowired
     public void setPowerAuthClient(PowerAuthClient powerAuthClient) {
@@ -65,18 +58,9 @@ class PowerAuthCallbackTest {
         this.config = config;
     }
 
-    @AfterEach
-    void tearDown() throws PowerAuthClientException {
-        // Remove all callbacks on test application, they slow down tests
-        final GetCallbackUrlListResponse callbacks = powerAuthClient.getCallbackUrlList(config.getApplicationId());
-        for (CallbackUrl callback: callbacks.getCallbackUrlList()) {
-            powerAuthClient.removeCallbackUrl(callback.getId());
-        }
-    }
-
     @Test
-    void callbackExecutionTest() throws PowerAuthClientException, RestClientException {
-        PowerAuthCallbackShared.callbackExecutionTest(powerAuthClient, config, port, VERSION);
+    void verifyAuthenticationTest() throws GenericCryptoException, CryptoProviderException, InvalidKeyException, PowerAuthClientException {
+        PowerAuthApiShared.verifyAuthenticationTest(powerAuthClient, config, VERSION);
     }
 
 }

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v4x/PowerAuthApplicationConfigurationTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v4x/PowerAuthApplicationConfigurationTest.java
@@ -1,0 +1,133 @@
+/*
+ * PowerAuth test and related software components
+ * Copyright (C) 2024 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.security.powerauth.test.v4x;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.wultra.app.enrollmentserver.api.model.enrollment.request.OidcApplicationConfigurationRequest;
+import com.wultra.app.enrollmentserver.api.model.enrollment.response.OidcApplicationConfigurationResponse;
+import com.wultra.core.rest.model.base.response.ObjectResponse;
+import com.wultra.security.powerauth.configuration.PowerAuthOidcActivationConfigurationProperties;
+import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
+import com.wultra.security.powerauth.crypto.lib.v4.encryptor.model.response.AeadEncryptedResponse;
+import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
+import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
+import com.wultra.security.powerauth.lib.cmd.logging.model.StepItem;
+import com.wultra.security.powerauth.lib.cmd.steps.EncryptStep;
+import com.wultra.security.powerauth.lib.cmd.steps.model.EncryptStepModel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opentest4j.AssertionFailedError;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.EnabledIf;
+
+import java.util.HashMap;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test for {@code /api/config/oidc}.
+ *
+ * @author Lubos Racansky, lubos.racansky@wultra.com
+ */
+@SpringBootTest(classes = {PowerAuthTestConfiguration.class, PowerAuthOidcActivationConfigurationProperties.class})
+@EnableConfigurationProperties
+@EnabledIf(expression = "#{T(org.springframework.util.StringUtils).hasText('${powerauth.test.activation.oidc.providerId}')}", loadContext = true)
+class PowerAuthApplicationConfigurationTest {
+
+    private static final PowerAuthVersion VERSION = PowerAuthVersion.V4_0;
+
+    private static final ObjectMapper objectMapper = new ObjectMapper().disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
+
+    @Autowired
+    private PowerAuthOidcActivationConfigurationProperties oidcConfigProperties;
+
+    @Autowired
+    private PowerAuthTestConfiguration config;
+
+    private EncryptStepModel encryptModel;
+
+    @BeforeEach
+    void setUp() {
+        encryptModel = new EncryptStepModel();
+        encryptModel.setApplicationKey(config.getApplicationKey());
+        encryptModel.setApplicationSecret(config.getApplicationSecret());
+        encryptModel.setMasterPublicKeyP256(config.getMasterPublicKeyP256());
+        encryptModel.setMasterPublicKeyP384(config.getMasterPublicKeyP384());
+        encryptModel.setMasterPublicKeyMlDsa65(config.getMasterPublicKeyMlDsa65());
+        encryptModel.setHeaders(new HashMap<>());
+        encryptModel.setResultStatusObject(config.getResultStatusObject(VERSION));
+        encryptModel.setBaseUriString(config.getPowerAuthIntegrationUrl());
+        encryptModel.setVersion(VERSION);
+    }
+
+    @Test
+    void testOidc() throws Exception {
+        final OidcApplicationConfigurationRequest request = new OidcApplicationConfigurationRequest();
+        request.setProviderId(oidcConfigProperties.getProviderId());
+
+        encryptModel.setUriString(config.getEnrollmentServiceUrl() + "/api/config/oidc");
+        encryptModel.setScope("application");
+        encryptModel.setData(objectMapper.writeValueAsBytes(request));
+
+        final ObjectStepLogger stepLogger = new ObjectStepLogger(System.out);
+        new EncryptStep().execute(stepLogger, encryptModel.toMap());
+        assertTrue(stepLogger.getResult().success());
+        assertEquals(200, stepLogger.getResponse().statusCode());
+
+        final AeadEncryptedResponse response = (AeadEncryptedResponse) stepLogger.getResponse().responseObject();
+        assertNotNull(response.getEncryptedData());
+        assertNotNull(response.getTimestamp());
+
+        final OidcApplicationConfigurationResponse decryptedData = stepLogger.getItems().stream()
+                .filter(isStepItemDecryptedResponse())
+                .map(StepItem::object)
+                .map(Object::toString)
+                .map(it -> safeReadValue(it, new TypeReference<ObjectResponse<OidcApplicationConfigurationResponse>>() {}))
+                .filter(Objects::nonNull)
+                .map(ObjectResponse::getResponseObject)
+                .findFirst()
+                .orElseThrow(() -> new AssertionFailedError("Decrypted data not found"));
+
+        assertEquals(oidcConfigProperties.getProviderId(), decryptedData.getProviderId());
+        assertNotNull(decryptedData.getClientId());
+        assertNotNull(decryptedData.getScopes());
+        assertNotNull(decryptedData.getRedirectUri());
+        assertFalse(decryptedData.isPkceEnabled());
+    }
+
+    private static Predicate<StepItem> isStepItemDecryptedResponse() {
+        return stepItem -> "Decrypted Response".equals(stepItem.name());
+    }
+
+    private static <T> T safeReadValue(final String value, final TypeReference<T> typeReference) {
+        try {
+            return objectMapper.readValue(value, typeReference);
+        } catch (JsonProcessingException e) {
+            fail("Unable to read json", e);
+            return null;
+        }
+    }
+
+}

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v4x/PowerAuthApplicationConfigurationTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v4x/PowerAuthApplicationConfigurationTest.java
@@ -73,7 +73,6 @@ class PowerAuthApplicationConfigurationTest {
         encryptModel = new EncryptStepModel();
         encryptModel.setApplicationKey(config.getApplicationKey());
         encryptModel.setApplicationSecret(config.getApplicationSecret());
-        encryptModel.setMasterPublicKeyP256(config.getMasterPublicKeyP256());
         encryptModel.setMasterPublicKeyP384(config.getMasterPublicKeyP384());
         encryptModel.setMasterPublicKeyMlDsa65(config.getMasterPublicKeyMlDsa65());
         encryptModel.setHeaders(new HashMap<>());

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v4x/PowerAuthAuthenticationTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v4x/PowerAuthAuthenticationTest.java
@@ -15,15 +15,15 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.wultra.security.powerauth.test.v3x;
+package com.wultra.security.powerauth.test.v4x;
 
-import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
+import com.wultra.security.powerauth.client.v4.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.v3.PowerAuthApiShared;
 import com.wultra.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
 import com.wultra.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
+import com.wultra.security.powerauth.test.shared.v4.PowerAuthApiShared;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,16 +34,16 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import java.security.InvalidKeyException;
 
 /**
- * PowerAuth API tests.
+ * PowerAuth additional authentication tests.
  *
  * @author Roman Strobl, roman.strobl@wultra.com
  */
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = PowerAuthTestConfiguration.class)
 @EnableConfigurationProperties
-class PowerAuthApiTest {
+class PowerAuthAuthenticationTest {
 
-    private static final PowerAuthVersion VERSION = PowerAuthVersion.V3_3;
+    private static final PowerAuthVersion VERSION = PowerAuthVersion.V4_0;
 
     private PowerAuthClient powerAuthClient;
     private PowerAuthTestConfiguration config;
@@ -59,23 +59,8 @@ class PowerAuthApiTest {
     }
 
     @Test
-    void verifySignatureTest() throws GenericCryptoException, CryptoProviderException, InvalidKeyException, PowerAuthClientException {
-        PowerAuthApiShared.verifySignatureTest(powerAuthClient, config, VERSION);
+    void verifyAuthenticationTest() throws GenericCryptoException, CryptoProviderException, InvalidKeyException, PowerAuthClientException {
+        PowerAuthApiShared.verifyAuthenticationTest(powerAuthClient, config, VERSION);
     }
-
-    @Test
-    void unlockVaultAndECDSASignatureTest() throws Exception {
-        PowerAuthApiShared.unlockVaultAndECDSASignatureTest(powerAuthClient, config, VERSION);
-    }
-
-    // createApplication and createApplication version tests are skipped to avoid creating too many applications
-
-    @Test
-    void createValidateAndRemoveTokenTestActiveActivation() throws Exception {
-        PowerAuthApiShared.createValidateAndRemoveTokenTestActiveActivation(powerAuthClient, config, VERSION);
-    }
-
-    // Activation flags are tested using PowerAuthActivationFlagsTest
-    // Application roles are tested using PowerAuthApplicationRolesTest
 
 }

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v4x/PowerAuthCallbackTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v4x/PowerAuthCallbackTest.java
@@ -15,16 +15,17 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.wultra.security.powerauth.test.v3x;
+package com.wultra.security.powerauth.test.v4x;
 
-import com.wultra.security.powerauth.client.v3.PowerAuthClient;
+import com.wultra.core.rest.client.base.RestClientException;
+import com.wultra.security.powerauth.client.model.entity.CallbackUrl;
+import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
+import com.wultra.security.powerauth.client.model.response.GetCallbackUrlListResponse;
+import com.wultra.security.powerauth.client.v4.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.v3.PowerAuthActivationFlagsShared;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
-import com.wultra.security.powerauth.lib.cmd.steps.model.PrepareActivationStepModel;
-import org.json.simple.JSONObject;
+import com.wultra.security.powerauth.test.shared.v4.PowerAuthCallbackShared;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,14 +35,8 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.HashMap;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 /**
- * Activation flag tests.
+ * Callback tests.
  *
  * @author Roman Strobl, roman.strobl@wultra.com
  */
@@ -49,15 +44,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableConfigurationProperties
 @ComponentScan(basePackages = "com.wultra.security.powerauth")
-public class PowerAuthActivationFlagsTest {
+class PowerAuthCallbackTest {
 
     // Test only in the latestPowerAuth protocol version
-    private static final PowerAuthVersion VERSION = PowerAuthVersion.V3_3;
+    private static final PowerAuthVersion VERSION = PowerAuthVersion.V4_0;
 
     private PowerAuthClient powerAuthClient;
     private PowerAuthTestConfiguration config;
-    private PrepareActivationStepModel model;
-    private File tempStatusFile;
 
     @LocalServerPort
     private int port;
@@ -72,43 +65,18 @@ public class PowerAuthActivationFlagsTest {
         this.config = config;
     }
 
-    @BeforeEach
-    void setUp() throws IOException {
-        // Create temp status file
-        tempStatusFile = File.createTempFile("pa_status_" + VERSION, ".json");
-
-        // Model shared among tests
-        model = new PrepareActivationStepModel();
-        model.setActivationName("test v3 flags");
-        model.setApplicationKey(config.getApplicationKey());
-        model.setApplicationSecret(config.getApplicationSecret());
-        model.setMasterPublicKeyP256(config.getMasterPublicKeyP256());
-        model.setHeaders(new HashMap<>());
-        model.setPassword(config.getPassword());
-        model.setStatusFileName(tempStatusFile.getAbsolutePath());
-        model.setResultStatusObject(new JSONObject());
-        model.setUriString(config.getPowerAuthIntegrationUrl());
-        model.setVersion(VERSION);
-        model.setDeviceInfo("backend-tests");
-    }
-
     @AfterEach
-    void tearDown() {
-        assertTrue(tempStatusFile.delete());
+    void tearDown() throws PowerAuthClientException {
+        // Remove all callbacks on test application, they slow down tests
+        final GetCallbackUrlListResponse callbacks = powerAuthClient.getCallbackUrlList(config.getApplicationId());
+        for (CallbackUrl callback: callbacks.getCallbackUrlList()) {
+            powerAuthClient.removeCallbackUrl(callback.getId());
+        }
     }
 
     @Test
-    void activationFlagCrudTest() throws Exception {
-        PowerAuthActivationFlagsShared.activationFlagCrudTest(powerAuthClient, config, model, VERSION);
+    void callbackExecutionTest() throws PowerAuthClientException, RestClientException {
+        PowerAuthCallbackShared.callbackExecutionTest(powerAuthClient, config, port, VERSION);
     }
 
-    @Test
-    void activationFlagLookupTest() throws Exception {
-        PowerAuthActivationFlagsShared.activationFlagLookupTest(powerAuthClient, config, model, VERSION);
-    }
-
-    @Test
-    void activationProviderFlagTest() throws Exception {
-        PowerAuthActivationFlagsShared.activationProviderFlagTest(powerAuthClient, config, tempStatusFile, port, VERSION);
-    }
 }

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v4x/PowerAuthHttpTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v4x/PowerAuthHttpTest.java
@@ -1,6 +1,6 @@
 /*
  * PowerAuth test and related software components
- * Copyright (C) 2018 Wultra s.r.o.
+ * Copyright (C) 2025 Wultra s.r.o.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
@@ -15,12 +15,12 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not see <http://www.gnu.org/licenses/>.
  */
-package com.wultra.security.powerauth.test;
+package com.wultra.security.powerauth.test.v4x;
 
 import com.wultra.core.rest.client.base.RestClientException;
-import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
 import com.wultra.core.rest.model.base.response.ErrorResponse;
 import com.wultra.core.rest.model.base.response.Response;
+import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
 import com.wultra.security.powerauth.http.PowerAuthAuthorizationHttpHeader;
 import com.wultra.security.powerauth.http.PowerAuthTokenHttpHeader;
 import com.wultra.security.powerauth.lib.cmd.util.MapUtil;
@@ -55,7 +55,7 @@ class PowerAuthHttpTest {
     @Test
     void invalidSignatureHeaderTest() {
         final byte[] data = "test".getBytes(StandardCharsets.UTF_8);
-        final String signatureHeaderInvalid = "PowerAuth pa_activation_id=\"79b910a6-b058-49bd-a56d-d54b5aada048\" pa_application_key=\"4rVingHqXITsWvGj1K+EBQ==\" pa_nonce=\"inZWJ5hCFBk+nnZ1sYTnjg==\" pa_signature_type=\"possession_knowledge\" pa_signature=\"77419567-47712563\" pa_version=\"3.0\"";
+        final String signatureHeaderInvalid = "PowerAuth pa_activation_id=\"79b910a6-b058-49bd-a56d-d54b5aada048\" pa_application_key=\"4rVingHqXITsWvGj1K+EBQ==\" pa_nonce=\"inZWJ5hCFBk+nnZ1sYTnjg==\" pa_auth_code_type=\"possession_knowledge\" pa_auth_code=\"lAKanQ2amnBBL7r48C2DEkyij14MBuODkzkaNEQm3PXVoFU2bGE+KZV8EWcMAIMgfBUlM81mxanVqJcr6k60Tg==\" pa_version=\"4.0\"";
 
         final Map<String, String> headers = Map.of(
                 "Accept", "application/json",
@@ -64,7 +64,7 @@ class PowerAuthHttpTest {
 
         final RestClientException exception = assertThrows(RestClientException.class, () ->
                 RestClientFactory.getRestClient().post(
-                        config.getPowerAuthIntegrationUrl() + "/pa/v3/signature/validate",
+                        config.getPowerAuthIntegrationUrl() + "/pa/v4/auth/validate",
                         data,
                         null,
                         MapUtil.toMultiValueMap(headers),
@@ -81,7 +81,7 @@ class PowerAuthHttpTest {
     @Test
     void invalidTokenHeaderTest() {
         byte[] data = "test".getBytes(StandardCharsets.UTF_8);
-        String tokenHeaderInvalid = "PowerAuth token_id=\"0f3da4d7-427d-4b54-8211-b1995214810b\" token_digest=\"rMYL7jvUhBqdGyNjiGJED+9cM0tAM9JhAhSdfbatPg4=\" nonce=\"jHaHL1mWWZoB/+QQbGTAwg==\" timestamp=\"1541000429960\" version=\"3.0\"";
+        String tokenHeaderInvalid = "PowerAuth token_id=\"2f126584-342c-4f9c-b687-dcf98d7c1ee4\", token_digest=\"53Qxy5Ast0xk+eJ1P9gs9DqlLTJGOnnQ7Y5tu3E42po=\", nonce=\"bqMyF7BnPxIos6E+RyDAig==\", timestamp=\"1757316828350\", version=\"4.0\"";
 
         Map<String, String> headers = new HashMap<>();
         headers.put("Accept", "application/json");
@@ -108,17 +108,17 @@ class PowerAuthHttpTest {
 
     @Test
     void invalidEncryptionHeaderTest() {
-        byte[] data = "{\"ephemeralPublicKey\":\"BHBy8Apj7BFxjGaiKs8nFRkD4rjlSuo1rguWnjlSChLKhRGUdooT0Geh8rE6u2QOnY2rBaIj+Stzqj6A/cs3WUY=\",\"encryptedData\":\"rZKU++q2HE3uwZRMLSlYfuUvHrKt9CVGYUGB21CjdaNyflyTOei7dvRAVACQRyJmcyWePAl0BQHRaN1trJyw8Ue1YzYVx7fGEQ9l9WtCJYeYBPS4krR7ZFo4ydmeFm/rhklClUVJZ2OSSt2Z/O9HctA8W/BlwAMSVDj496wdZ3ozxDLhDwd+sBx03Y3812GD0s3HbxK4wHN/OCj+jAczowI0FzI1cT5DA+M7e7Hc0golN1SExVqw1aMVAwA32gwjbc0nuqecXPB0op4AhGTAOZFQDtmQH/U1chcykTXso4Y7FF1fKjyeyZN73imO3lImhKETBc+2hg3/KEVjP43OqtB5DgaCatoWXjAVHJY/mSLWJd7WtfCAq1+xNSbwuhAEt8y2+/2BzvaRQFs8WuqAuBlTx/c1u2hddCpfQFRb0a3x2l7FYrBtYYfmQZb38s+zsix6Ju4esZ9HibmX8XvdMZB9F4E+tUfLrRwJmFpRm5dC6ufZp8+Qur8c+SM5aOVqLRWf/by6rC/6P+Pm35UNwAYA5sbrZU+0za4TlT7hNR4bkxkHStz5moBRyrwIYtJVMKDg3pXMzLW/j35lN9mnlQHEKPbt7ZlRjeKotXGAjrztXDOT3bOHBayMHm/fjCk+cHUIEYvR3jd4PvgG6YuU9W6F/jCxG8XnFumuBVJzRVnHYlCC+eZ2XxwLxSxTpO3D\",\"mac\":\"RLhrZebxh03EssLgC265flJ06Wp67QdOhkAeXxAMxSk=\"}".getBytes(StandardCharsets.UTF_8);
-        String tokenHeaderInvalid = "PowerAuth application_key=\"4rVingHqXITsWvGj1K+EBQ==\" version=\"3.0\"";
+        byte[] data = "\"temporaryKeyId\":\"bdf6c492-2e54-485e-b71d-8f6adb26add3\",\"ephemeralPublicKey\":\"BEew43/VjKxV0dXPmejnbV745cUrIY1guojm6nsq554Mn/XCtn+sHz954VTWIyOYqnliGRrICaIr5cqWcpk1gUU=\",\"encryptedData\":\"LenJAtwgHUXPfRwHFuo6bjV+2x7fW7zyQQ6npOY+xNz8302KXgkm8OMYVEISaMSrOGPSdVKk7Pd/djna9HqeVEXLiLr9IZONid8BzaL9nSenk16G472d4OZyJKLgrZeFRlAOxSQCLCwn3nrVEuAOYGCVaTE+xMQZk9Lx7ze2uhE33n6fUIBfK+IgQWdqVG/+TYJcveRWRrkuf9/CS1zXiO0sVl3p2EuTXGSOxT3evdBMB8ctQBlZRpdRWGXNUnYthkmpE8G0mYcO3q+VoKRz8ikDWjibMZijtINL0wUA+b8DKkdtziZEjoJvxfvoDmZG0zxdut1zx3e9v8TAt/QGv21R0UT+4HkBFbZmrGxcctn0VKb1NzB8yRg9FhEofKMru5/4ZU4IIgOmaXton5tym+FFiQY+um2jfnl3Jq8JacpAS4eaRI3qSV44kU1uh+jj+v1P2IIHZG87HKxtAYImVClOBgXN5dyAGMXlcYk1IED9mXJt/uyP0jizHc9S6LTJhGVeyHm8r4SfqaqWVn2ZltkvHV4Obf4IcB6jquv8ssHmkvMvJ+c/UJ7P5NRt2ZFiRZ9h5h7j9tmWaoaLHsF6Xjq9i3PNggK79KKgcvlfBI8Dxxrwhxi17nMM+hOtw350UA3AufN4mJoyrrnpYdGIScCqFRtwaBWuZ1jG1KdnSAWKbl36O9sFZbTtU8ZTSOpi7u6NQb6NbBpqEftHjM2ijoGvsvKlWyDFfJol/F7s4ojB+ieKVZVOb9DP671r21wznrl2aGlVxisOAVi2UY27wYw7JJzynq2L7pQJMQMZAC+vmsovG+BB+JPzLoGOok08qdJUuxIz+UcxWI16nE1jcMjd8Wp4ojtrIleQ0VbzQHE=\",\"mac\":\"Lvtq2jumm7OC8+pu1nDTuING2VgIUhfXBWY+jEC818w=\",\"nonce\":\"qoy2Xti0oyzTVwvFbvZ7bQ==\",\"timestamp\":1757316677976".getBytes(StandardCharsets.UTF_8);
+        String headerInvalid = "PowerAuth application_key=\"4rVingHqXITsWvGj1K+EBQ==\" version=\"4.0\"";
 
         Map<String, String> headers = new HashMap<>();
         headers.put("Accept", "application/json");
         headers.put("Content-Type", "application/json");
-        headers.put(PowerAuthTokenHttpHeader.HEADER_NAME, tokenHeaderInvalid);
+        headers.put(PowerAuthTokenHttpHeader.HEADER_NAME, headerInvalid);
 
         try {
             RestClientFactory.getRestClient().post(
-                    config.getPowerAuthIntegrationUrl() + "/pa/v3/activation/create",
+                    config.getPowerAuthIntegrationUrl() + "/pa/v4/activation/create",
                     data,
                     null,
                     MapUtil.toMultiValueMap(headers),

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v4x/PowerAuthInfoTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v4x/PowerAuthInfoTest.java
@@ -15,12 +15,12 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.wultra.security.powerauth.test.v3x;
+package com.wultra.security.powerauth.test.v4x;
 
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
-import com.wultra.security.powerauth.test.shared.v3.PowerAuthInfoShared;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.steps.model.EncryptStepModel;
+import com.wultra.security.powerauth.test.shared.v4.PowerAuthInfoShared;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,7 +33,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import java.util.HashMap;
 
 /**
- * Test for {@code /pa/v3/user/info}.
+ * Test for {@code /pa/v4/user/info}.
  *
  * @author Lubos Racansky, lubos.racansky@wultra.com
  */
@@ -43,7 +43,7 @@ import java.util.HashMap;
 @EnabledIf(expression = "${powerauth.test.includeCustomTests}", loadContext = true)
 class PowerAuthInfoTest {
 
-    private static final PowerAuthVersion VERSION = PowerAuthVersion.V3_3;
+    private static final PowerAuthVersion VERSION = PowerAuthVersion.V4_0;
 
     @Autowired
     private PowerAuthTestConfiguration config;
@@ -56,6 +56,8 @@ class PowerAuthInfoTest {
         encryptModel.setApplicationKey(config.getApplicationKey());
         encryptModel.setApplicationSecret(config.getApplicationSecret());
         encryptModel.setMasterPublicKeyP256(config.getMasterPublicKeyP256());
+        encryptModel.setMasterPublicKeyP384(config.getMasterPublicKeyP384());
+        encryptModel.setMasterPublicKeyMlDsa65(config.getMasterPublicKeyMlDsa65());
         encryptModel.setHeaders(new HashMap<>());
         encryptModel.setResultStatusObject(config.getResultStatusObject(VERSION));
         encryptModel.setBaseUriString(config.getPowerAuthIntegrationUrl());

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v4x/PowerAuthInfoTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v4x/PowerAuthInfoTest.java
@@ -55,7 +55,6 @@ class PowerAuthInfoTest {
         encryptModel = new EncryptStepModel();
         encryptModel.setApplicationKey(config.getApplicationKey());
         encryptModel.setApplicationSecret(config.getApplicationSecret());
-        encryptModel.setMasterPublicKeyP256(config.getMasterPublicKeyP256());
         encryptModel.setMasterPublicKeyP384(config.getMasterPublicKeyP384());
         encryptModel.setMasterPublicKeyMlDsa65(config.getMasterPublicKeyMlDsa65());
         encryptModel.setHeaders(new HashMap<>());


### PR DESCRIPTION
I updated the tests for crypto4.

I had to keep two versions of shared test code for v3 and v4 because `PowerAuthClient` instances are different, as well as some of the request/response classes.

There are tests for new functionality such as activation confirmation, dynamic factor keys, updated vault unlock and shared secret algorithm selection.

I will write additional tests as part of: https://github.com/wultra/powerauth-tests/issues/673