### PR TITLE
Fix #769: PowerAuthOnboardingTest affects global state

### DIFF
--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthOnboardingShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthOnboardingShared.java
@@ -196,8 +196,8 @@ public class PowerAuthOnboardingShared {
 
         model.setHeaders(new HashMap<>());
         model.setPassword(ctx.config().getPassword());
-        model.setResultStatusObject(ctx.config().getResultStatusObject(version));
-        model.setStatusFileName(ctx.config().getStatusFile(version).getAbsolutePath());
+        model.setResultStatusObject(new JSONObject());
+        model.setStatusFileName(File.createTempFile("pa_status_onboarding_test_" + version, ".json").getAbsolutePath());
         model.setUriString(ctx.config().getEnrollmentServiceUrl());
         model.setVersion(version);
         model.setDeviceInfo("backend-tests");

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthOnboardingShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthOnboardingShared.java
@@ -53,9 +53,11 @@ import com.wultra.security.powerauth.model.request.OtpDetailRequest;
 import com.wultra.security.powerauth.model.response.OtpDetailResponse;
 import com.wultra.security.powerauth.rest.api.model.response.v3.ActivationLayer2Response;
 import com.wultra.security.powerauth.rest.api.model.response.v3.ActivationStatusResponse;
+import org.json.simple.JSONObject;
 import org.junit.jupiter.api.AssertionFailureBuilder;
 import org.opentest4j.AssertionFailedError;
 
+import java.io.File;
 import java.math.BigInteger;
 import java.security.SecureRandom;
 import java.util.*;


### PR DESCRIPTION
A quick fix for the problem with sharing the same status file in onboarding tests.