### PR TITLE
Fix #862: Remove unused authentication code types

### DIFF
--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthApiShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v3/PowerAuthApiShared.java
@@ -113,7 +113,7 @@ public class PowerAuthApiShared {
             if (signatureValue.equals(item.getSignature())) {
                 assertEquals(config.getActivationId(version), item.getActivationId());
                 assertEquals(normalizedDataWithSecret, new String(Base64.getDecoder().decode(item.getDataBase64())));
-                assertEquals(SignatureType.POSSESSION_KNOWLEDGE, item.getSignatureType());
+                assertEquals("POSSESSION_KNOWLEDGE", item.getSignatureType());
                 assertEquals(version.value(), item.getSignatureVersion());
                 assertEquals(ActivationStatus.ACTIVE, item.getActivationStatus());
                 assertEquals(config.getApplicationId(), item.getApplicationId());

--- a/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthApiShared.java
+++ b/powerauth-backend-tests/src/test/java/com/wultra/security/powerauth/test/shared/v4/PowerAuthApiShared.java
@@ -233,7 +233,7 @@ public class PowerAuthApiShared {
                 normalizedDataWithSecret,
                 new String(Base64.getDecoder().decode(item.getDataBase64()))
         );
-        assertEquals(AuthenticationCodeType.POSSESSION_KNOWLEDGE.toString(), item.getSignatureType().toString());
+        assertEquals("POSSESSION_KNOWLEDGE", item.getSignatureType());
         assertEquals(version.value(), item.getSignatureVersion());
         assertEquals(ActivationStatus.ACTIVE, item.getActivationStatus());
         assertEquals(config.getApplicationId(), item.getApplicationId());


### PR DESCRIPTION
Fix failing test because of wrong expected data type.
