### PR TITLE
Fix #678: Add tests for signing data using device private key

### DIFF
--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthVaultUnlockShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthVaultUnlockShared.java
@@ -26,9 +26,12 @@ import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncrypte
 import com.wultra.security.powerauth.crypto.lib.enums.EcCurve;
 import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;
 import com.wultra.security.powerauth.crypto.lib.generator.HashBasedCounter;
+import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
 import com.wultra.security.powerauth.crypto.lib.util.SignatureUtils;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
+import com.wultra.security.powerauth.lib.cmd.steps.SignAsymmetricStep;
+import com.wultra.security.powerauth.lib.cmd.steps.model.SignAsymmetricStepModel;
 import com.wultra.security.powerauth.lib.cmd.steps.model.VaultUnlockStepModel;
 import com.wultra.security.powerauth.lib.cmd.steps.VaultUnlockStep;
 import com.wultra.security.powerauth.lib.cmd.util.CounterUtil;
@@ -36,6 +39,7 @@ import org.junit.jupiter.api.AssertionFailureBuilder;
 
 import java.nio.charset.StandardCharsets;
 import java.security.PrivateKey;
+import java.security.PublicKey;
 import java.util.Base64;
 import java.util.Map;
 
@@ -48,6 +52,7 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 public class PowerAuthVaultUnlockShared {
 
+    private static final KeyConvertor KEY_CONVERTOR = new KeyConvertor();
     private static final SignatureUtils SIGNATURE_UTILS = new SignatureUtils();
 
     public static void vaultUnlockTest(final VaultUnlockStepModel model, final ObjectStepLogger stepLogger) throws Exception {
@@ -238,6 +243,29 @@ public class PowerAuthVaultUnlockShared {
 
         final VerifyECDSASignatureResponse verifyResponse = powerAuthClient.verifyECDSASignature("AAAAA-BBBBB-CCCCC-DDDDD", data, Base64.getEncoder().encodeToString(signature));
         assertFalse(verifyResponse.isSignatureValid());
+    }
+
+    public static void vaultUnlockDevicePrivateKeyAndSignTest(final PowerAuthTestConfiguration config, final SignAsymmetricStepModel model, final ObjectStepLogger stepLogger, final PowerAuthVersion version) throws Exception {
+        new SignAsymmetricStep().execute(stepLogger, model.toMap());
+        assertTrue(stepLogger.getResult().success());
+        assertEquals(200, stepLogger.getResponse().statusCode());
+
+        final String signatureEc = stepLogger.getItems().stream()
+                .filter(item -> item.name().equals("Sign Asymmetric Succeeded"))
+                .map(item -> (Map<String, Object>) item.object())
+                .map(item -> (String) item.get("signature"))
+                .findAny()
+                .orElse(null);
+        assertNotNull(signatureEc);
+        final byte[] signatureEcBytes = Base64.getDecoder().decode(signatureEc);
+
+        // Verify EC signature
+        final byte[] requestBytes = "Confidential test message used for testing".getBytes(StandardCharsets.UTF_8);
+        final String ecDevicePublicKeyBase64 = (String) config.getResultStatusObject(version).get("devicePublicKey");
+        assertNotNull(ecDevicePublicKeyBase64);
+        final byte[] ecDevicePublicKeyBytes = Base64.getDecoder().decode(ecDevicePublicKeyBase64);
+        final PublicKey ecDevicePublicKey = KEY_CONVERTOR.convertBytesToPublicKey(EcCurve.P256, ecDevicePublicKeyBytes);
+        assertTrue(SIGNATURE_UTILS.validateECDSASignature(EcCurve.P256, requestBytes, signatureEcBytes, ecDevicePublicKey));
     }
 
     private static PrivateKey obtainDevicePrivateKeyUsingVaultUnlock(final ObjectStepLogger stepLogger, final VaultUnlockStepModel model, final PowerAuthTestConfiguration config) throws Exception {

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthVaultUnlockShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthVaultUnlockShared.java
@@ -21,15 +21,27 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wultra.core.rest.model.base.response.ErrorResponse;
 import com.wultra.security.powerauth.client.v4.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
+import com.wultra.security.powerauth.crypto.lib.enums.EcCurve;
 import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;
 import com.wultra.security.powerauth.crypto.lib.generator.HashBasedCounter;
+import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
+import com.wultra.security.powerauth.crypto.lib.util.SignatureUtils;
+import com.wultra.security.powerauth.crypto.lib.v4.api.PqcDsa;
+import com.wultra.security.powerauth.crypto.lib.v4.api.PqcDsaKeyConvertor;
 import com.wultra.security.powerauth.crypto.lib.v4.encryptor.model.response.AeadEncryptedResponse;
+import com.wultra.security.powerauth.crypto.lib.v4.ml.MlDsa;
+import com.wultra.security.powerauth.crypto.lib.v4.ml.MlDsaKeyConvertor;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
+import com.wultra.security.powerauth.lib.cmd.steps.SignAsymmetricStep;
 import com.wultra.security.powerauth.lib.cmd.steps.VaultUnlockStep;
+import com.wultra.security.powerauth.lib.cmd.steps.model.SignAsymmetricStepModel;
 import com.wultra.security.powerauth.lib.cmd.steps.model.VaultUnlockStepModel;
 import com.wultra.security.powerauth.lib.cmd.util.CounterUtil;
 
+import java.nio.charset.StandardCharsets;
+import java.security.PublicKey;
+import java.util.Base64;
 import java.util.Map;
 import java.util.Objects;
 
@@ -41,6 +53,11 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Roman Strobl, roman.strobl@wultra.com
  */
 public class PowerAuthVaultUnlockShared {
+
+    private static final SignatureUtils SIGNATURE_UTILS = new SignatureUtils();
+    private static final KeyConvertor KEY_CONVERTOR_EC = new KeyConvertor();
+    private static final PqcDsaKeyConvertor KEY_CONVERTOR_PQC = new MlDsaKeyConvertor();
+    private static final PqcDsa PQC_DSA = new MlDsa();
 
     public static void vaultUnlockTest(final VaultUnlockStepModel model, final ObjectStepLogger stepLogger) throws Exception {
         new VaultUnlockStep().execute(stepLogger, model.toMap());
@@ -187,6 +204,44 @@ public class PowerAuthVaultUnlockShared {
         assertEquals("ERROR", errorResponse.getStatus());
         assertEquals("ERR_SECURE_VAULT", errorResponse.getResponseObject().getCode());
         assertEquals("POWER_AUTH_SECURE_VAULT_INVALID", errorResponse.getResponseObject().getMessage());
+    }
+
+    public static void vaultUnlockDevicePrivateKeyAndSignTest(final PowerAuthTestConfiguration config, final SignAsymmetricStepModel model, final ObjectStepLogger stepLogger, final PowerAuthVersion version) throws Exception {
+        new SignAsymmetricStep().execute(stepLogger, model.toMap());
+        assertTrue(stepLogger.getResult().success());
+        assertEquals(200, stepLogger.getResponse().statusCode());
+
+        final String signatureEc = stepLogger.getItems().stream()
+                .filter(item -> item.name().equals("Sign Asymmetric Succeeded"))
+                .map(item -> (Map<String, Object>) item.object())
+                .map(item -> (String) item.get("signatureEc"))
+                .findAny()
+                .orElse(null);
+        assertNotNull(signatureEc);
+        final byte[] signatureEcBytes = Base64.getDecoder().decode(signatureEc);
+
+        // Verify EC signature
+        final byte[] requestBytes = "Confidential test message used for testing".getBytes(StandardCharsets.UTF_8);
+        final String ecDevicePublicKeyBase64 = (String) config.getResultStatusObject(version).get("ecDevicePublicKey");
+        assertNotNull(ecDevicePublicKeyBase64);
+        final byte[] ecDevicePublicKeyBytes = Base64.getDecoder().decode(ecDevicePublicKeyBase64);
+        final PublicKey ecDevicePublicKey = KEY_CONVERTOR_EC.convertBytesToPublicKey(EcCurve.P384, ecDevicePublicKeyBytes);
+        assertTrue(SIGNATURE_UTILS.validateECDSASignature(EcCurve.P384, requestBytes, signatureEcBytes, ecDevicePublicKey));
+
+        final String signaturePqc = stepLogger.getItems().stream()
+                .filter(item -> item.name().equals("Sign Asymmetric Succeeded"))
+                .map(item -> (Map<String, Object>) item.object())
+                .map(item -> (String) item.get("signaturePqc"))
+                .findAny()
+                .orElse(null);
+        assertNotNull(signaturePqc);
+        final byte[] signaturePqcBytes = Base64.getDecoder().decode(signaturePqc);
+
+        final String pqcDevicePublicKeyBase64 = (String) config.getResultStatusObject(version).get("pqcDevicePublicKey");
+        assertNotNull(pqcDevicePublicKeyBase64);
+        final byte[] pqcDevicePublicKeyBytes = Base64.getDecoder().decode(pqcDevicePublicKeyBase64);
+        final PublicKey pqcDevicePublicKey = KEY_CONVERTOR_PQC.convertBytesToPublicKey(pqcDevicePublicKeyBytes);
+        assertTrue(PQC_DSA.verify(pqcDevicePublicKey, requestBytes, signaturePqcBytes));
     }
 
     private static void checkAuthenticationError(ErrorResponse errorResponse) {

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v30/PowerAuthVaultUnlockTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v30/PowerAuthVaultUnlockTest.java
@@ -19,11 +19,13 @@ package com.wultra.security.powerauth.test.v30;
 
 import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
+import com.wultra.security.powerauth.lib.cmd.steps.model.SignAsymmetricStepModel;
 import com.wultra.security.powerauth.test.shared.v3.PowerAuthVaultUnlockShared;
 import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
 import com.wultra.security.powerauth.lib.cmd.steps.model.VaultUnlockStepModel;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,6 +34,11 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.HashMap;
 
 /**
@@ -47,6 +54,7 @@ class PowerAuthVaultUnlockTest {
     private static final PowerAuthVersion VERSION = PowerAuthVersion.V3_0;
 
     private PowerAuthTestConfiguration config;
+    private static File dataFile;
     private PowerAuthClient powerAuthClient;
     private VaultUnlockStepModel model;
     private ObjectStepLogger stepLogger;
@@ -59,6 +67,14 @@ class PowerAuthVaultUnlockTest {
     @Autowired
     public void setPowerAuthClient(PowerAuthClient powerAuthClient) {
         this.powerAuthClient = powerAuthClient;
+    }
+
+    @BeforeAll
+    static void setUpBeforeClass() throws IOException {
+        dataFile = File.createTempFile("data", ".txt");
+        FileWriter fw = new FileWriter(dataFile);
+        fw.write("Confidential test message used for testing");
+        fw.close();
     }
 
     @BeforeEach
@@ -141,6 +157,22 @@ class PowerAuthVaultUnlockTest {
     @Test
     void vaultUnlockAndECDSASignatureNonExistentActivationTest() throws Exception {
         PowerAuthVaultUnlockShared.vaultUnlockAndECDSASignatureNonExistentActivationTest(powerAuthClient, config, model, stepLogger, VERSION);
+    }
+
+    @Test
+    void vaultUnlockDevicePrivateKeyAndSignTest() throws Exception {
+        final SignAsymmetricStepModel model = new SignAsymmetricStepModel();
+        model.setApplicationKey(config.getApplicationKey());
+        model.setApplicationSecret(config.getApplicationSecret());
+        model.setHeaders(new HashMap<>());
+        model.setPassword(config.getPassword());
+        model.setResultStatusObject(config.getResultStatusObject(VERSION));
+        model.setStatusFileName(config.getStatusFile(VERSION).getAbsolutePath());
+        model.setAuthenticationCodeType(PowerAuthCodeType.POSSESSION_KNOWLEDGE);
+        model.setUriString(config.getPowerAuthIntegrationUrl());
+        model.setData(Files.readAllBytes(Paths.get(dataFile.getAbsolutePath())));
+        model.setVersion(VERSION);
+        PowerAuthVaultUnlockShared.vaultUnlockDevicePrivateKeyAndSignTest(config, model, stepLogger, VERSION);
     }
 
 }

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthVaultUnlockTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v31/PowerAuthVaultUnlockTest.java
@@ -19,11 +19,13 @@ package com.wultra.security.powerauth.test.v31;
 
 import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
+import com.wultra.security.powerauth.lib.cmd.steps.model.SignAsymmetricStepModel;
 import com.wultra.security.powerauth.test.shared.v3.PowerAuthVaultUnlockShared;
 import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
 import com.wultra.security.powerauth.lib.cmd.steps.model.VaultUnlockStepModel;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,6 +34,11 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.HashMap;
 
 /**
@@ -47,6 +54,7 @@ class PowerAuthVaultUnlockTest {
     private static final PowerAuthVersion VERSION = PowerAuthVersion.V3_1;
 
     private PowerAuthTestConfiguration config;
+    private static File dataFile;
     private PowerAuthClient powerAuthClient;
     private VaultUnlockStepModel model;
     private ObjectStepLogger stepLogger;
@@ -59,6 +67,14 @@ class PowerAuthVaultUnlockTest {
     @Autowired
     public void setPowerAuthClient(PowerAuthClient powerAuthClient) {
         this.powerAuthClient = powerAuthClient;
+    }
+
+    @BeforeAll
+    static void setUpBeforeClass() throws IOException {
+        dataFile = File.createTempFile("data", ".txt");
+        FileWriter fw = new FileWriter(dataFile);
+        fw.write("Confidential test message used for testing");
+        fw.close();
     }
 
     @BeforeEach
@@ -141,6 +157,22 @@ class PowerAuthVaultUnlockTest {
     @Test
     void vaultUnlockAndECDSASignatureNonExistentActivationTest() throws Exception {
         PowerAuthVaultUnlockShared.vaultUnlockAndECDSASignatureNonExistentActivationTest(powerAuthClient, config, model, stepLogger, VERSION);
+    }
+
+    @Test
+    void vaultUnlockDevicePrivateKeyAndSignTest() throws Exception {
+        final SignAsymmetricStepModel model = new SignAsymmetricStepModel();
+        model.setApplicationKey(config.getApplicationKey());
+        model.setApplicationSecret(config.getApplicationSecret());
+        model.setHeaders(new HashMap<>());
+        model.setPassword(config.getPassword());
+        model.setResultStatusObject(config.getResultStatusObject(VERSION));
+        model.setStatusFileName(config.getStatusFile(VERSION).getAbsolutePath());
+        model.setAuthenticationCodeType(PowerAuthCodeType.POSSESSION_KNOWLEDGE);
+        model.setUriString(config.getPowerAuthIntegrationUrl());
+        model.setData(Files.readAllBytes(Paths.get(dataFile.getAbsolutePath())));
+        model.setVersion(VERSION);
+        PowerAuthVaultUnlockShared.vaultUnlockDevicePrivateKeyAndSignTest(config, model, stepLogger, VERSION);
     }
 
 }

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v32/PowerAuthVaultUnlockTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v32/PowerAuthVaultUnlockTest.java
@@ -19,11 +19,13 @@ package com.wultra.security.powerauth.test.v32;
 
 import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
+import com.wultra.security.powerauth.lib.cmd.steps.model.SignAsymmetricStepModel;
 import com.wultra.security.powerauth.test.shared.v3.PowerAuthVaultUnlockShared;
 import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
 import com.wultra.security.powerauth.lib.cmd.steps.model.VaultUnlockStepModel;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,6 +34,11 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.HashMap;
 
 /**
@@ -47,6 +54,7 @@ class PowerAuthVaultUnlockTest {
     private static final PowerAuthVersion VERSION = PowerAuthVersion.V3_2;
 
     private PowerAuthTestConfiguration config;
+    private static File dataFile;
     private PowerAuthClient powerAuthClient;
     private VaultUnlockStepModel model;
     private ObjectStepLogger stepLogger;
@@ -59,6 +67,14 @@ class PowerAuthVaultUnlockTest {
     @Autowired
     public void setPowerAuthClient(PowerAuthClient powerAuthClient) {
         this.powerAuthClient = powerAuthClient;
+    }
+
+    @BeforeAll
+    static void setUpBeforeClass() throws IOException {
+        dataFile = File.createTempFile("data", ".txt");
+        FileWriter fw = new FileWriter(dataFile);
+        fw.write("Confidential test message used for testing");
+        fw.close();
     }
 
     @BeforeEach
@@ -141,6 +157,23 @@ class PowerAuthVaultUnlockTest {
     @Test
     void vaultUnlockAndECDSASignatureNonExistentActivationTest() throws Exception {
         PowerAuthVaultUnlockShared.vaultUnlockAndECDSASignatureNonExistentActivationTest(powerAuthClient, config, model, stepLogger, VERSION);
+    }
+
+
+    @Test
+    void vaultUnlockDevicePrivateKeyAndSignTest() throws Exception {
+        final SignAsymmetricStepModel model = new SignAsymmetricStepModel();
+        model.setApplicationKey(config.getApplicationKey());
+        model.setApplicationSecret(config.getApplicationSecret());
+        model.setHeaders(new HashMap<>());
+        model.setPassword(config.getPassword());
+        model.setResultStatusObject(config.getResultStatusObject(VERSION));
+        model.setStatusFileName(config.getStatusFile(VERSION).getAbsolutePath());
+        model.setAuthenticationCodeType(PowerAuthCodeType.POSSESSION_KNOWLEDGE);
+        model.setUriString(config.getPowerAuthIntegrationUrl());
+        model.setData(Files.readAllBytes(Paths.get(dataFile.getAbsolutePath())));
+        model.setVersion(VERSION);
+        PowerAuthVaultUnlockShared.vaultUnlockDevicePrivateKeyAndSignTest(config, model, stepLogger, VERSION);
     }
 
 }

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v33/PowerAuthVaultUnlockTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v33/PowerAuthVaultUnlockTest.java
@@ -19,11 +19,13 @@ package com.wultra.security.powerauth.test.v33;
 
 import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
+import com.wultra.security.powerauth.lib.cmd.steps.model.SignAsymmetricStepModel;
 import com.wultra.security.powerauth.test.shared.v3.PowerAuthVaultUnlockShared;
 import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
 import com.wultra.security.powerauth.lib.cmd.steps.model.VaultUnlockStepModel;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,6 +34,11 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.HashMap;
 
 /**
@@ -47,6 +54,7 @@ class PowerAuthVaultUnlockTest {
     private static final PowerAuthVersion VERSION = PowerAuthVersion.V3_3;
 
     private PowerAuthTestConfiguration config;
+    private static File dataFile;
     private PowerAuthClient powerAuthClient;
     private VaultUnlockStepModel model;
     private ObjectStepLogger stepLogger;
@@ -59,6 +67,14 @@ class PowerAuthVaultUnlockTest {
     @Autowired
     public void setPowerAuthClient(PowerAuthClient powerAuthClient) {
         this.powerAuthClient = powerAuthClient;
+    }
+
+    @BeforeAll
+    static void setUpBeforeClass() throws IOException {
+        dataFile = File.createTempFile("data", ".txt");
+        FileWriter fw = new FileWriter(dataFile);
+        fw.write("Confidential test message used for testing");
+        fw.close();
     }
 
     @BeforeEach
@@ -141,6 +157,22 @@ class PowerAuthVaultUnlockTest {
     @Test
     void vaultUnlockAndECDSASignatureNonExistentActivationTest() throws Exception {
         PowerAuthVaultUnlockShared.vaultUnlockAndECDSASignatureNonExistentActivationTest(powerAuthClient, config, model, stepLogger, VERSION);
+    }
+
+    @Test
+    void vaultUnlockDevicePrivateKeyAndSignTest() throws Exception {
+        final SignAsymmetricStepModel model = new SignAsymmetricStepModel();
+        model.setApplicationKey(config.getApplicationKey());
+        model.setApplicationSecret(config.getApplicationSecret());
+        model.setHeaders(new HashMap<>());
+        model.setPassword(config.getPassword());
+        model.setResultStatusObject(config.getResultStatusObject(VERSION));
+        model.setStatusFileName(config.getStatusFile(VERSION).getAbsolutePath());
+        model.setAuthenticationCodeType(PowerAuthCodeType.POSSESSION_KNOWLEDGE);
+        model.setUriString(config.getPowerAuthIntegrationUrl());
+        model.setData(Files.readAllBytes(Paths.get(dataFile.getAbsolutePath())));
+        model.setVersion(VERSION);
+        PowerAuthVaultUnlockShared.vaultUnlockDevicePrivateKeyAndSignTest(config, model, stepLogger, VERSION);
     }
 
 }

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthVaultUnlockTest.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/v40/PowerAuthVaultUnlockTest.java
@@ -22,8 +22,10 @@ import com.wultra.security.powerauth.configuration.PowerAuthTestConfiguration;
 import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
 import com.wultra.security.powerauth.lib.cmd.logging.ObjectStepLogger;
+import com.wultra.security.powerauth.lib.cmd.steps.model.SignAsymmetricStepModel;
 import com.wultra.security.powerauth.lib.cmd.steps.model.VaultUnlockStepModel;
 import com.wultra.security.powerauth.test.shared.v4.PowerAuthVaultUnlockShared;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,6 +34,11 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.HashMap;
 
 /**
@@ -47,6 +54,7 @@ class PowerAuthVaultUnlockTest {
     private static final PowerAuthVersion VERSION = PowerAuthVersion.V4_0;
 
     private PowerAuthTestConfiguration config;
+    private static File dataFile;
     private PowerAuthClient powerAuthClient;
     private VaultUnlockStepModel model;
     private ObjectStepLogger stepLogger;
@@ -59,6 +67,14 @@ class PowerAuthVaultUnlockTest {
     @Autowired
     public void setPowerAuthClient(PowerAuthClient powerAuthClient) {
         this.powerAuthClient = powerAuthClient;
+    }
+
+    @BeforeAll
+    static void setUpBeforeClass() throws IOException {
+        dataFile = File.createTempFile("data", ".txt");
+        FileWriter fw = new FileWriter(dataFile);
+        fw.write("Confidential test message used for testing");
+        fw.close();
     }
 
     @BeforeEach
@@ -154,6 +170,22 @@ class PowerAuthVaultUnlockTest {
     @Test
     void vaultUnlockTooLongReasonTest() throws Exception {
         PowerAuthVaultUnlockShared.vaultUnlockTooLongReasonTest(config, model, stepLogger);
+    }
+
+    @Test
+    void vaultUnlockDevicePrivateKeyAndSignTest() throws Exception {
+        final SignAsymmetricStepModel model = new SignAsymmetricStepModel();
+        model.setApplicationKey(config.getApplicationKey());
+        model.setApplicationSecret(config.getApplicationSecret());
+        model.setHeaders(new HashMap<>());
+        model.setPassword(config.getPassword());
+        model.setResultStatusObject(config.getResultStatusObject(VERSION));
+        model.setStatusFileName(config.getStatusFile(VERSION).getAbsolutePath());
+        model.setAuthenticationCodeType(PowerAuthCodeType.POSSESSION_KNOWLEDGE);
+        model.setUriString(config.getPowerAuthIntegrationUrl());
+        model.setData(Files.readAllBytes(Paths.get(dataFile.getAbsolutePath())));
+        model.setVersion(VERSION);
+        PowerAuthVaultUnlockShared.vaultUnlockDevicePrivateKeyAndSignTest(config, model, stepLogger, VERSION);
     }
 
 }


### PR DESCRIPTION
Tests for the new `SignAsymmetricStep`.