### PR TITLE
Drop environment input from maven-integration-test.yml

### DIFF
--- a/.github/workflows/maven-integration-test.yml
+++ b/.github/workflows/maven-integration-test.yml
@@ -3,12 +3,6 @@ name: Integration Test with Maven
 on:
   workflow_dispatch:
     inputs:
-      environment:
-        type: string
-        description: environment
-        default: 'dev'
-        options:
-          - dev
       includeCustomTests:
         type: boolean
         description: Set whether to include custom tests, such as onboarding tests and test requiring specific customizations in enrollment-server-wultra
@@ -19,7 +13,6 @@ on:
 jobs:
   run-integration-tests:
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment || 'dev' }}
     steps:
       - uses: actions/checkout@v6
       - name: Set up JDK 21

--- a/powerauth-backend-tests/pom.xml
+++ b/powerauth-backend-tests/pom.xml
@@ -328,6 +328,7 @@
         --spring.datasource.password=
         --spring.datasource.driver-class-name=org.h2.Driver
         --spring.jpa.hibernate.ddl-auto=create-drop
+        --powerauth.server.db.master.encryption.aead-kmac.key=NlcNpEU4l79W2qc95FQfuxR10lm7uPV171vuFcblrNA=
         --spring.sql.init.mode=always
         --spring.sql.init.schema-locations=file:${runtime.dir}/schema/powerauth/extra-tables.sql
         &gt; &quot;${runtime.dir}/powerauth-server.log&quot; 2&gt;&amp;1 &amp;

--- a/powerauth-backend-tests/pom.xml
+++ b/powerauth-backend-tests/pom.xml
@@ -328,7 +328,6 @@
         --spring.datasource.password=
         --spring.datasource.driver-class-name=org.h2.Driver
         --spring.jpa.hibernate.ddl-auto=create-drop
-        --powerauth.server.db.master.encryption.aead-kmac.key=NlcNpEU4l79W2qc95FQfuxR10lm7uPV171vuFcblrNA=
         --spring.sql.init.mode=always
         --spring.sql.init.schema-locations=file:${runtime.dir}/schema/powerauth/extra-tables.sql
         &gt; &quot;${runtime.dir}/powerauth-server.log&quot; 2&gt;&amp;1 &amp;


### PR DESCRIPTION
Tests run their own Tomcat, so the environment does not need to specify it anymore.