### PR TITLE
Fix #690: Update Test Server configuration 

### DIFF
--- a/docs/db/changelog/changesets/powerauth-test-server/2.0.x/20250929-update-config.xml
+++ b/docs/db/changelog/changesets/powerauth-test-server/2.0.x/20250929-update-config.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+
+    <changeSet id="1" logicalFilePath="powerauth-test-server/2.0.x/20250929-update-config.xml" author="Roman Strobl">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="pa_test_config" columnName="mobile_sdk_config"/>
+            </not>
+        </preConditions>
+        <comment>Create column mobile_sdk_config in table pa_test_config</comment>
+        <addColumn tableName="pa_test_config">
+            <column name="mobile_sdk_config" type="clob" />
+        </addColumn>
+    </changeSet>
+
+    <changeSet id="2" author="Roman Strobl">
+        <preConditions onFail="MARK_RAN">
+            <columnExists tableName="pa_test_config" columnName="master_public_key"/>
+            <notNullConstraintExists tableName="pa_test_config" columnName="master_public_key"/>
+        </preConditions>
+        <comment>Make master_public_key nullable in table pa_test_config</comment>
+        <dropNotNullConstraint  tableName="pa_test_config" columnName="master_public_key" columnDataType="varchar(255)"/>
+    </changeSet>
+</databaseChangeLog>

--- a/docs/db/changelog/changesets/powerauth-test-server/2.0.x/20250929-update-config.xml
+++ b/docs/db/changelog/changesets/powerauth-test-server/2.0.x/20250929-update-config.xml
@@ -23,6 +23,6 @@
             <notNullConstraintExists tableName="pa_test_config" columnName="master_public_key"/>
         </preConditions>
         <comment>Make master_public_key nullable in table pa_test_config</comment>
-        <dropNotNullConstraint  tableName="pa_test_config" columnName="master_public_key" columnDataType="varchar(255)"/>
+        <dropNotNullConstraint tableName="pa_test_config" columnName="master_public_key" columnDataType="varchar(255)"/>
     </changeSet>
 </databaseChangeLog>

--- a/docs/db/changelog/changesets/powerauth-test-server/2.0.x/db.changelog-version.xml
+++ b/docs/db/changelog/changesets/powerauth-test-server/2.0.x/db.changelog-version.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+
+    <include file="20250929-update-config.xml" relativeToChangelogFile="true"/>
+
+</databaseChangeLog>

--- a/docs/db/changelog/changesets/powerauth-test-server/db.changelog-module.xml
+++ b/docs/db/changelog/changesets/powerauth-test-server/db.changelog-module.xml
@@ -13,5 +13,6 @@
     <property name="blob_type" value="varbinary(max)" dbms="mssql"/>
 
     <include file="1.5.x/db.changelog-version.xml" relativeToChangelogFile="true" />
+    <include file="2.0.x/db.changelog-version.xml" relativeToChangelogFile="true" />
 
 </databaseChangeLog>

