### PR TITLE
Fix #809: Update PowerAuth API to v4 in PowerAuthWebServiceConfiguration

### DIFF
--- a/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/configuration/PowerAuthWebServiceConfiguration.java
+++ b/powerauth-fido2-tests/src/main/java/com/wultra/security/powerauth/fido2/configuration/PowerAuthWebServiceConfiguration.java
@@ -18,14 +18,14 @@
 
 package com.wultra.security.powerauth.fido2.configuration;
 
-import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
+import com.wultra.security.powerauth.client.v4.PowerAuthClient;
 import com.wultra.security.powerauth.fido2.client.PowerAuthFido2Client;
 import com.wultra.security.powerauth.fido2.model.error.PowerAuthFido2Exception;
 import com.wultra.security.powerauth.rest.client.PowerAuthFido2RestClient;
 import com.wultra.security.powerauth.rest.client.PowerAuthFido2RestClientConfiguration;
-import com.wultra.security.powerauth.rest.client.v3.PowerAuthRestClient;
 import com.wultra.security.powerauth.rest.client.PowerAuthRestClientConfiguration;
+import com.wultra.security.powerauth.rest.client.v4.PowerAuthRestClient;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;


### PR DESCRIPTION
Fixed PowerAuth FIDO2 Tests application not starting due to PowerAuth client version mismatch (v3 leftovers replaced with v4).