--- a/powerauth-test-server/src/main/java/com/wultra/security/powerauth/app/testserver/database/entity/TestConfigEntity.java
+++ b/powerauth-test-server/src/main/java/com/wultra/security/powerauth/app/testserver/database/entity/TestConfigEntity.java
@@ -60,8 +60,11 @@ public class TestConfigEntity implements Serializable {
     @Column(name = "application_secret", nullable = false)
     private String applicationSecret;
 
-    @Column(name = "master_public_key", nullable = false)
+    @Column(name = "master_public_key")
     private String masterPublicKey;
+
+    @Column(name = "mobile_sdk_config", columnDefinition = "TEXT")
+    private String mobileSdkConfig;
 
     @Override
     public boolean equals(Object o) {

--- a/powerauth-test-server/src/main/java/com/wultra/security/powerauth/app/testserver/service/ActivationService.java
+++ b/powerauth-test-server/src/main/java/com/wultra/security/powerauth/app/testserver/service/ActivationService.java
@@ -82,7 +82,7 @@ public class ActivationService extends BaseService {
         // TODO - input validation
         final String applicationId = request.getApplicationId();
         final TestConfigEntity appConfig = getTestAppConfig(applicationId);
-        final PublicKey publicKey = getMasterPublicKey(appConfig);
+        final PublicKey publicKey = getMasterPublicKeyP256(appConfig);
         final JSONObject resultStatusObject = new JSONObject();
 
         // Prepare activation

--- a/powerauth-test-server/src/main/java/com/wultra/security/powerauth/app/testserver/service/ApplicationService.java
+++ b/powerauth-test-server/src/main/java/com/wultra/security/powerauth/app/testserver/service/ApplicationService.java
@@ -80,7 +80,8 @@ public class ApplicationService extends BaseService {
             }
             applicationKey = config.appKey();
             applicationSecret = config.appSecret();
-            masterPublicKey = config.masterPublicKeyP256();
+            // Removed in crypto4
+            masterPublicKey = null;
         } else {
             applicationKey = request.getApplicationKey();
             applicationSecret = request.getApplicationSecret();
@@ -91,6 +92,7 @@ public class ApplicationService extends BaseService {
         appConfig.setApplicationKey(applicationKey);
         appConfig.setApplicationSecret(applicationSecret);
         appConfig.setMasterPublicKey(masterPublicKey);
+        appConfig.setMobileSdkConfig(mobileSdkConfig);
 
         appConfigRepository.save(appConfig);
 

--- a/powerauth-test-server/src/main/java/com/wultra/security/powerauth/app/testserver/service/BaseService.java
+++ b/powerauth-test-server/src/main/java/com/wultra/security/powerauth/app/testserver/service/BaseService.java
@@ -21,7 +21,10 @@ import com.wultra.security.powerauth.app.testserver.database.TestConfigRepositor
 import com.wultra.security.powerauth.app.testserver.database.entity.TestConfigEntity;
 import com.wultra.security.powerauth.app.testserver.errorhandling.AppConfigNotFoundException;
 import com.wultra.security.powerauth.app.testserver.errorhandling.GenericCryptographyException;
+import com.wultra.security.powerauth.crypto.lib.enums.EcCurve;
 import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
+import com.wultra.security.powerauth.lib.cmd.util.config.SdkConfiguration;
+import com.wultra.security.powerauth.lib.cmd.util.config.SdkConfigurationSerializer;
 import lombok.extern.slf4j.Slf4j;
 
 import java.security.PublicKey;
@@ -66,11 +69,18 @@ public class BaseService {
      * @return Master public key.
      * @throws GenericCryptographyException Thrown in case public key conversion fails.
      */
-    protected PublicKey getMasterPublicKey(TestConfigEntity appConfig) throws GenericCryptographyException {
-        final byte[] masterKeyBytes = Base64.getDecoder().decode(appConfig.getMasterPublicKey());
+    protected PublicKey getMasterPublicKeyP256(TestConfigEntity appConfig) throws GenericCryptographyException {
+        final String masterPublicKeyP256;
+        if (appConfig.getMobileSdkConfig() != null) {
+            final SdkConfiguration sdkConfig = SdkConfigurationSerializer.deserialize(appConfig.getMobileSdkConfig());
+            masterPublicKeyP256 = sdkConfig.masterPublicKeyP256();
+        } else {
+            masterPublicKeyP256 = appConfig.getMasterPublicKey();
+        }
+        final byte[] masterKeyBytes = Base64.getDecoder().decode(masterPublicKeyP256);
 
         try {
-            return keyConvertor.convertBytesToPublicKey(masterKeyBytes);
+            return keyConvertor.convertBytesToPublicKey(EcCurve.P256, masterKeyBytes);
         } catch (Exception ex) {
             logger.warn("Key conversion failed, reason: {}", ex.getMessage());
             logger.debug(ex.getMessage(), ex);

--- a/powerauth-test-server/src/main/java/com/wultra/security/powerauth/app/testserver/service/SignatureService.java
+++ b/powerauth-test-server/src/main/java/com/wultra/security/powerauth/app/testserver/service/SignatureService.java
@@ -163,9 +163,9 @@ public class SignatureService extends BaseService {
         }
 
         final Optional<String> otpCode = stepLogger.getItems().stream()
-                .filter(item -> "signature-offline-compute-finished".equals(item.id()))
+                .filter(item -> "authentication-offline-compute-finished".equals(item.id()))
                 .map(item -> (Map<String, Object>) item.object())
-                .map(item -> item.get("offlineSignature").toString())
+                .map(item -> item.get("offlineAuthentication").toString())
                 .findAny();
 
         if (otpCode.isPresent()) {

--- a/powerauth-test-server/src/main/java/com/wultra/security/powerauth/app/testserver/service/TokenService.java
+++ b/powerauth-test-server/src/main/java/com/wultra/security/powerauth/app/testserver/service/TokenService.java
@@ -22,7 +22,6 @@ import com.wultra.security.powerauth.app.testserver.database.TestConfigRepositor
 import com.wultra.security.powerauth.app.testserver.database.entity.TestConfigEntity;
 import com.wultra.security.powerauth.app.testserver.errorhandling.ActivationFailedException;
 import com.wultra.security.powerauth.app.testserver.errorhandling.AppConfigNotFoundException;
-import com.wultra.security.powerauth.app.testserver.errorhandling.GenericCryptographyException;
 import com.wultra.security.powerauth.app.testserver.errorhandling.RemoteExecutionException;
 import com.wultra.security.powerauth.app.testserver.model.converter.SignatureTypeConverter;
 import com.wultra.security.powerauth.app.testserver.model.request.ComputeTokenDigestRequest;
@@ -42,7 +41,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.security.PublicKey;
 import java.util.Collections;
 import java.util.Map;
 
@@ -81,18 +79,16 @@ public class TokenService extends BaseService {
      * Create a new token.
      * @param request Request for creating a new token.
      * @return Response with a created token.
-     * @throws GenericCryptographyException In case a crypto provider is not initialized properly.
      * @throws RemoteExecutionException In case remote communication fails.
      * @throws AppConfigNotFoundException In case app configuration is incorrect.
      * @throws ActivationFailedException In case activation is not found.
      */
     @Transactional
     @SuppressWarnings("unchecked")
-    public CreateTokenResponse createToken(CreateTokenRequest request) throws AppConfigNotFoundException, GenericCryptographyException, RemoteExecutionException, ActivationFailedException {
+    public CreateTokenResponse createToken(CreateTokenRequest request) throws AppConfigNotFoundException, RemoteExecutionException, ActivationFailedException {
 
         final String applicationId = request.getApplicationId();
         final TestConfigEntity appConfig = getTestAppConfig(applicationId);
-        final PublicKey publicKey = getMasterPublicKey(appConfig);
         final JSONObject resultStatusObject = resultStatusUtil.getTestStatus(request.getActivationId());
         PowerAuthCodeType signatureType = SignatureTypeConverter.convert(request.getSignatureType());
         if (signatureType == null) {


### PR DESCRIPTION
We will need to do a small database migration of test server to allow running v3 tests against 2.0.x stack due to migration to configuration via `mobile_sdk_config` which supports multiple keys.